### PR TITLE
devops: 머지 후 브랜치·ref 정리 규약 및 헬퍼 스크립트 추가

### DIFF
--- a/.claude/agents/devops.md
+++ b/.claude/agents/devops.md
@@ -18,9 +18,34 @@ model: inherit
 ## 하는 일
 - `gh pr merge <N>` (사용자 승인 후)
 - 머지 후 라벨 `devops-ready` 추가, 상위 단계 라벨 정리
+- **머지 후 브랜치 정리** (아래 절 참조)
 - CI/CD 파이프라인 상태 확인, 실패 시 원인 보고
 - Slack 알림 자동화 경로 확인(MVP 범위)
 - 인프라 비용 모니터링 (`README.md` Cost Strategy 범위 유지)
+
+## 머지 후 정리
+
+머지가 끝나면 **반드시** 다음 순서로 로컬·원격 상태를 정리한다.
+
+1. `git checkout main && git pull --ff-only origin main` — 로컬 main 최신화
+2. `git branch -d feature/<slug>` — 머지된 로컬 feature 브랜치 삭제
+3. `git push origin --delete feature/<slug>` — 원격 feature 브랜치 삭제
+4. `git branch -D pr-<N>` — QA/Reviewer가 PR 체크아웃용으로 만든 `pr-<N>` ref 삭제
+5. `git fetch --prune` — 원격에서 삭제된 브랜치의 로컬 tracking ref 정리
+
+### 일괄 정리 스크립트
+
+위 2~5를 한 번에 처리하는 헬퍼가 있다.
+
+```bash
+scripts/cleanup-merged-branches.sh            # 대화형 확인 후 삭제
+scripts/cleanup-merged-branches.sh --yes      # 확인 없이 바로 삭제
+scripts/cleanup-merged-branches.sh --dry-run  # 삭제 대상만 표시
+```
+
+이 스크립트는 현재 브랜치가 `main`일 때만 동작하여, 실수로 feature 브랜치 위에서 자기 자신을 지우는 사고를 막는다.
+
+**GitHub UI(Squash & merge 등)로 직접 머지한 경우**에도 로컬 feature 브랜치·`pr-<N>` ref는 자동 삭제되지 않으므로, 사용자 또는 DevOps 에이전트가 이 스크립트를 실행하도록 안내한다.
 
 ## 하지 않는 일
 - 테스트 스킵·훅 bypass (`--no-verify` 등) 불가.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ UI·유저 인터랙션이 PRD에 포함될 때 합류합니다.
 - **Slack 알림** 자동화(MVP 단계 핵심 채널), 장애·실패 알림 경로 확보
 - **인프라 비용 모니터링** (`README.md`의 Cost Strategy 범위 내 유지)
 - 운영 환경 헬스체크·로그 수집·경보 구성
+- **머지 후 브랜치 정리**: 로컬·원격 feature 브랜치, QA/Reviewer가 만든 `pr-<N>` 체크아웃 ref를 정리한다. 헬퍼는 `scripts/cleanup-merged-branches.sh`. GitHub UI로 직접 머지한 경우에도 이 정리는 수동으로 수행해야 한다(상세는 `.claude/agents/devops.md` §"머지 후 정리")
 
 ---
 

--- a/scripts/cleanup-merged-branches.sh
+++ b/scripts/cleanup-merged-branches.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# 머지 완료된 로컬 브랜치와 PR 체크아웃 ref를 정리한다.
+#
+# 사용법:
+#   scripts/cleanup-merged-branches.sh          # 대화형 확인 후 삭제
+#   scripts/cleanup-merged-branches.sh --yes    # 확인 없이 바로 삭제
+#   scripts/cleanup-merged-branches.sh --dry-run  # 삭제 대상만 표시
+
+set -euo pipefail
+
+MAIN_BRANCH="${MAIN_BRANCH:-main}"
+YES=0
+DRY_RUN=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y) YES=1 ;;
+    --dry-run|-n) DRY_RUN=1 ;;
+    -h|--help)
+      sed -n '2,8p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "알 수 없는 인자: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+current="$(git symbolic-ref --short HEAD 2>/dev/null || echo '')"
+if [[ "$current" != "$MAIN_BRANCH" ]]; then
+  echo "경고: 현재 브랜치가 '$current' 이다. 안전하게 작업하려면 '$MAIN_BRANCH' 위에서 실행하자." >&2
+  echo "계속하려면 먼저 'git checkout $MAIN_BRANCH' 후 재실행." >&2
+  exit 1
+fi
+
+echo "1/3 원격 삭제된 ref 정리 (git fetch --prune)"
+if [[ $DRY_RUN -eq 1 ]]; then
+  git fetch --prune --dry-run
+else
+  git fetch --prune
+fi
+
+echo
+echo "2/3 $MAIN_BRANCH 에 머지된 로컬 브랜치 탐색"
+merged_branches="$(git branch --merged "$MAIN_BRANCH" \
+  | sed 's/^[* ]*//' \
+  | grep -Ev "^(\*|$MAIN_BRANCH|HEAD)$" \
+  || true)"
+
+if [[ -z "$merged_branches" ]]; then
+  echo "  (정리할 머지된 브랜치 없음)"
+else
+  echo "$merged_branches" | sed 's/^/  - /'
+fi
+
+echo
+echo "3/3 PR 체크아웃 ref 탐색 (pr-*)"
+pr_refs="$(git branch --list 'pr-*' | sed 's/^[* ]*//' || true)"
+if [[ -z "$pr_refs" ]]; then
+  echo "  (정리할 pr-* ref 없음)"
+else
+  echo "$pr_refs" | sed 's/^/  - /'
+fi
+
+all_targets="$(printf '%s\n%s\n' "$merged_branches" "$pr_refs" | grep -v '^$' || true)"
+if [[ -z "$all_targets" ]]; then
+  echo
+  echo "정리할 대상 없음. 종료."
+  exit 0
+fi
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo
+  echo "--dry-run 모드: 실제 삭제는 수행하지 않음."
+  exit 0
+fi
+
+echo
+if [[ $YES -eq 0 ]]; then
+  read -r -p "위 브랜치들을 삭제할까? [y/N] " answer
+  case "$answer" in
+    y|Y|yes|YES) ;;
+    *) echo "취소."; exit 0 ;;
+  esac
+fi
+
+echo
+while IFS= read -r branch; do
+  [[ -z "$branch" ]] && continue
+  # pr-* 는 보통 origin/pull/N/head fetch로만 만들어지므로 강제 삭제(-D) 허용.
+  # 그 외 머지된 브랜치는 안전 삭제(-d) 후, 혹시 남아있는 변경이 있으면 사용자가 직접 판단.
+  if [[ "$branch" == pr-* ]]; then
+    git branch -D "$branch"
+  else
+    git branch -d "$branch"
+  fi
+done <<< "$all_targets"
+
+echo
+echo "완료."


### PR DESCRIPTION
- scripts/cleanup-merged-branches.sh: main 위에서만 동작, pr-*·머지된 로컬 브랜치 일괄 삭제, --dry-run/--yes 지원
- .claude/agents/devops.md: "머지 후 정리" 절 신설
- AGENTS.md DevOps 섹션에 정리 책임 한 줄 추가