### PR TITLE
ai: Slack 메시지 subtype 가드 추가

### DIFF
--- a/ai/coordinator/auth.py
+++ b/ai/coordinator/auth.py
@@ -36,6 +36,36 @@ def is_self_message(event: Mapping[str, Any], self_bot_user_id: str | None) -> b
     return False
 
 
+def extract_sender(event: Mapping[str, Any]) -> str | None:
+    """
+    이벤트 페이로드에서 발신자 user id 를 추출 (subtype 별 위치 차이 보정).
+
+    Slack 은 subtype 에 따라 user 필드가 다른 위치에 들어간다:
+    - 일반 메시지: `event["user"]`
+    - `message_changed`: 편집된 본문은 `event["message"]["user"]`
+    - `message_deleted`: 삭제 전 본문은 `event["previous_message"]["user"]`
+
+    우선순위(top-level → message → previous_message)대로 첫 비어있지 않은 값을
+    반환하며, 어디에도 없으면 None.
+    """
+    if not isinstance(event, Mapping):
+        return None
+    sender = event.get("user")
+    if sender:
+        return sender
+    nested = event.get("message")
+    if isinstance(nested, Mapping):
+        sender = nested.get("user")
+        if sender:
+            return sender
+    previous = event.get("previous_message")
+    if isinstance(previous, Mapping):
+        sender = previous.get("user")
+        if sender:
+            return sender
+    return None
+
+
 def is_handleable_message_subtype(event: Mapping[str, Any]) -> bool:
     """
     명령 라우팅 대상 이벤트인지 판정 (PRD: slack-message-subtype-guard §3.1).

--- a/ai/coordinator/auth.py
+++ b/ai/coordinator/auth.py
@@ -36,6 +36,29 @@ def is_self_message(event: Mapping[str, Any], self_bot_user_id: str | None) -> b
     return False
 
 
+def is_handleable_message_subtype(event: Mapping[str, Any]) -> bool:
+    """
+    명령 라우팅 대상 이벤트인지 판정 (PRD: slack-message-subtype-guard §3.1).
+
+    whitelist 정책 — 일반 사용자 텍스트 메시지만 True 로 판정한다:
+    - `subtype` 키가 이벤트에 없는 경우
+    - `subtype` 값이 None 인 경우
+    - `subtype` 값이 빈 문자열인 경우
+
+    그 외 모든 subtype(`message_changed`, `message_deleted`, `thread_broadcast`,
+    `file_share`, `bot_message`, `channel_join`, `channel_leave`, 그리고 알려지지
+    않은 신규 subtype 등)은 False 를 반환해 보수적으로 무시한다.
+
+    부수효과 없음 (로깅은 호출부에서 수행).
+    """
+    if not isinstance(event, Mapping):
+        return False
+    subtype = event.get("subtype")
+    if subtype is None or subtype == "":
+        return True
+    return False
+
+
 def is_allowed_sender(
     user_id: str | None,
     allowed_user_ids: Iterable[str],

--- a/ai/coordinator/main.py
+++ b/ai/coordinator/main.py
@@ -19,7 +19,12 @@ import signal
 import sys
 from typing import Any
 
-from ai.coordinator.auth import is_allowed_sender, is_self_message, mask_user_id
+from ai.coordinator.auth import (
+    is_allowed_sender,
+    is_handleable_message_subtype,
+    is_self_message,
+    mask_user_id,
+)
 from ai.coordinator.config import ConfigError, CoordinatorConfig, load_config
 from ai.coordinator.handlers import route_command
 
@@ -67,6 +72,17 @@ def build_app(config: CoordinatorConfig, logger: logging.Logger) -> Any:
 
         # MVP 는 DM(IM)만 처리. 그 외 채널 타입은 무시.
         if event.get("channel_type") != "im":
+            return
+
+        # PRD slack-message-subtype-guard: 편집·삭제·시스템 메시지 등은 조용히 무시.
+        if not is_handleable_message_subtype(event):
+            logger.info(
+                "처리 대상이 아닌 메시지 이벤트를 무시했습니다 "
+                "(subtype=%s, sender=%s, type=%s)",
+                event.get("subtype"),
+                mask_user_id(event.get("user")),
+                event.get("type"),
+            )
             return
 
         sender = event.get("user")

--- a/ai/coordinator/main.py
+++ b/ai/coordinator/main.py
@@ -20,6 +20,7 @@ import sys
 from typing import Any
 
 from ai.coordinator.auth import (
+    extract_sender,
     is_allowed_sender,
     is_handleable_message_subtype,
     is_self_message,
@@ -80,12 +81,12 @@ def build_app(config: CoordinatorConfig, logger: logging.Logger) -> Any:
                 "처리 대상이 아닌 메시지 이벤트를 무시했습니다 "
                 "(subtype=%s, sender=%s, type=%s)",
                 event.get("subtype"),
-                mask_user_id(event.get("user")),
+                mask_user_id(extract_sender(event)),
                 event.get("type"),
             )
             return
 
-        sender = event.get("user")
+        sender = extract_sender(event)
 
         # AC-5: 화이트리스트 외 발신자는 무시 + INFO 로그.
         if not is_allowed_sender(sender, config.allowed_user_ids):

--- a/ai/tests/test_coordinator_auth.py
+++ b/ai/tests/test_coordinator_auth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ai.coordinator.auth import (
     is_allowed_sender,
+    is_handleable_message_subtype,
     is_self_message,
     mask_user_id,
 )
@@ -65,6 +66,59 @@ class TestIsSelfMessage:
     def test_non_mapping_input_is_not_self(self):
         assert is_self_message(None, "U_BOT") is False  # type: ignore[arg-type]
         assert is_self_message("not a dict", "U_BOT") is False  # type: ignore[arg-type]
+
+
+class TestIsHandleableMessageSubtype:
+    """PRD slack-message-subtype-guard §3.1: subtype whitelist 가드."""
+
+    def test_event_without_subtype_key_is_handleable(self):
+        # T-1: subtype 키가 아예 없는 일반 메시지.
+        event = {"type": "message", "text": "ping"}
+        assert is_handleable_message_subtype(event) is True
+
+    def test_event_with_subtype_none_is_handleable(self):
+        # T-2: subtype 값이 None.
+        event = {"type": "message", "subtype": None, "text": "ping"}
+        assert is_handleable_message_subtype(event) is True
+
+    def test_event_with_subtype_empty_string_is_handleable(self):
+        # T-3: subtype 값이 빈 문자열.
+        event = {"type": "message", "subtype": "", "text": "ping"}
+        assert is_handleable_message_subtype(event) is True
+
+    def test_message_changed_is_not_handleable(self):
+        # T-4: 메시지 편집 이벤트는 무시.
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "message": {"text": "수정된 본문"},
+        }
+        assert is_handleable_message_subtype(event) is False
+
+    def test_message_deleted_is_not_handleable(self):
+        # T-5: 메시지 삭제 이벤트는 무시.
+        event = {"type": "message", "subtype": "message_deleted"}
+        assert is_handleable_message_subtype(event) is False
+
+    def test_bot_message_is_not_handleable(self):
+        # T-6: 다른 봇/외부 통합이 보낸 메시지.
+        event = {
+            "type": "message",
+            "subtype": "bot_message",
+            "user": "U_OTHER",
+            "text": "외부 알림",
+        }
+        assert is_handleable_message_subtype(event) is False
+
+    def test_unknown_future_subtype_is_not_handleable(self):
+        # T-7: 알려지지 않은 신규 subtype 도 보수적(whitelist)으로 거부.
+        event = {"type": "message", "subtype": "foo_unknown_future"}
+        assert is_handleable_message_subtype(event) is False
+
+    def test_non_mapping_input_is_not_handleable(self):
+        # 방어적: dict 가 아닌 입력은 즉시 False.
+        assert is_handleable_message_subtype(None) is False  # type: ignore[arg-type]
+        assert is_handleable_message_subtype("not a dict") is False  # type: ignore[arg-type]
 
 
 class TestMaskUserId:

--- a/ai/tests/test_coordinator_auth.py
+++ b/ai/tests/test_coordinator_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ai.coordinator.auth import (
+    extract_sender,
     is_allowed_sender,
     is_handleable_message_subtype,
     is_self_message,
@@ -135,3 +136,50 @@ class TestMaskUserId:
 
     def test_empty_returns_unknown(self):
         assert mask_user_id("") == "<unknown>"
+
+
+class TestExtractSender:
+    """subtype 별 user 위치 차이 보정 — message_changed/message_deleted 등에서 실 발신자 추출."""
+
+    def test_top_level_user_returned(self):
+        assert extract_sender({"user": "U_AAA"}) == "U_AAA"
+
+    def test_message_changed_uses_nested_message_user(self):
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "message": {"user": "U_BBB", "text": "edited"},
+            "previous_message": {"user": "U_BBB", "text": "old"},
+        }
+        assert extract_sender(event) == "U_BBB"
+
+    def test_message_deleted_uses_previous_message_user(self):
+        event = {
+            "type": "message",
+            "subtype": "message_deleted",
+            "previous_message": {"user": "U_CCC", "text": "deleted"},
+        }
+        assert extract_sender(event) == "U_CCC"
+
+    def test_top_level_user_takes_precedence_over_nested(self):
+        event = {
+            "user": "U_TOP",
+            "message": {"user": "U_NESTED"},
+            "previous_message": {"user": "U_PREV"},
+        }
+        assert extract_sender(event) == "U_TOP"
+
+    def test_no_user_anywhere_returns_none(self):
+        assert extract_sender({"type": "message"}) is None
+
+    def test_empty_user_falls_through_to_nested(self):
+        event = {"user": "", "message": {"user": "U_FALLBACK"}}
+        assert extract_sender(event) == "U_FALLBACK"
+
+    def test_non_mapping_returns_none(self):
+        assert extract_sender(None) is None  # type: ignore[arg-type]
+        assert extract_sender("not a dict") is None  # type: ignore[arg-type]
+
+    def test_non_mapping_nested_message_ignored(self):
+        event = {"message": "broken", "previous_message": {"user": "U_PREV"}}
+        assert extract_sender(event) == "U_PREV"

--- a/docs/prd/slack-message-subtype-guard.md
+++ b/docs/prd/slack-message-subtype-guard.md
@@ -1,0 +1,269 @@
+# PRD: Slack 메시지 subtype 가드 추가
+
+- **slug**: `slack-message-subtype-guard`
+- **PM**: 이하영 (hayoung.lee2@musinsa.com, Slack `U0AE7A54NHL`)
+- **작성일**: 2026-05-01
+- **UI 포함 여부**: **No** (백엔드 데몬 가드 로직 변경. 별도 화면 변화 없음)
+- **관련 Issue**: [#5 Slack 메시지 subtype 가드 추가](https://github.com/deeptrading-lab/trading-signal-engine/issues/5)
+- **출처**: PR #3 리뷰 발견 1, 가이드 [`docs/references/slack-coordinator-bot-setup.md`](../references/slack-coordinator-bot-setup.md) §7 Out-of-Scope
+
+---
+
+## 1. 배경 / 문제
+
+### 1.1 현재 동작
+`ai/coordinator/main.py`의 `handle_message_im` 클로저(라인 62-90)는 Slack에서 들어오는 `message.im` 이벤트를 받으면 다음만 검사하고 곧장 `route_command(text)` 를 호출한다.
+
+1. `is_self_message(event, self_user_id)` — 봇 자기 자신이 보낸 메시지인지
+2. `event.get("channel_type") == "im"` — DM 채널인지
+3. `is_allowed_sender(sender, allowed_user_ids)` — 화이트리스트 발신자인지
+
+이 세 가드를 통과하면 `text = event.get("text") or ""` 를 그대로 라우팅한다.
+
+### 1.2 무엇이 문제인가
+Slack은 일반 사용자 메시지뿐 아니라 다양한 **subtype** 이벤트를 같은 `message.im` 채널로 흘려보낸다. 대표적으로:
+
+| subtype | 발생 상황 | 현재 코드의 반응 |
+|---|---|---|
+| `message_changed` | 사용자가 자기 DM 메시지를 **편집** | `text` = 편집된 새 본문 → fallback("사용 가능한 명령") 응답 발사 |
+| `message_deleted` | 사용자가 자기 DM 메시지를 **삭제** | `text` = 빈 문자열 → fallback 응답 발사 |
+| `thread_broadcast` | 스레드 답글을 채널에도 동시 게시 | 본문이 그대로 라우팅 (의도 없는 응답) |
+| `file_share` | 파일 첨부 | `text`가 파일 캡션이라 보통 fallback 발사 |
+| `bot_message` | 외부 통합·다른 봇이 DM에 게시 | `is_self_message`가 일부 잡지만, `bot_id`가 없는 변종에 노출 가능 |
+| `channel_join` / `channel_leave` 등 | 시스템 메시지 | text가 시스템 안내라 fallback 발사 |
+
+### 1.3 왜 P0인가
+사용자가 DM에서 자기 메시지를 **편집·삭제하는 것은 일상적인 동작**이다. 현재 구현에서는 이 동작이 매번 `사용 가능한 명령: ping, status` fallback 응답을 유발해, **봇과의 1:1 DM 채널이 노이즈로 가득 찬다**. 이는 사용자 경험을 직접 망가뜨리며, 동료 가시성 있는 회사 Slack 워크스페이스(무신사/29CM)에서 봇 DM이 비정상적으로 보이는 부수효과도 있다.
+
+### 1.4 외부 노출 텍스트 제약 (재확인)
+- 봇 응답·로그·문서·커밋·PR 본문에서 트레이딩 도메인 키워드 금지: `signal`, `trade`, `trading`, `desk`, `quant`, `finance`, `market`, `ticker`, `pnl`.
+- 본 PRD에서 봇은 "코디네이터" 로 통칭한다.
+- 자세한 원칙은 `docs/prd/slack-coordinator-inbound.md` §3.3 / AC-8 참고.
+
+---
+
+## 2. 목표
+
+`message.im` 이벤트 중 **사용자가 직접 입력한 일반 텍스트 메시지**에 대해서만 명령 라우팅이 일어나고, 그 외 subtype은 조용히 무시(no-op + INFO 로그)되도록 가드를 추가한다.
+
+성공 정의:
+
+- 사용자가 DM에서 메시지를 편집·삭제해도 봇이 응답하지 않는다.
+- 정상 입력(`ping`, `status`, 임의 텍스트)은 기존과 동일하게 동작 (회귀 0건).
+- 알려지지 않은 새 subtype도 보수적으로 무시된다 (whitelist 방식).
+
+---
+
+## 3. 범위 (In scope)
+
+### 3.1 subtype 화이트리스트 도입
+
+명령 라우팅 **응답 대상**(handleable):
+- `subtype` 키가 이벤트에 **없는** 경우 (= 일반 사용자 메시지)
+- `subtype`이 `None`인 경우
+- `subtype`이 빈 문자열(`""`)인 경우
+
+**무시 대상**(non-handleable, 응답하지 않음):
+- 위에 해당하지 않는 모든 subtype.
+- 대표 케이스(테스트로 명시 커버):
+  `message_changed`, `message_deleted`, `thread_broadcast`, `file_share`, `bot_message`, `channel_join`, `channel_leave`
+- 알려지지 않은 임의 subtype(예: `subtype=foo`)도 보수적으로 무시.
+
+### 3.2 무시 사유 로깅
+
+INFO 레벨로 한 줄 로깅. 토큰·평문 식별자 미노출.
+
+- 포함: subtype 값, 마스킹된 sender id (`mask_user_id` 재사용), 이벤트 type
+- 메시지 톤: "처리 대상이 아닌 메시지 이벤트를 무시했습니다"
+- 노이즈가 너무 많아질 수 있으므로 **각 subtype에 대해 한 줄**만 남긴다 (rate limit 별도 X).
+
+### 3.3 코드 위치
+
+`ai/coordinator/auth.py` 에 **순수 함수**를 추가한다:
+
+```python
+def is_handleable_message_subtype(event: Mapping[str, Any]) -> bool: ...
+```
+
+- 입력: slack-bolt가 전달하는 `event` dict
+- 출력: bool (True면 명령 라우팅 진행, False면 무시)
+- 부수효과 없음 (로깅은 main.py 호출부에서 수행)
+
+`ai/coordinator/main.py` 의 `handle_message_im` 호출부에서 기존 가드 사이에 끼워 넣는다:
+
+```
+1. is_self_message → return
+2. channel_type != "im" → return
+3. is_handleable_message_subtype(event) == False → INFO 로그 + return  ← 신규
+4. is_allowed_sender → return (기존)
+5. route_command(text)
+```
+
+> NOTE: subtype 가드는 화이트리스트 검사보다 **앞에** 둔다. 비-handleable 이벤트는 화이트리스트 통과 여부와 무관하게 무시되어야 하며(예: 본인이 자기 메시지를 삭제해도 응답 X), 화이트리스트 외 발신자의 system message로 인한 불필요한 분기를 줄인다. (단, `is_self_message`는 더 앞에 둔다 — 봇 자기 에코 방지가 우선.)
+
+### 3.4 단위 테스트 추가
+
+`ai/tests/test_coordinator_auth.py` 에 `is_handleable_message_subtype` 테스트 케이스 **최소 5개** 추가. 네트워크/slack-bolt 호출 없음 (순수 함수 테스트).
+
+필수 커버 케이스:
+
+| # | 입력 event | 기대 |
+|---|---|---|
+| T-1 | `{"type": "message", "text": "ping"}` (subtype 키 없음) | `True` |
+| T-2 | `{"type": "message", "subtype": None, "text": "ping"}` | `True` |
+| T-3 | `{"type": "message", "subtype": "", "text": "ping"}` | `True` |
+| T-4 | `{"type": "message", "subtype": "message_changed", ...}` | `False` |
+| T-5 | `{"type": "message", "subtype": "message_deleted"}` | `False` |
+| T-6 | `{"type": "message", "subtype": "bot_message", ...}` | `False` |
+| T-7 | `{"type": "message", "subtype": "foo_unknown_future"}` | `False` (보수적 거부) |
+
+권장: T-1~T-7 모두 명시적으로 작성 (총 7개).
+
+### 3.5 문서
+
+- `docs/references/slack-coordinator-bot-setup.md` §7 Out-of-Scope 항목에서 "메시지 subtype 가드" 줄을 제거하거나 "구현됨 (PRD: slack-message-subtype-guard)" 표기로 갱신.
+  - 본 PRD는 **개발자 작업의 일부로 §7 갱신을 포함**한다 (별도 docs PR 분리하지 않음).
+
+---
+
+## 4. 비범위 (Out of Scope)
+
+- `handle_message_im` 클로저를 모듈 함수로 추출하거나 dispatcher 패턴으로 리팩터하는 작업 — Issue **#6**의 영역. 본 PRD는 가드 함수 추가와 호출만 한다.
+- `app_mention` 이벤트의 subtype 처리 — 현재 `ignore_mentions` 핸들러가 무조건 무시하므로 영향 없음.
+- 그룹 DM(`mpim`) / 채널 메시지에 대한 가드 — 기존 `channel_type == "im"` 체크로 이미 차단됨. 본 PRD에서는 그 가드를 그대로 둔다.
+- subtype별 **차별 처리**(예: `message_changed` 일 때 편집 전/후 비교 응답) — MVP 범위 아님.
+- 무시 카운터 메트릭/대시보드 — 현재 메트릭 인프라 미도입.
+- 새로운 응답 메시지 추가 — 본 PRD는 **응답을 줄이는** 변경이지 늘리는 변경이 아니다.
+
+---
+
+## 5. 수용 기준 (Acceptance Criteria)
+
+QA가 그대로 체크리스트로 사용한다. **재현 절차 + 기대 결과** 형식.
+
+### AC-1. 일반 텍스트 메시지는 기존 동작 유지
+- **재현**: 본인(`U0AE7A54NHL`)이 코디네이터 봇 DM에 `ping` 입력.
+- **기대**: 5초 이내 `pong` 응답이 도착한다 (PRD `slack-coordinator-inbound` AC-2 회귀 없음). `subtype` 키가 없는 이벤트가 정상 라우팅된다.
+
+### AC-2. 메시지 편집(`message_changed`)은 무시
+- **재현**: 본인 DM에서 임의 메시지 전송 → 즉시 해당 메시지를 **편집**.
+- **기대**: 봇은 편집된 본문에 대해 **응답하지 않는다**. 데몬 로그에 INFO 레벨로 한 줄, `subtype=message_changed` 와 마스킹된 sender id가 기록된다. 토큰·평문 ID 미노출.
+
+### AC-3. 메시지 삭제(`message_deleted`)는 무시
+- **재현**: 본인 DM에서 임의 메시지 전송 → 해당 메시지를 **삭제**.
+- **기대**: 봇은 응답하지 않는다. INFO 로그에 `subtype=message_deleted` 가 한 줄 기록된다.
+
+### AC-4. `bot_message` subtype은 무시
+- **재현**: 단위 테스트로 `{"subtype": "bot_message", "user": "U_OTHER", ...}` 이벤트를 `is_handleable_message_subtype` 에 전달.
+- **기대**: 함수가 `False` 를 반환한다. 통합 검증으로, 화이트리스트 통과 여부와 무관하게 `route_command` 가 호출되지 않는 것을 확인 (mock 또는 dispatcher 추출 후 #6에서 통합 테스트로 보강 가능 — 본 PRD에서는 단위 테스트로 충분).
+
+### AC-5. 알려지지 않은 새 subtype도 보수적으로 무시
+- **재현**: 단위 테스트로 `{"subtype": "foo_unknown_future"}` 이벤트 전달.
+- **기대**: 함수가 `False` 반환. 응답 발사 없음. 보수적(whitelist) 정책이 적용됨을 확인.
+
+### AC-6. 무시 시 로그 포맷
+- **재현**: AC-2 또는 AC-3 시나리오 실행 후 데몬 stdout/로그 확인.
+- **기대**: 한 줄에 다음이 모두 포함:
+  - `subtype=<값>` (예: `subtype=message_changed`)
+  - 마스킹된 sender id (예: `sender=U0AE***`)
+  - 이벤트 type (`type=message`)
+- **금지**: 토큰 값, 평문 user id 전체, 평문 메시지 본문 노출.
+
+### AC-7. 기존 회귀 0건
+- **재현**: 본 PRD 구현 후 `ai/tests/` 전체 단위 테스트 실행 (`pytest ai/tests/`).
+- **기대**: 기존 단위 테스트(약 53개) 및 회귀 영역(약 122개)이 모두 통과한다. 신규 추가 테스트(7개)도 모두 통과.
+
+### AC-8. 외부 노출 텍스트 컴플라이언스
+- **재현**: 본 PRD 구현으로 추가/변경된 모든 사용자 노출 문자열(없음 — 응답 메시지는 추가되지 않음), 로그 메시지, 신규 코드 주석, 문서를 검사.
+- **기대**: 다음 키워드가 단 한 곳도 등장하지 않는다(대소문자 무시):
+  `signal`, `trade`, `trading`, `desk`, `quant`, `finance`, `market`, `ticker`, `pnl`.
+- **참고**: 코드 내부 식별자(`ai.coordinator`, 모듈 변수명 등)는 검사 대상이 아니다.
+
+---
+
+## 6. 가정 · 제약
+
+### 6.1 기술
+
+- **slack-bolt 1.28.0** 의 이벤트 페이로드 구조에 의존. 향후 메이저 업그레이드 시 subtype 필드 의미가 바뀌면 본 가드의 재검토가 필요(가능성 낮음 — Slack API 자체의 안정 영역).
+- **Python 3.11+** (`ai/` 디렉토리 컨벤션, `docs/prd/cost-aware-llm-pipeline.md` §6 정렬).
+- 단위 테스트는 **순수 함수 테스트**만으로 검증 가능 — slack-bolt 실제 호출 없음, 네트워크 mock 불필요.
+- 신규 의존성 추가 없음 (`ai/requirements.txt` 변경 없음).
+
+### 6.2 안전성
+
+- **whitelist 정책**: 알려진 정상 케이스(subtype 부재/None/빈 문자열)만 허용하고 그 외는 거부. 향후 Slack이 새 subtype을 추가하더라도 봇이 자동으로 잘못된 응답을 발사할 위험 없음.
+- **화이트리스트 검사보다 subtype 가드를 앞에 둔다** — 비-handleable 이벤트가 화이트리스트 통과 여부와 무관하게 즉시 차단되어야 하므로(자기 메시지 삭제 시에도 응답 금지). 단, `is_self_message` 는 그보다 더 앞에 둔다 (에코 루프 방지가 최우선).
+
+### 6.3 일정 / 운영
+
+- 로컬 데몬 변경. 배포 인프라 변경 없음. CI 변경 없음.
+- 사용자 1인(이하영) 단독 사용을 가정 (PRD `slack-coordinator-inbound` §6.4 동일).
+
+### 6.4 의존 / 선후관계
+
+- 본 PRD는 **PR #3(slack-coordinator-inbound) 머지 완료를 전제**로 한다.
+- 본 PRD 구현은 Issue **#6**(dispatcher 추출)과 **독립**적으로 진행 가능하다. 둘 다 `handle_message_im` 을 건드리지만, 본 PRD는 가드 함수 추가 + 호출 1줄 삽입만 하므로 #6의 추출 작업과 충돌 영역이 작다. 머지 순서는 작은 변경(본 PRD)을 먼저 머지하면 #6의 리팩터 부담이 줄어든다.
+
+---
+
+## 7. 참고
+
+- 저장소 루트 [`AGENTS.md`](../../AGENTS.md) — PRD 양식, 라벨 플로우
+- [`docs/agents/pm.md`](../agents/pm.md) — PM 작성 원칙
+- [`docs/prd/slack-coordinator-inbound.md`](./slack-coordinator-inbound.md) — 선행 PRD (현재 가드의 출발점)
+- [`docs/references/slack-coordinator-bot-setup.md`](../references/slack-coordinator-bot-setup.md) §7 Out-of-Scope — 본 작업의 출처 항목
+- 관련 코드:
+  - `ai/coordinator/main.py:62-90` — 가드 호출 삽입 위치
+  - `ai/coordinator/auth.py` — 신규 함수 `is_handleable_message_subtype` 추가 위치
+  - `ai/tests/test_coordinator_auth.py` — 단위 테스트 추가 위치
+- GitHub Issue: [#5 Slack 메시지 subtype 가드 추가](https://github.com/deeptrading-lab/trading-signal-engine/issues/5) (라벨: `enhancement`, `priority:P0`)
+- 후속/연관 Issue: #6 (dispatcher 추출 — 본 PRD 비범위)
+- Slack API 레퍼런스: https://api.slack.com/events/message — 메시지 subtype 카탈로그
+- 사용자 메모리 노트: 회사 Slack 동료 가시성, 봇 표시명에 트레이딩 도메인 노출 금지
+
+---
+
+## 부록 A. 의사 코드 (참고용; 구현 강제 아님)
+
+> 개발자 가이드라인 수준. 실제 구현 시 시그니처·로깅 포맷은 동등 의미면 변경 가능.
+
+```python
+# ai/coordinator/auth.py
+def is_handleable_message_subtype(event: Mapping[str, Any]) -> bool:
+    """
+    명령 라우팅 대상 이벤트인지 판정.
+    일반 사용자 텍스트 메시지(subtype 부재/None/빈 문자열)만 True.
+    그 외 모든 subtype(message_changed, message_deleted, thread_broadcast,
+    file_share, bot_message, channel_join, ... 미지의 신규 subtype 포함)은 False.
+    """
+    if not isinstance(event, Mapping):
+        return False
+    subtype = event.get("subtype")
+    if subtype is None or subtype == "":
+        return True
+    return False
+```
+
+```python
+# ai/coordinator/main.py — handle_message_im 내부
+if is_self_message(event, self_user_id):
+    return
+if event.get("channel_type") != "im":
+    return
+if not is_handleable_message_subtype(event):
+    logger.info(
+        "처리 대상이 아닌 메시지 이벤트를 무시했습니다 "
+        "(subtype=%s, sender=%s, type=%s)",
+        event.get("subtype"),
+        mask_user_id(event.get("user")),
+        event.get("type"),
+    )
+    return
+sender = event.get("user")
+if not is_allowed_sender(sender, config.allowed_user_ids):
+    ...
+text = event.get("text") or ""
+reply = route_command(text)
+say(reply)
+```

--- a/docs/qa/slack-message-subtype-guard.md
+++ b/docs/qa/slack-message-subtype-guard.md
@@ -1,0 +1,352 @@
+# QA 리포트: slack-message-subtype-guard
+
+> 작성자: QA 에이전트
+> 작성일: 2026-05-01
+> 대상 PRD: `docs/prd/slack-message-subtype-guard.md`
+> 대상 PR: https://github.com/deeptrading-lab/trading-signal-engine/pull/12
+> 대상 브랜치: `feature/slack-message-subtype-guard`
+> 대상 커밋: `18e77ae`
+> 관련 Issue: #5 (P0)
+> 실행 환경: Python 3.11.15 / pytest 9.0.3 / Darwin 25.4.0
+
+---
+
+## 0. 실행 요약
+
+- **자동화 테스트**: `ai/tests/` 전체 **130개 PASSED** (`pytest`, 0.19s). 신규 추가 `TestIsHandleableMessageSubtype` **8개 PASSED**.
+- **자동 검증 가능 AC** (AC-1, AC-4, AC-5, AC-6, AC-7, AC-8): 모두 **PASS**.
+- **사용자 수동 검증 필요 AC** (AC-2 메시지 편집, AC-3 메시지 삭제, AC-6 실 로그 포맷, AC-1 실 e2e): Slack Workspace·실 Socket Mode 연결 의존이라 본 환경에서 실행 불가 → **MANUAL** 분류, 체크리스트 §3 제공.
+- **추가 점검** (호출 순서·whitelist 정책·순수 함수성·외부 노출 텍스트): 모두 **PASS**.
+- **종합 판정**: 자동 검증 범위 내 실패 0건. 라벨 `qa-auto-passed` 권장 (수동 검증은 사용자 영역).
+
+---
+
+## 1. 수용 기준별 테스트 매핑·결과
+
+| AC | 분류 | 검증 수단 | 결과 |
+|----|------|-----------|------|
+| **AC-1. 일반 텍스트 메시지 기존 동작 유지** | AUTO + MANUAL | T-1/T-2/T-3 단위 테스트 + `route_command`/`render_ping` 회귀 + 실 DM 수동 | **PASS (auto)** / MANUAL (e2e) |
+| AC-2. `message_changed` 무시 | MANUAL | T-4 단위 테스트는 PASS, 실 Slack 편집 동작은 사용자 검증 | **PASS (auto)** / MANUAL (e2e) |
+| AC-3. `message_deleted` 무시 | MANUAL | T-5 단위 테스트는 PASS, 실 Slack 삭제 동작은 사용자 검증 | **PASS (auto)** / MANUAL (e2e) |
+| **AC-4. `bot_message` subtype 무시** | **AUTO** | T-6 단위 테스트 | **PASS** |
+| **AC-5. 알려지지 않은 신규 subtype 보수적 무시** | **AUTO** | T-7 단위 테스트 | **PASS** |
+| **AC-6. 무시 시 로그 포맷** | AUTO + MANUAL | `main.py` 로그 호출 코드 리뷰 (포맷 문자열·마스킹·키 3종 포함) | **PASS (코드 리뷰)** / MANUAL (실 stdout) |
+| **AC-7. 기존 회귀 0건** | **AUTO** | `pytest ai/tests/` 전체 130개 | **PASS** |
+| **AC-8. 외부 노출 텍스트 키워드 0건** | **AUTO** | diff 대상 파일 grep + 정책 키워드 9종 | **PASS** |
+
+---
+
+## 2. 자동 검증 결과
+
+### 2.1 단위 테스트 실행
+
+신규 가드 테스트 단독:
+
+```
+$ python -m pytest ai/tests/test_coordinator_auth.py::TestIsHandleableMessageSubtype -v
+collected 8 items
+
+ai/tests/test_coordinator_auth.py::TestIsHandleableMessageSubtype::test_event_without_subtype_key_is_handleable PASSED  [ 12%]
+ai/tests/test_coordinator_auth.py::TestIsHandleableMessageSubtype::test_event_with_subtype_none_is_handleable PASSED   [ 25%]
+ai/tests/test_coordinator_auth.py::TestIsHandleableMessageSubtype::test_event_with_subtype_empty_string_is_handleable PASSED [ 37%]
+ai/tests/test_coordinator_auth.py::TestIsHandleableMessageSubtype::test_message_changed_is_not_handleable PASSED        [ 50%]
+ai/tests/test_coordinator_auth.py::TestIsHandleableMessageSubtype::test_message_deleted_is_not_handleable PASSED        [ 62%]
+ai/tests/test_coordinator_auth.py::TestIsHandleableMessageSubtype::test_bot_message_is_not_handleable PASSED            [ 75%]
+ai/tests/test_coordinator_auth.py::TestIsHandleableMessageSubtype::test_unknown_future_subtype_is_not_handleable PASSED [ 87%]
+ai/tests/test_coordinator_auth.py::TestIsHandleableMessageSubtype::test_non_mapping_input_is_not_handleable PASSED      [100%]
+
+============================== 8 passed in 0.18s ===============================
+```
+
+PRD §3.4 표 기준 매핑:
+
+| PRD 케이스 | 테스트 메서드 | 입력 subtype | 기대 | 결과 |
+|---|---|---|---|---|
+| T-1 | `test_event_without_subtype_key_is_handleable` | (없음) | `True` | PASS |
+| T-2 | `test_event_with_subtype_none_is_handleable` | `None` | `True` | PASS |
+| T-3 | `test_event_with_subtype_empty_string_is_handleable` | `""` | `True` | PASS |
+| T-4 | `test_message_changed_is_not_handleable` | `message_changed` | `False` | PASS |
+| T-5 | `test_message_deleted_is_not_handleable` | `message_deleted` | `False` | PASS |
+| T-6 | `test_bot_message_is_not_handleable` | `bot_message` | `False` | PASS |
+| T-7 | `test_unknown_future_subtype_is_not_handleable` | `foo_unknown_future` | `False` | PASS |
+| (보강) | `test_non_mapping_input_is_not_handleable` | `None` / `str` | `False` | PASS |
+
+PRD가 요구한 최소 5개를 초과해 8개 작성됨 (T-1 ~ T-7 + 비-Mapping 방어). 양호.
+
+전체 회귀:
+
+```
+$ python -m pytest ai/tests/ -q
+........................................................................ [ 55%]
+..........................................................                [100%]
+============================= 130 passed in 0.19s ==============================
+```
+
+→ 기존 122개 + 신규 8개 = **130개 모두 통과**. AC-7 충족.
+
+---
+
+### 2.2 AC-1 (정상 텍스트 회귀)
+
+T-1·T-2·T-3 단위 테스트로 일반 메시지 이벤트가 가드를 통과해 `True` 반환을 확인. 동시에 `route_command` 회귀(`test_coordinator_handlers.py::TestRouteCommand` 7개) 모두 PASS — `ping → pong`, `status → render_status` 동작 유지.
+
+가드 호출부 (`ai/coordinator/main.py:78-86`)는 라우팅 분기 앞에 `if not is_handleable_...`로 추가됐을 뿐, `True` 경로에서는 기존 `is_allowed_sender` → `route_command(text)` 흐름을 그대로 통과시킴 → 회귀 가능성 없음.
+
+**판정**: PASS (auto 부분).
+
+---
+
+### 2.3 AC-4 / AC-5 (whitelist 정책)
+
+`is_handleable_message_subtype`(`ai/coordinator/auth.py:39-59`):
+
+```python
+if not isinstance(event, Mapping):
+    return False
+subtype = event.get("subtype")
+if subtype is None or subtype == "":
+    return True
+return False
+```
+
+- `bot_message` (T-6): `False` 반환 → AC-4 충족.
+- `foo_unknown_future` (T-7): `False` 반환 → AC-5 충족.
+- 알려진 비핸들러블 4종(`message_changed`, `message_deleted`, `thread_broadcast`, `file_share`)도 모두 `False` 반환 (T-4·T-5 + 정책상 자동 포괄).
+
+**판정**: PASS.
+
+---
+
+### 2.4 AC-6 (로그 포맷 — 코드 리뷰)
+
+`ai/coordinator/main.py:78-86`:
+
+```python
+if not is_handleable_message_subtype(event):
+    logger.info(
+        "처리 대상이 아닌 메시지 이벤트를 무시했습니다 "
+        "(subtype=%s, sender=%s, type=%s)",
+        event.get("subtype"),
+        mask_user_id(event.get("user")),
+        event.get("type"),
+    )
+    return
+```
+
+PRD §3.2 / AC-6 요구사항 매핑:
+
+| 요구 | 구현 위치 | 충족 여부 |
+|---|---|---|
+| INFO 레벨 한 줄 | `logger.info(...)` 단일 호출 | PASS |
+| `subtype=<값>` 포함 | format `subtype=%s` | PASS |
+| 마스킹된 sender id 포함 | `mask_user_id(event.get("user"))` 사용 (`auth.py:80-86`에서 `U0AE***` 형태) | PASS |
+| 이벤트 type 포함 | `type=%s` | PASS |
+| 평문 user id 미노출 | `mask_user_id` 경유 (앞 4자만 + `***`) | PASS |
+| 평문 메시지 본문 미노출 | `event.get("text")`/`event.get("message")` 미참조 | PASS |
+| 토큰 미노출 | 토큰은 `config` 객체에만 존재, 본 로그 라인은 미참조 | PASS |
+| 메시지 톤 (PRD §3.2) | "처리 대상이 아닌 메시지 이벤트를 무시했습니다" 정확 일치 | PASS |
+| 각 subtype에 대해 한 줄 (rate-limit 별도 X) | 단일 `logger.info` + 즉시 `return`, 큐잉/배치 없음 | PASS |
+
+**판정**: PASS (코드 리뷰 한정). 실 stdout 확인은 §3 수동 체크리스트.
+
+---
+
+### 2.5 AC-7 (회귀 0건)
+
+§2.1 마지막 블록 — `ai/tests/` 전체 **130 passed**. 기존 122 + 신규 8.
+
+**판정**: PASS.
+
+---
+
+### 2.6 AC-8 (외부 노출 텍스트 키워드)
+
+본 PR diff에서 변경된 파일에 한해 금지 키워드 9종 grep:
+
+```
+$ git diff main...pr-12 -- ai/coordinator/auth.py ai/coordinator/main.py \
+      ai/tests/test_coordinator_auth.py docs/references/slack-coordinator-bot-setup.md \
+    | grep -niE 'signal|trade|trading|desk|quant|finance|market|ticker|pnl'
+39:@@ -19,7 +19,12 @@ import signal
+```
+
+매치 1건은 `import signal` (Python 표준 시그널 모듈 import 라인의 컨텍스트). PRD §AC-8 명시: "코드 내부 식별자(`ai.coordinator`, 모듈 변수명 등)는 검사 대상이 아니다." → 정당한 식별자.
+
+추가 검사 — 변경된 4개 파일 전체 본문 grep:
+
+```
+ai/coordinator/main.py:18: import signal
+ai/coordinator/main.py:111-157: signal.signal/_install_signal_handlers (Python 표준 모듈 호출)
+docs/references/slack-coordinator-bot-setup.md:24: 금지 키워드 정책을 나열하는 정책 문장 (본 PR이 추가한 라인 아님)
+```
+
+모두 코드 내부 식별자 또는 정책 문서 자체의 키워드 나열 — 외부 노출 텍스트가 아님. 사용자 응답 메시지나 새 로그 문구에 금지 키워드는 **0건**.
+
+**판정**: PASS.
+
+---
+
+## 2.7 추가 점검 (PRD §3.3 / §6.2 코드 리뷰)
+
+### A. 호출 순서 (PRD §3.3)
+
+`ai/coordinator/main.py` `handle_message_im` (라인 67-101):
+
+| 순서 | 가드 | 라인 | PRD 명세와 일치? |
+|---|---|---|---|
+| 1 | `is_self_message(event, self_user_id)` | 70 | YES |
+| 2 | `event.get("channel_type") != "im"` | 74 | YES |
+| 3 | `is_handleable_message_subtype(event)` (+ INFO 로그) | 78-86 | YES |
+| 4 | `is_allowed_sender(sender, ...)` | 91 | YES |
+| 5 | `route_command(text)` → `say(reply)` | 100-101 | YES |
+
+→ PRD §3.3 명세 순서와 정확히 일치. 특히 subtype 가드가 화이트리스트 검사보다 **앞**에 위치함을 확인 (PRD §6.2의 "화이트리스트 통과 여부와 무관하게 비-handleable 이벤트 즉시 차단" 의도 충족).
+
+**판정**: PASS.
+
+### B. whitelist 정책 검증 (PRD §3.1)
+
+`auth.py:39-59` 로직:
+
+```
+1) Mapping 아니면 False (방어)
+2) event.get("subtype") 조회
+3) subtype 가 None 또는 "" 이면 True
+4) 그 외 모두 False
+```
+
+- `subtype` 키 부재 → `dict.get("subtype")` 은 `None` → `True` (T-1 검증)
+- `subtype = None` → `True` (T-2 검증)
+- `subtype = ""` → `True` (T-3 검증)
+- 그 외 임의 문자열 → `False` (T-4·T-5·T-6·T-7 검증)
+
+블랙리스트가 아닌 **whitelist** 방식임을 확인. 향후 Slack이 새 subtype을 도입해도 자동으로 차단됨.
+
+**판정**: PASS.
+
+### C. 순수 함수성 (PRD §3.3)
+
+`is_handleable_message_subtype` 본문 분석:
+- I/O 호출 없음 (logger·network·file system 미참조).
+- 전역 상태 변경 없음.
+- 입력 `event` mutate 없음 (`event.get()` 만 사용 — read-only).
+- 결정적 (`subtype` 값에만 의존).
+
+→ 순수 함수. 로깅은 PRD 명세대로 호출부(`main.py`)에서만 수행.
+
+**판정**: PASS.
+
+### D. 문서 갱신 (PRD §3.5)
+
+`docs/references/slack-coordinator-bot-setup.md` 라인 226 (diff `-` `+`):
+
+```
+- 메시지 subtype 가드 (`message_changed`/`message_deleted`/`thread_broadcast` 무시)
++ 메시지 subtype 가드 — 구현됨 (PRD: [`slack-message-subtype-guard`](../prd/slack-message-subtype-guard.md))
+```
+
+→ §7 Out-of-Scope 항목이 PRD §3.5 명세대로 "구현됨" 표기로 갱신됨.
+
+**판정**: PASS.
+
+---
+
+## 3. 사용자 수동 검증 체크리스트
+
+자동화로는 실 Slack Socket Mode 연결을 재현할 수 없으므로 아래 항목은 사용자(이하영) 본인이 직접 수행해야 합니다.
+
+### 사전 준비
+
+- [ ] `.env` 로드 (`source .env`).
+- [ ] 데몬 기동: `python -m ai.coordinator.main` (별도 터미널 — stdout 로그 관찰용).
+- [ ] 시작 로그에 `Socket Mode 연결을 시도합니다.` 한 줄이 보이는지 확인.
+
+### M-1. AC-1 회귀 — `ping` 정상 동작
+
+- [ ] 코디네이터 봇 DM에 `ping` 입력.
+- [ ] **기대**: 5초 이내 `pong` 응답 도착.
+- [ ] **기대**: 데몬 stdout 에 "처리 대상이 아닌 메시지 이벤트를 무시했습니다" 로그가 **나오지 않음**.
+
+### M-2. AC-2 — 메시지 편집 무시
+
+- [ ] DM 에 임의 텍스트(예: `안녕`) 전송.
+- [ ] (봇이 fallback 응답을 한 번 보낼 수 있음 — 이는 본 PRD 비범위, 정상)
+- [ ] 즉시 방금 전송한 메시지를 **편집** (Slack 메시지에 마우스 올리고 ⋯ → "메시지 편집").
+- [ ] 본문을 다른 텍스트로 바꿔 저장.
+- [ ] **기대**: 편집된 본문에 대해 봇 응답 **없음** (fallback 메시지 발사 X).
+- [ ] **기대**: 데몬 stdout 에 다음 형식 로그 한 줄:
+      `... INFO ai.coordinator: 처리 대상이 아닌 메시지 이벤트를 무시했습니다 (subtype=message_changed, sender=U0AE***, type=message)`
+- [ ] **금지**: 로그에 평문 user id (`U0AE7A54NHL` 전체), 토큰 값, 평문 메시지 본문이 보이지 않아야 함.
+
+### M-3. AC-3 — 메시지 삭제 무시
+
+- [ ] DM 에 임의 텍스트(예: `삭제테스트`) 전송.
+- [ ] 방금 전송한 메시지를 **삭제** (⋯ → "메시지 삭제" → 확인).
+- [ ] **기대**: 봇 응답 **없음**.
+- [ ] **기대**: 데몬 stdout 에 한 줄:
+      `... INFO ai.coordinator: 처리 대상이 아닌 메시지 이벤트를 무시했습니다 (subtype=message_deleted, sender=U0AE***, type=message)`
+- [ ] **금지**: 평문 user id / 토큰 / 본문 미노출.
+
+### M-4. AC-6 — 로그 포맷 종합 확인
+
+위 M-2·M-3 의 로그 라인을 캡처해 다음 모두 포함되는지 한 번에 확인:
+
+- [ ] `subtype=<값>` (값이 정확히 들어감).
+- [ ] `sender=U0AE***` (마스킹된 형태).
+- [ ] `type=message`.
+- [ ] 로그 레벨이 `INFO`.
+- [ ] 한 이벤트당 정확히 한 줄만 출력 (중복 없음).
+
+### M-5. (선택) thread_broadcast / file_share 등
+
+워크스페이스 정책상 재현이 어렵지만 가능하다면:
+
+- [ ] DM 에 파일 첨부(이미지·문서 등) → 봇 응답 없음, 로그에 `subtype=file_share` 한 줄.
+- [ ] DM 스레드에 답글 후 "채널에도 게시" 옵션 → `subtype=thread_broadcast` 한 줄.
+
+수동 검증 결과(PASS / FAIL)를 PR #12 코멘트로 남기면, 모두 PASS 시 `qa-passed` 라벨로 갱신 가능합니다.
+
+---
+
+## 4. 에지 케이스 별도 섹션
+
+본 PRD는 백엔드 가드 로직 변경 단건이므로 외부 의존(거래소/뉴스 피드/네트워크) 영향은 거의 없으나 점검:
+
+| 에지 | 영향 | 본 PR 처리 | 결과 |
+|---|---|---|---|
+| Slack API 페이로드에서 `subtype` 키 자체 누락 | 일반 메시지 케이스 | `dict.get("subtype")` → `None` → `True` 라우팅 | PASS (T-1) |
+| `subtype` 값이 `None` (Slack SDK가 명시적으로 빈 값을 보낼 가능성) | 일반 메시지 케이스 | `is None` 체크 → `True` | PASS (T-2) |
+| `subtype` 값이 빈 문자열 | 일반 메시지 케이스 (페이로드 변형) | `== ""` 체크 → `True` | PASS (T-3) |
+| Slack 가 미래에 새 subtype 추가 | 보수적 무시 (whitelist) | `False` 반환 → 로그 후 무시 | PASS (T-7) |
+| `event` 가 dict 아님 (slack-bolt 변종 / 예외 페이로드) | 방어적 차단 | `isinstance(..., Mapping)` 체크 → `False` | PASS (방어 테스트) |
+| 네트워크 지연으로 동일 이벤트 재전송 | Slack 측 deduplication 영역, 본 PR 비범위 | 가드는 동일하게 동작 | N/A |
+| Slack API 레이트리밋 | `say()` 호출이 실패해도 가드는 영향 없음 (가드는 `say` 이전) | N/A | N/A |
+| 데몬 재시작 중 큐잉된 편집/삭제 이벤트 | 재기동 후 정상 가드 적용 | 무상태 함수라 영향 없음 | PASS |
+
+---
+
+## 5. 자동 검증 로그 모음 (재현 명령)
+
+```
+$ python -m pytest ai/tests/test_coordinator_auth.py::TestIsHandleableMessageSubtype -v
+============================== 8 passed in 0.18s ===============================
+
+$ python -m pytest ai/tests/ -q
+============================= 130 passed in 0.19s ==============================
+
+$ git diff main...pr-12 -- ai/coordinator/auth.py ai/coordinator/main.py \
+    ai/tests/test_coordinator_auth.py docs/references/slack-coordinator-bot-setup.md \
+    | grep -niE 'signal|trade|trading|desk|quant|finance|market|ticker|pnl'
+39:@@ -19,7 +19,12 @@ import signal      # ← 코드 내부 식별자(Python 표준 모듈), AC-8 예외
+```
+
+---
+
+## 6. 종합 판정
+
+- **자동 검증 가능 AC**: AC-1 / AC-4 / AC-5 / AC-6(코드 리뷰) / AC-7 / AC-8 — 모두 **PASS**.
+- **수동 검증 필요**: AC-1(e2e) / AC-2 / AC-3 / AC-6(실 stdout) — 사용자 체크리스트 §3.
+- **추가 점검 (호출 순서·whitelist·순수 함수성·문서 갱신)**: 모두 PASS.
+- **실패 항목**: 0건.
+
+→ 라벨 권장: **`qa-auto-passed`** (수동 검증 완료 시 PR 코멘트 + `qa-passed` 로 승격).

--- a/docs/qa/slack-message-subtype-guard.md
+++ b/docs/qa/slack-message-subtype-guard.md
@@ -350,3 +350,129 @@ $ git diff main...pr-12 -- ai/coordinator/auth.py ai/coordinator/main.py \
 - **실패 항목**: 0건.
 
 → 라벨 권장: **`qa-auto-passed`** (수동 검증 완료 시 PR 코멘트 + `qa-passed` 로 승격).
+
+---
+
+## 7. 추가 검증 (커밋 `c358f28`)
+
+> 작성일: 2026-05-01 (2차 검증)
+> 트리거: 사용자 1차 수동 검증에서 편집·삭제 시 봇 응답은 정상이나 stdout 로그가 `sender=<unknown>` 으로 찍히는 문제 발견 → 발신자 추출 fallback 보강 커밋.
+
+### 7.1 변경 요약
+
+| 파일 | 변경 |
+|---|---|
+| `ai/coordinator/auth.py` | 순수 함수 `extract_sender(event)` 추가 (top-level → `message.user` → `previous_message.user` 우선순위) |
+| `ai/coordinator/main.py` | 2곳에 적용 — (1) subtype 무시 로그의 `mask_user_id(...)` 인자, (2) 화이트리스트 체크용 `sender = ...` 할당 |
+| `ai/tests/test_coordinator_auth.py` | `TestExtractSender` 8 케이스 추가 |
+
+### 7.2 자동 회귀
+
+```
+$ python -m pytest ai/tests/ -q
+138 passed in 0.27s
+
+$ python -m pytest ai/tests/test_coordinator_auth.py::TestExtractSender -v
+============================== 8 passed in 0.18s ===============================
+```
+
+기존 130개 + 신규 8개 = **138개 전부 PASS**. 회귀 0건.
+
+| # | 케이스 | 입력 | 기대 | 결과 |
+|---|---|---|---|---|
+| 1 | top-level user | `{"user": "U_AAA"}` | `"U_AAA"` | PASS |
+| 2 | `message_changed` nested | `event["message"]["user"]` | nested user 반환 | PASS |
+| 3 | `message_deleted` previous | `event["previous_message"]["user"]` | previous user 반환 | PASS |
+| 4 | 우선순위 (top > nested > prev) | 셋 다 존재, top 다른 값 | top 값 우선 | PASS |
+| 5 | 어디에도 없음 | `{"type": "message"}` | `None` | PASS |
+| 6 | 빈 top-level user fallback | `{"user": "", "message": {"user": "U_FB"}}` | nested로 fallback | PASS |
+| 7 | 비-Mapping 입력 | `None` / `"str"` | `None` (방어) | PASS |
+| 8 | 비-Mapping nested 무시 | `{"message": "broken", "previous_message": {...}}` | previous로 폴스루 | PASS |
+
+### 7.3 코드 정합성 점검
+
+#### A. `extract_sender` 순수 함수성
+
+`ai/coordinator/auth.py:39-69`:
+- I/O 없음 (logger·network·fs 미참조).
+- 전역 상태 미변경.
+- 입력 mutate 없음 (`Mapping.get()` read-only).
+- 결정적 출력. 부수효과 없음.
+
+→ PRD 정신(가드 헬퍼는 순수 함수, 로깅은 호출부)과 일치. PASS.
+
+#### B. 우선순위 로직 정합성
+
+PRD AC-6 명세 ("마스킹된 sender id") + Slack 페이로드 스키마:
+- `message_changed`: 봇이 응답해야 할 발신자는 **편집한 사용자** = `message.user` ✓
+- `message_deleted`: 보존되는 정보는 **삭제 전 작성자** = `previous_message.user` ✓
+- 우선순위 (top → nested → previous): 일반 메시지에 top-level user 가 있으면 즉시 반환 → 빠른 경로 보존, 부수효과 없음.
+- 빈 문자열은 falsy → 다음 폴백으로 폴스루 (T-6 검증). `None`/`""` 모두 처리.
+
+→ PASS.
+
+#### C. `main.py` 호출부 적용 (2곳)
+
+```
+$ grep -n "extract_sender" ai/coordinator/main.py
+23:    extract_sender,
+84:                mask_user_id(extract_sender(event)),
+89:        sender = extract_sender(event)
+```
+
+```
+$ grep -nE "event\.get\(['\"]user['\"]\)" ai/coordinator/main.py
+(매치 없음)
+```
+
+| 적용 지점 | 라인 | 변경 전 | 변경 후 |
+|---|---|---|---|
+| subtype 무시 로그의 sender | 84 | `mask_user_id(event.get("user"))` | `mask_user_id(extract_sender(event))` |
+| 화이트리스트 체크 sender | 89 | `sender = event.get("user")` | `sender = extract_sender(event)` |
+
+→ PRD 명시 2곳 모두 정확히 적용됨. 잔여 raw `event.get("user")` 호출 없음. PASS.
+
+또한 `is_self_message`(`auth.py:14-37`) 의 `event.get("user")` 는 의도된 분리 — 자기 메시지 판정은 `bot_id` 우선이고 user 필드는 봇 자신 user id 와의 일치 여부 판정용이므로 fallback 적용 대상 아님 (subtype=bot_message 는 `bot_id` 또는 별도 분기에서 이미 차단). 변경 불필요.
+
+#### D. 외부 노출 텍스트 컴플라이언스
+
+```
+$ git diff 0430e28..c358f28 -- ai/coordinator/auth.py ai/coordinator/main.py \
+    ai/tests/test_coordinator_auth.py \
+    | grep -niE 'signal|trade|trading|desk|quant|finance|market|ticker|pnl'
+MATCHES: 0
+```
+
+→ 추가 커밋 diff에 트레이딩 키워드 **0건**. PRD AC-8 충족 (Slack 봇 표시명/응답 노출 키워드 정책 준수).
+
+### 7.4 사용자 재검증 체크리스트 (수동)
+
+`docs/qa/slack-message-subtype-guard.md` §3 의 M-2·M-3 를 데몬 재기동 후 다시 수행하면서 **로그 내 sender 값** 만 추가로 확인하면 됩니다.
+
+- [ ] 데몬 종료 후 재기동: `python -m ai.coordinator.main`
+- [ ] **M-2 재확인 (편집)**: 본인 DM 메시지 편집 → 데몬 stdout 의 로그 라인이
+      `... INFO ai.coordinator: 처리 대상이 아닌 메시지 이벤트를 무시했습니다 (subtype=message_changed, sender=U0AE***, type=message)`
+      형태로 **본인 user id 가 마스킹되어** 보이는지. (`U0AE***` 등 — 끝 4자리 가림)
+- [ ] **M-3 재확인 (삭제)**: 본인 DM 메시지 삭제 → 동일 형식, `subtype=message_deleted`, `sender=U0AE***` 로 표시.
+- [ ] **회귀 음성 확인**: `sender=<unknown>` 문자열이 stdout 에 더 이상 출력되지 **않는지** (`grep -F '<unknown>' ` 등으로 확인 가능).
+- [ ] **AC-1 회귀 (정상 메시지)**: `ping` → `pong` 정상 응답이 그대로 동작하는지 (extract_sender 가 top-level 경로에서 즉시 반환되어 화이트리스트 체크 통과해야 함).
+
+### 7.5 에지 케이스 보강
+
+| 에지 | 처리 | 결과 |
+|---|---|---|
+| `message_changed` 페이로드의 `previous_message` 까지 user 누락 | top → nested → prev 순회 후 None | PASS (T-5) |
+| top-level `user` 가 빈 문자열 (Slack SDK 의 자료형 변형) | falsy 판정으로 nested 폴스루 | PASS (T-6) |
+| `message` 키 값이 dict 아닌 변형 페이로드 | `isinstance(..., Mapping)` 가드로 안전, previous 로 폴스루 | PASS (T-8) |
+| 비-Mapping `event` (slack-bolt 변종) | 즉시 None 반환 | PASS (T-7) |
+| 봇 자기 메시지의 `extract_sender` 호출 | `is_self_message` 가 먼저 차단해 도달 불가 (`main.py:71-72`) | PASS (호출 순서) |
+
+### 7.6 종합 (2차)
+
+- 자동 회귀: **138 PASS / 0 FAIL**.
+- 신규 함수 정합성: PASS (순수 함수, 우선순위 PRD/Slack 스키마 부합).
+- `main.py` 호출부 정합성: 2곳 모두 적용, 잔여 raw 호출 0.
+- 외부 노출 텍스트 컴플라이언스: 키워드 0건.
+- 실패 항목: **0건**.
+
+→ 자동 검증 범위 내 회귀/정합성 모두 PASS. 라벨 유지 권장 (`qa-auto-passed`). 사용자 §7.4 재확인 후 모두 PASS 시 PR 코멘트와 함께 `qa-passed` 로 승격.

--- a/docs/references/slack-coordinator-bot-setup.md
+++ b/docs/references/slack-coordinator-bot-setup.md
@@ -223,7 +223,7 @@ ai/coordinator/
 - 슬래시 커맨드, Block Kit 인터랙티브 컴포넌트
 - 클라우드 배포 (Cloud Run / Lambda 등 — Socket Mode 대신 HTTP webhook으로 전환)
 - `python-dotenv` 자동 로딩 (매번 `source .env` 불필요하게)
-- 메시지 subtype 가드 (`message_changed`/`message_deleted`/`thread_broadcast` 무시)
+- 메시지 subtype 가드 — 구현됨 (PRD: [`slack-message-subtype-guard`](../prd/slack-message-subtype-guard.md))
 
 ---
 


### PR DESCRIPTION
## 개요

Slack DM 이벤트 중 일반 텍스트 메시지(subtype 부재/None/빈 문자열)만 명령 라우팅 대상으로 판정하고, 그 외 subtype(`message_changed`, `message_deleted`, `bot_message`, 알려지지 않은 신규 subtype 등)은 조용히 무시(no-op + INFO 로그)하도록 가드를 추가합니다.

PRD: [`docs/prd/slack-message-subtype-guard.md`](https://github.com/deeptrading-lab/trading-signal-engine/blob/feature/slack-message-subtype-guard/docs/prd/slack-message-subtype-guard.md)

Closes #5

## 변경 사항

- `ai/coordinator/auth.py` — 순수 함수 `is_handleable_message_subtype(event)` 추가 (whitelist 정책)
- `ai/coordinator/main.py` — `handle_message_im` 에 가드 호출 1줄 삽입. 호출 순서: `is_self_message` → `channel_type == "im"` → `is_handleable_message_subtype` → `is_allowed_sender` → `route_command`
- `ai/tests/test_coordinator_auth.py` — 단위 테스트 8개 추가 (T-1~T-7 + non-mapping 방어)
- `docs/references/slack-coordinator-bot-setup.md` §7 — Out-of-Scope 항목을 "구현됨" 표기로 갱신

> 주의: `handle_message_im` 클로저를 모듈 함수로 추출하는 리팩터는 #6 영역. 본 PR은 가드 함수 추가 + 1줄 호출 삽입 범위로 제한.

## 수용 기준 체크리스트

- [x] **AC-1**: 일반 텍스트 메시지(subtype 키 없음/None/빈 문자열)는 기존대로 라우팅
- [x] **AC-2**: `message_changed` 이벤트는 무시 (가드에서 차단, 로그 기록)
- [x] **AC-3**: `message_deleted` 이벤트는 무시
- [x] **AC-4**: `bot_message` subtype은 무시 (단위 테스트로 검증)
- [x] **AC-5**: 알려지지 않은 신규 subtype도 보수적으로 무시 (whitelist)
- [x] **AC-6**: 무시 시 INFO 로그 한 줄 — `subtype=<값>`, 마스킹된 sender(`U0AE***`), 이벤트 type 포함. 토큰·평문 user id 미노출
- [x] **AC-7**: 기존 회귀 0건 — 단위 테스트 130개(이전 122개 + 신규 8개) 전체 통과
- [x] **AC-8**: 외부 노출 텍스트 컴플라이언스 — 신규 추가된 로그 메시지·주석에 금지 키워드 없음

## 테스트 결과

```
$ python -m pytest ai/tests/
============================= 130 passed in 0.27s ==============================
```

신규 추가 8개:

```
TestIsHandleableMessageSubtype::test_event_without_subtype_key_is_handleable PASSED
TestIsHandleableMessageSubtype::test_event_with_subtype_none_is_handleable PASSED
TestIsHandleableMessageSubtype::test_event_with_subtype_empty_string_is_handleable PASSED
TestIsHandleableMessageSubtype::test_message_changed_is_not_handleable PASSED
TestIsHandleableMessageSubtype::test_message_deleted_is_not_handleable PASSED
TestIsHandleableMessageSubtype::test_bot_message_is_not_handleable PASSED
TestIsHandleableMessageSubtype::test_unknown_future_subtype_is_not_handleable PASSED
TestIsHandleableMessageSubtype::test_non_mapping_input_is_not_handleable PASSED
```

## QA 가이드 (실 데몬)

1. 데몬 실행 → 본인 DM에서 `ping` → `pong` 응답 확인 (AC-1)
2. 임의 메시지 전송 후 즉시 편집 → 봇 무응답, 로그에 `subtype=message_changed, sender=U0AE***, type=message` 한 줄 (AC-2)
3. 임의 메시지 전송 후 삭제 → 봇 무응답, `subtype=message_deleted` 로그 (AC-3)