### PR TITLE
ai: 코디네이터 진입점에서 .env 자동 로딩

### DIFF
--- a/ai/coordinator/main.py
+++ b/ai/coordinator/main.py
@@ -2,11 +2,13 @@
 코디네이터 데몬 엔트리포인트.
 
 PRD: docs/prd/slack-coordinator-inbound.md
+PRD: docs/prd/coordinator-dotenv-autoload.md  ―  `.env` 자동 로딩
 
 실행:
     python -m ai.coordinator.main
 
 동작:
+- 진입 시 `.env` 자동 로딩(셸 export 우선, override=False).
 - 환경변수 검증(fail-fast) → Socket Mode 클라이언트 시작.
 - `message.im` 이벤트만 처리. 화이트리스트 외 발신자·봇 자기 메시지는 무시.
 - SIGINT/SIGTERM 수신 시 graceful shutdown.
@@ -18,6 +20,8 @@ import logging
 import signal
 import sys
 from typing import Any
+
+from dotenv import find_dotenv, load_dotenv
 
 from ai.coordinator.auth import (
     extract_sender,
@@ -137,8 +141,26 @@ def _install_signal_handlers(logger: logging.Logger) -> None:
         pass
 
 
+def _autoload_dotenv() -> None:
+    """프로젝트 루트의 `.env` 를 자동 로딩한다.
+
+    PRD: docs/prd/coordinator-dotenv-autoload.md
+
+    - `find_dotenv()` 로 cwd → 상위 디렉토리를 탐색한다.
+    - `override=False` 로 **셸 export 가 항상 우선**(운영 환경 안전).
+    - `.env` 부재 시 조용히 무시(다음 단계의 `ConfigError` fail-fast 가 자연스럽게 작동).
+    - 본 라이브러리 import 는 진입점(`main.py`)에만 두고 `config.py` 는 순수 환경변수
+      검증 책임만 유지한다(단위 테스트가 dotenv 의존성 없이 동작).
+    """
+    dotenv_path = find_dotenv(usecwd=True)
+    if dotenv_path:
+        load_dotenv(dotenv_path, override=False)
+
+
 def run() -> int:
     """데몬 메인 루프. 종료 코드(0=정상)를 반환한다."""
+    _autoload_dotenv()
+
     try:
         config = load_config()
     except ConfigError as exc:

--- a/ai/requirements.txt
+++ b/ai/requirements.txt
@@ -9,5 +9,9 @@ anthropic>=0.97.0
 # PRD: docs/prd/slack-coordinator-inbound.md
 slack-bolt>=1.18
 
+# `.env` 자동 로딩 — 진입점에서 `load_dotenv(override=False)` 한 줄.
+# PRD: docs/prd/coordinator-dotenv-autoload.md
+python-dotenv>=1.0
+
 # 개발·테스트 의존성 (pytest 는 테스트 실행 시 필요).
 pytest>=8.0

--- a/ai/tests/test_coordinator_main_dotenv.py
+++ b/ai/tests/test_coordinator_main_dotenv.py
@@ -1,0 +1,182 @@
+"""코디네이터 진입점 `.env` 자동 로딩 테스트.
+
+PRD: docs/prd/coordinator-dotenv-autoload.md
+
+- AC-A1: `.env` 만 있고 셸 환경변수가 없을 때 자동 로딩된다.
+- AC-O1: 셸 환경변수가 export 되어 있으면 그 값이 우선이고 `.env` 가 덮어쓰지 않는다.
+- AC-F1: `.env` 부재 + 셸 환경변수 부재 시 기존 `ConfigError` fail-fast 가 그대로 동작한다.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from ai.coordinator import main as coordinator_main
+from ai.coordinator.config import ConfigError, load_config
+
+
+# ---------------------------------------------------------------------------
+# 헬퍼
+# ---------------------------------------------------------------------------
+
+_TOKEN_ENV_KEYS = (
+    "SLACK_BOT_TOKEN",
+    "SLACK_APP_TOKEN",
+    "SLACK_ALLOWED_USER_IDS",
+    "LOG_LEVEL",
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """테스트 격리 — 기존 셸에 export 된 토큰류를 모두 제거한 환경을 보장."""
+    for key in _TOKEN_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    return monkeypatch
+
+
+def _write_env(dir_path: Path, lines: dict[str, str]) -> Path:
+    env_file = dir_path / ".env"
+    env_file.write_text("\n".join(f"{k}={v}" for k, v in lines.items()) + "\n")
+    return env_file
+
+
+# ---------------------------------------------------------------------------
+# AC-A1 — `.env` 자동 로딩
+# ---------------------------------------------------------------------------
+
+
+class TestDotenvAutoload:
+    def test_loads_env_from_cwd(self, tmp_path, clean_env):
+        """프로젝트 루트(cwd)의 `.env` 가 자동 로딩되어 환경변수에 적용된다."""
+        _write_env(
+            tmp_path,
+            {
+                "SLACK_BOT_TOKEN": "xoxb-FROM-DOTENV",
+                "SLACK_APP_TOKEN": "xapp-FROM-DOTENV",
+            },
+        )
+        clean_env.chdir(tmp_path)
+
+        coordinator_main._autoload_dotenv()
+
+        assert os.environ.get("SLACK_BOT_TOKEN") == "xoxb-FROM-DOTENV"
+        assert os.environ.get("SLACK_APP_TOKEN") == "xapp-FROM-DOTENV"
+
+        # 후속 `load_config` 가 정상 동작하는지(AC-A1: 기동 직전까지 진행).
+        cfg = load_config()
+        assert cfg.bot_token == "xoxb-FROM-DOTENV"
+        assert cfg.app_token == "xapp-FROM-DOTENV"
+
+    def test_loads_env_from_subdirectory(self, tmp_path, clean_env):
+        """하위 디렉토리에서 실행해도 상위 `.env` 를 찾아 로딩한다(`find_dotenv` 동작)."""
+        _write_env(
+            tmp_path,
+            {
+                "SLACK_BOT_TOKEN": "xoxb-PARENT-DIR",
+                "SLACK_APP_TOKEN": "xapp-PARENT-DIR",
+            },
+        )
+        sub = tmp_path / "nested" / "deep"
+        sub.mkdir(parents=True)
+        clean_env.chdir(sub)
+
+        coordinator_main._autoload_dotenv()
+
+        assert os.environ.get("SLACK_BOT_TOKEN") == "xoxb-PARENT-DIR"
+        assert os.environ.get("SLACK_APP_TOKEN") == "xapp-PARENT-DIR"
+
+
+# ---------------------------------------------------------------------------
+# AC-O1 — 셸 export 우선
+# ---------------------------------------------------------------------------
+
+
+class TestShellOverridesDotenv:
+    def test_shell_value_wins_over_dotenv(self, tmp_path, clean_env):
+        """셸에 export 된 값이 있으면 `.env` 가 그 값을 덮어쓰지 않는다."""
+        _write_env(
+            tmp_path,
+            {
+                "SLACK_BOT_TOKEN": "xoxb-FROM-DOTENV",
+                "SLACK_APP_TOKEN": "xapp-FROM-DOTENV",
+            },
+        )
+        clean_env.chdir(tmp_path)
+
+        # 셸 export 모사 — `.env` 와 다른 값.
+        clean_env.setenv("SLACK_BOT_TOKEN", "xoxb-FROM-SHELL")
+        clean_env.setenv("SLACK_APP_TOKEN", "xapp-FROM-SHELL")
+
+        coordinator_main._autoload_dotenv()
+
+        # 셸 값이 살아 있어야 한다(override=False).
+        assert os.environ["SLACK_BOT_TOKEN"] == "xoxb-FROM-SHELL"
+        assert os.environ["SLACK_APP_TOKEN"] == "xapp-FROM-SHELL"
+
+        cfg = load_config()
+        assert cfg.bot_token == "xoxb-FROM-SHELL"
+        assert cfg.app_token == "xapp-FROM-SHELL"
+
+    def test_partial_shell_export_merges_with_dotenv(self, tmp_path, clean_env):
+        """셸에 일부만 export 되어 있으면 나머지는 `.env` 값으로 채워진다."""
+        _write_env(
+            tmp_path,
+            {
+                "SLACK_BOT_TOKEN": "xoxb-FROM-DOTENV",
+                "SLACK_APP_TOKEN": "xapp-FROM-DOTENV",
+            },
+        )
+        clean_env.chdir(tmp_path)
+        clean_env.setenv("SLACK_BOT_TOKEN", "xoxb-FROM-SHELL")  # APP_TOKEN 은 미설정.
+
+        coordinator_main._autoload_dotenv()
+
+        assert os.environ["SLACK_BOT_TOKEN"] == "xoxb-FROM-SHELL"
+        assert os.environ["SLACK_APP_TOKEN"] == "xapp-FROM-DOTENV"
+
+
+# ---------------------------------------------------------------------------
+# AC-F1 — `.env` 부재 시 기존 fail-fast 회귀 무결
+# ---------------------------------------------------------------------------
+
+
+class TestDotenvAbsentFailsFast:
+    def test_autoload_is_silent_when_no_dotenv(self, tmp_path, clean_env):
+        """`.env` 가 없는 디렉토리에서 호출해도 예외를 던지지 않는다."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        clean_env.chdir(empty)
+
+        # 예외 없이 통과해야 한다.
+        coordinator_main._autoload_dotenv()
+
+        # 환경변수도 새로 만들어지지 않아야 한다.
+        assert os.environ.get("SLACK_BOT_TOKEN") is None
+        assert os.environ.get("SLACK_APP_TOKEN") is None
+
+    def test_run_returns_nonzero_when_dotenv_absent_and_shell_empty(
+        self, tmp_path, clean_env, capsys
+    ):
+        """`.env` 부재 + 셸 환경변수 부재 시 `run()` 이 non-zero 종료 코드를 반환한다."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        clean_env.chdir(empty)
+
+        exit_code = coordinator_main.run()
+
+        assert exit_code != 0
+        captured = capsys.readouterr()
+        # 한 줄 fail-fast 포맷이 유지된다(트레이싱백 미노출).
+        assert "[코디네이터] 시작 실패" in captured.err
+        assert "SLACK_BOT_TOKEN" in captured.err
+        # 평문 토큰이 노출될 일은 없지만, 기존 마스킹 원칙도 회귀 무결.
+        assert "Traceback" not in captured.err
+
+    def test_load_config_raises_when_environment_empty(self, clean_env):
+        """기존 `ConfigError` fail-fast 가 그대로 동작함을 명시 회귀."""
+        with pytest.raises(ConfigError):
+            load_config()

--- a/docs/prd/coordinator-dotenv-autoload.md
+++ b/docs/prd/coordinator-dotenv-autoload.md
@@ -1,0 +1,147 @@
+# PRD: coordinator-dotenv-autoload
+
+> 작성자: PM 에이전트  
+> 작성일: 2026-05-01  
+> 대상 디렉터리: `ai/coordinator/` (Python)  
+> UI: 없음  
+> 관련 이슈: [#9](https://github.com/deeptrading-lab/trading-signal-engine/issues/9) (라벨: `enhancement`, `priority:P1`)  
+> 출처: PR #3 가이드 §7 + 사용자 UX 피드백
+
+---
+
+## 1. 배경 / 문제
+
+- 현재 `python -m ai.coordinator.main` 으로 코디네이터 데몬을 띄우려면, 사용자는 매번 셸에서 다음 한 줄을 선행 실행해야 한다.
+  ```bash
+  set -a && source .env && set +a
+  ```
+- 이는 **매일 데몬을 띄우는 사용자 워크플로**(아침 시작 시, 새 터미널 창, tmux 분할 패널 등)에서 다음과 같은 마찰을 만든다.
+  - 새 셸·새 창마다 동일 명령을 반복해야 한다.
+  - `source` 직후 `python ...` 까지 한 줄에 묶지 않으면 export 누락이 발생하기 쉽다.
+  - 가이드(`docs/references/slack-coordinator-bot-setup.md` §3-3)도 이 두 단계를 사용자에게 외우게 만들고 있어, 신규 합류자의 첫 실행 실패율이 높다.
+- 파이썬 진영의 표준 해법인 `python-dotenv` 는 진입점에서 `load_dotenv()` 한 줄로 `.env` 를 자동 탐색·로딩한다. 이미 `.env.example` 가 PR #3에서 도입되어 있으므로, **로딩 메커니즘만 코드 쪽으로 옮기면** 사용자는 한 줄(`python -m ai.coordinator.main`)로 데몬을 시작할 수 있다.
+- `python-dotenv` 는 **기본적으로 셸에 export 된 값을 덮어쓰지 않는다**(`override=False`). 따라서 운영 환경(systemd / 컨테이너)에서 명시적으로 환경변수를 주입하는 워크플로와 충돌하지 않는다.
+
+**요약 문제**: `.env` 로딩이 **셸 단계**에 있어 매일 사용자 UX가 나쁘고 실수가 잦다. 진입점 코드 한 곳에서 자동 처리해야 한다.
+
+---
+
+## 2. 목표
+
+무엇이 달라지면 성공인가.
+
+- **G1 (UX)**: 사용자가 프로젝트 루트에서 `python -m ai.coordinator.main` **단일 명령**만 실행해도 `.env` 의 토큰이 적재되어 데몬이 정상 시작된다.
+- **G2 (안전)**: 셸에 이미 export 된 환경변수가 있으면 **셸 값이 우선**된다(운영 환경에서 의도치 않은 오버라이드 금지).
+- **G3 (회귀 무결)**: `.env` 와 셸 환경변수가 모두 부재하면 기존 `ConfigError` fail-fast 동작이 그대로 유지된다(조용한 실패 금지).
+- **G4 (문서 일치)**: 가이드 문서가 새 사용법을 정확히 반영하고, 외부 노출 텍스트 제약(트레이딩 도메인 키워드 금지)을 위반하지 않는다.
+
+---
+
+## 3. 범위 (In scope)
+
+이번 PRD에서 반드시 포함한다.
+
+1. **의존성 추가**
+   - `ai/requirements.txt` 에 `python-dotenv >= 1.0` (정확한 마이너 버전 핀은 구현자 재량, 단 `>= 1.0` 메이저).
+   - 현재 사용 중인 `pip-tools`/락 파일이 있다면 동일하게 갱신.
+
+2. **자동 로딩 진입점**
+   - `ai/coordinator/main.py` 의 진입점, 또는 `ai/coordinator/config.py` 의 모듈 로딩 시점 중 **단 한 곳**에서 `load_dotenv()` 를 호출한다.
+   - 구현 결정사항(둘 중 어느 곳을 선택했는지·이유)은 Backend Dev 가 PR 본문에 한 줄로 기록한다.
+   - `.env` 파일은 **프로젝트 루트** 에서 자동 탐색한다(`python-dotenv` 의 `find_dotenv()` 기본 동작 또는 명시적 경로 계산 모두 허용).
+   - `load_dotenv(override=False)` 또는 동등한 명시적 인자로 **셸 환경변수 우선** 을 보장한다.
+
+3. **가이드 문서 갱신**
+   - `docs/references/slack-coordinator-bot-setup.md` §3-3 (또는 해당 절):
+     - `set -a && source .env && set +a` 단계를 **제거** 하거나, "자동 로딩되므로 별도 export 불필요" 안내로 대체한다.
+     - `.env` 파일이 프로젝트 루트에 존재하면 자동 인식됨을 명시.
+     - 운영 환경에서 셸 export 가 우선됨을 한 줄로 명시(혼동 방지).
+   - 트레이딩 도메인 키워드(예: `signal`, `trade`, `desk`, `order` 등) 노출 금지 원칙은 그대로 유지.
+
+4. **테스트 (pytest, 단위)**
+   - `.env` 가 있고 셸 환경변수가 없을 때 자동 로딩되는지 검증 (tempfile 로 가짜 `.env` + 모킹된 cwd / `find_dotenv` 경로).
+   - 셸 환경변수가 export 되어 있고 `.env` 에 다른 값이 있을 때, **셸 값이 우선** 됨을 검증 (monkeypatch 로 `os.environ` 주입).
+   - `.env` 부재 + 셸 환경변수 부재 시 기존 `ConfigError` fail-fast 가 그대로 작동함을 검증.
+   - 외부 API 호출(Slack 등)은 mock 으로 차단.
+
+---
+
+## 4. 비범위 (Out of scope)
+
+이번 PRD에서 **하지 않는다**.
+
+- **`.env` 파일 위치 커스터마이징**: `--env-file` 같은 CLI 플래그, `DOTENV_PATH` 같은 별도 환경변수로 경로 지정하는 기능은 본 PRD 범위 밖. 프로젝트 루트 1곳만 본다.
+- **다중 환경 파일**: `.env.local`, `.env.production`, `.env.test` 같은 머지·우선순위 정책은 다루지 않는다.
+- **`ai/coordinator/` 외 디렉터리**: `backend/`(Kotlin), `ai/` 의 다른 진입점에서의 dotenv 도입은 본 PRD 범위 밖. 코디네이터 데몬에 한정.
+- **시크릿 매니저 연동**: AWS Secrets Manager / Vault 등의 외부 소스에서 시크릿을 끌어오는 기능은 후속 과제.
+- **`.env` 포맷 확장**: 다중 라인 값, 변수 보간(`${VAR}`) 등의 고급 기능은 `python-dotenv` 기본값을 그대로 따른다(별도 설계 없음).
+- **로깅 변경**: dotenv 로딩 자체에 대한 별도 INFO/DEBUG 로그 포맷 정의는 하지 않는다(라이브러리 기본 동작 그대로).
+
+---
+
+## 5. 수용 기준 (Acceptance criteria)
+
+QA 가 그대로 테스트로 변환할 수 있도록 검증 가능한 문장으로 기술한다.
+
+### 자동 로딩 (AC-A)
+- **AC-A1**: 프로젝트 루트에 `SLACK_BOT_TOKEN=xoxb-FROM-DOTENV` 등을 담은 `.env` 가 존재하고, 셸에 해당 환경변수가 export 되어 있지 **않을 때**, `python -m ai.coordinator.main` 단일 명령만 실행하면 코디네이터가 토큰을 정상 적재해 데몬을 시작한다(에러 없이 기동, 또는 mock 환경에서 시작 직전까지 진행).
+- **AC-A2**: `.env` 가 없는 디렉터리에서 시작해도, 라이브러리 호출 자체는 예외를 던지지 않는다(다음 단계의 `ConfigError` 가 자연스럽게 작동해야 한다).
+
+### 우선순위 (AC-O)
+- **AC-O1**: 셸에 `SLACK_BOT_TOKEN=xoxb-FROM-SHELL` 가 export 되어 있고, `.env` 에는 `SLACK_BOT_TOKEN=xoxb-FROM-DOTENV` 가 들어 있을 때, **실제 사용되는 값은 `xoxb-FROM-SHELL`** 이다(즉, dotenv 가 셸 값을 덮어쓰지 않는다).
+- **AC-O2**: 셸에 환경변수가 없고 `.env` 에만 값이 있을 때는 `.env` 값이 적용된다(AC-A1 의 reaffirm).
+
+### Fail-fast 회귀 (AC-F)
+- **AC-F1**: `.env` 부재 + 셸 환경변수 부재 + 필수 토큰 누락 상태로 `python -m ai.coordinator.main` 을 실행하면, **기존과 동일한 `ConfigError`** 가 발생하고, 프로세스는 **non-zero exit code** 로 종료한다.
+- **AC-F2**: 위 실패 메시지는 한 줄(또는 기존 가이드와 동일한 길이)이며, 트레이싱백이 길게 노출되지 않는다(기존 fail-fast 포맷 유지).
+
+### 보안 (AC-S)
+- **AC-S1**: 토큰이 자동 로딩되더라도, 로그·에러 메시지 어디에도 평문 토큰이 출력되지 않는다(기존 마스킹 동작 그대로).
+- **AC-S2**: `.env` 의 키 이름·값 어느 쪽도 stdout/stderr 에 그대로 dump 되지 않는다.
+
+### 회귀 (AC-R)
+- **AC-R1**: 기존 단위 테스트 138 개 + 통합 회귀 모두 통과한다(현재 테스트 카운트는 작성 시점 기준이며, 구현 시점에 늘었다면 그 수치 기준으로 전부 통과).
+- **AC-R2**: 새로 추가된 dotenv 관련 단위 테스트가 최소 3 개(AC-A1, AC-O1, AC-F1) 이상 추가되어 통과한다.
+
+### 문서 (AC-D)
+- **AC-D1**: `docs/references/slack-coordinator-bot-setup.md` §3-3 가 새 사용법(자동 로딩, 한 줄 실행)을 반영한다.
+- **AC-D2**: 같은 문서에 "셸 export 가 우선됨" 한 줄이 명시된다(운영 혼동 방지).
+- **AC-D3**: 위 문서 변경분에 트레이딩 도메인 키워드(`signal`, `trade`, `desk`, `order`, `position` 등)가 새로 추가되지 않는다.
+
+### 의존성 (AC-Dep)
+- **AC-Dep1**: `ai/requirements.txt` 에 `python-dotenv >= 1.0` 이 명시되어 있다(버전 핀 형식은 기존 파일의 컨벤션 따름).
+- **AC-Dep2**: `pip install -r ai/requirements.txt` 가 추가 옵션 없이 성공한다.
+
+---
+
+## 6. 가정 · 제약
+
+- **런타임**: Python 3.11+.
+- **라이브러리**: `python-dotenv >= 1.0`. 1.x 메이저 안에서는 `load_dotenv` / `find_dotenv` API가 안정적이라고 가정.
+- **`.env` 형식**: 표준 `KEY=VALUE` 라인. 따옴표·주석 등은 `python-dotenv` 기본 파서 규칙을 그대로 따른다. PR #3 의 `.env.example` 와 호환된다.
+- **탐색 경로**: 프로젝트 루트 1곳. 사용자는 `python -m ai.coordinator.main` 을 **프로젝트 루트에서** 실행한다고 가정한다(다른 경로에서의 실행은 본 PRD 범위 밖이며, `find_dotenv` 의 상위 디렉터리 탐색 동작에 위임).
+- **운영 환경**: 컨테이너/CI 등에서는 셸 환경변수가 항상 우선이라는 정책이 유지된다(`override=False`).
+- **외부 노출 텍스트 제약**: 응답·로그·문서·커밋·PR 본문에서 트레이딩 도메인 키워드를 노출하지 않는다(회사 Slack 가시성 제약, 메모리 노트 `project_slack_bot_naming` 참조).
+- **일정**: 단일 PR로 완료 가능한 소규모 변경(코드 1~2 파일 + 문서 1 파일 + 테스트 1 파일).
+
+---
+
+## 7. 참고
+
+- GitHub Issue #9: `https://github.com/deeptrading-lab/trading-signal-engine/issues/9`
+- 출처: PR #3 가이드 §7 + 사용자 UX 피드백
+- `docs/references/slack-coordinator-bot-setup.md` §3-3 — 갱신 대상 문서
+- `python-dotenv` 공식 문서: `load_dotenv`, `find_dotenv`, `override` 옵션
+- `AGENTS.md` §"PRD (PM 산출물)" — 본 PRD 양식 기준
+- 메모리 노트: `project_slack_bot_naming` (Slack 봇 표시명/외부 텍스트 제약)
+
+---
+
+**UI 포함 여부: 없음**  
+**대상 에이전트: Backend Dev (Python, `ai/coordinator/`) → QA → Code Reviewer → DevOps**
+
+### 보고 (PR/QA 작성 시 필수 기재)
+- 산출물 경로: 변경된 코드 파일·테스트 파일·문서 파일 경로 명시.
+- 핵심 결정사항:
+  1. `load_dotenv()` 호출 위치 — `config.py` 모듈 로드 시점 vs `main.py` 진입점 — 어디로 결정했고 그 이유.
+  2. `.env` 탐색 경로 정책 — `find_dotenv()` 기본 동작 사용 여부, 또는 명시적 경로 계산 사용 여부와 이유.

--- a/docs/qa/coordinator-dotenv-autoload.md
+++ b/docs/qa/coordinator-dotenv-autoload.md
@@ -1,0 +1,200 @@
+# QA Report: coordinator-dotenv-autoload
+
+> 작성자: QA 에이전트
+> 작성일: 2026-05-01
+> PRD: [`docs/prd/coordinator-dotenv-autoload.md`](../prd/coordinator-dotenv-autoload.md)
+> PR: [#13](https://github.com/deeptrading-lab/trading-signal-engine/pull/13)
+> 브랜치: `feature/coordinator-dotenv-autoload`
+> 커밋: `1581a39`
+> 관련 이슈: #9 (라벨: `enhancement`, `priority:P1`)
+
+---
+
+## 1. 판정 요약
+
+- **자동 검증 결과**: PASS — 자동 검증 가능한 모든 항목 통과 (실패 0건).
+- **수동 검증**: 사용자 몫. 본 리포트 §6 체크리스트 참조.
+- **권장 라벨 변경**: `impl-ready` 제거 → `qa-auto-passed` 부여.
+  - 사용자 수동 체크리스트 통과 확인 후 `qa-passed`로 승격 제안(머지 권한자 재량).
+  - 어느 한 항목이라도 실패 시 `qa-failed`로 갱신 + PR 코멘트로 개발자에게 회송.
+
+---
+
+## 2. 변경 파일 요약 (PR diff)
+
+```
+ai/coordinator/main.py                         |  22 +++  (← _autoload_dotenv 추가, run() 첫 실행문에 호출)
+ai/requirements.txt                            |   4 +    (← python-dotenv>=1.0)
+ai/tests/test_coordinator_main_dotenv.py       | 182 +++  (← 신규 단위 테스트 7개)
+docs/prd/coordinator-dotenv-autoload.md        | 147 +++  (← PRD 추적)
+docs/references/slack-coordinator-bot-setup.md |  11 +-   (← §3-3 갱신 + 트러블슈팅 표 갱신 + §7 향후 확장 갱신)
+```
+
+- **`ai/coordinator/config.py`**: 변경 없음 (관심사 분리 유지 — PRD §"핵심 결정사항" 1번 준수).
+
+---
+
+## 3. 자동 검증 결과 (AUTO)
+
+### 3-1. 단위 테스트 — 신규 추가분
+
+```
+$ python -m pytest ai/tests/test_coordinator_main_dotenv.py -v
+============================== 7 passed in 0.17s ==============================
+
+TestDotenvAutoload::test_loads_env_from_cwd                                PASSED
+TestDotenvAutoload::test_loads_env_from_subdirectory                       PASSED
+TestShellOverridesDotenv::test_shell_value_wins_over_dotenv                PASSED
+TestShellOverridesDotenv::test_partial_shell_export_merges_with_dotenv     PASSED
+TestDotenvAbsentFailsFast::test_autoload_is_silent_when_no_dotenv          PASSED
+TestDotenvAbsentFailsFast::test_run_returns_nonzero_when_dotenv_absent_and_shell_empty  PASSED
+TestDotenvAbsentFailsFast::test_load_config_raises_when_environment_empty  PASSED
+```
+
+### 3-2. AC별 PASS/FAIL/MANUAL 판정
+
+| AC ID | 분류 | 판정 | 근거 |
+|---|---|---|---|
+| **AC-A1** | 자동 | **PASS** | `test_loads_env_from_cwd` — `.env` 만 있고 셸 환경변수 없을 때 `_autoload_dotenv()` 후 `os.environ` 적재 + `load_config()` 정상 동작 |
+| **AC-A2** | 자동 | **PASS** | `test_autoload_is_silent_when_no_dotenv` — 빈 디렉토리에서 호출해도 예외 미발생, 환경변수도 새로 만들지 않음 |
+| **AC-O1** | 자동 | **PASS** | `test_shell_value_wins_over_dotenv` — `monkeypatch.setenv` 로 셸 값 주입 후 `.env` 와 다른 값 검증 → 셸 값 유지 |
+| **AC-O2** | 자동 | **PASS** | `test_loads_env_from_cwd`(reaffirm) + `test_partial_shell_export_merges_with_dotenv` (셸 일부만 export 시 나머지는 `.env` 적용) |
+| **AC-F1** | 자동 | **PASS** | `test_run_returns_nonzero_when_dotenv_absent_and_shell_empty` — `run()` 호출 시 `exit_code != 0`, stderr 에 `[코디네이터] 시작 실패` + `SLACK_BOT_TOKEN` 포함 |
+| **AC-F2** | 자동 | **PASS** | 동일 테스트의 `assert "Traceback" not in captured.err` — 트레이싱백 미노출 검증. fail-fast 한 줄 포맷 유지(`config.py` 변경 없음) |
+| **AC-S1** | 자동(회귀) | **PASS** | `config.py` 미변경 + `test_coordinator_config.py::test_masked_repr_does_not_leak_token` 통과(전체 회귀 145 passed). `_mask()`/`with_masked_repr()` 무손상 |
+| **AC-S2** | 자동(회귀) | **PASS** | `_autoload_dotenv()` 는 `find_dotenv()` 결과만 사용하고 stdout/stderr 출력 없음. 라이브러리 기본 동작은 silent |
+| **AC-R1** | 자동 | **PASS** | `python -m pytest ai/tests/ -q` → **145 passed** (기존 138 + 신규 7) |
+| **AC-R2** | 자동 | **PASS** | 신규 dotenv 테스트 **7개** (요구 최소 3개 초과). AC-A1/A2/O1/O2/F1/F2 모두 커버 |
+| **AC-D1** | 자동(diff) | **PASS** | `slack-coordinator-bot-setup.md` §3-3 — 제목 "환경변수 로딩 + 데몬 실행" → "데몬 실행", `set -a && source .env && set +a` 라인 제거, "**자동 로딩**되므로 별도의 `source` 단계가 필요 없습니다" 명시 |
+| **AC-D2** | 자동(diff) | **PASS** | 같은 §3-3 인용 블록 — "**셸 export 우선순위**: 셸에 이미 동일 이름의 환경변수가 export 되어 있으면 그 값이 우선 ... 컨테이너/CI 같은 운영 환경에서도 셸 환경변수 주입이 그대로 동작" 명시 |
+| **AC-D3** | 자동(grep) | **PASS** | `git diff main...pr-13 -- docs/...slack-coordinator-bot-setup.md` 의 추가 라인에서 `signal`/`trade`/`desk`/`order`/`position`/`portfolio` 키워드 grep 결과 0건. PR 전체 변경 파일 통합 grep 도 0건 |
+| **AC-Dep1** | 자동(파일 확인) | **PASS** | `ai/requirements.txt` 14행: `python-dotenv>=1.0` (PRD §3 의존성 §6 가정 준수) |
+| **AC-Dep2** | 자동(설치 확인) | **PASS** | `pip show python-dotenv` → `Version: 1.2.2` (1.x 메이저 안). PR 본문에도 설치 성공 기재 |
+
+### 3-3. 추가 점검 (사용자 지시 사항)
+
+| 점검 항목 | 결과 |
+|---|---|
+| `_autoload_dotenv()` 호출 위치가 `run()` 진입 첫 실행문인지 | **OK** — `main.py:162` `_autoload_dotenv()` 가 `run()` 본문 첫 statement(docstring 직후 첫 실행문). `try: load_config()` 보다 먼저 호출됨 |
+| `load_dotenv(override=False)` 명시되어 있는지 (override=True 금지) | **OK** — `main.py:157` `load_dotenv(dotenv_path, override=False)` |
+| `find_dotenv(usecwd=True)` 사용해 cwd 부터 상위 탐색 | **OK** — `main.py:155` `find_dotenv(usecwd=True)`. `test_loads_env_from_subdirectory` 로 상위 탐색 동작 검증 |
+| `config.py`는 변경 없는지 (관심사 분리 유지) | **OK** — `git diff main...pr-13 --name-only` 에 `ai/coordinator/config.py` 미포함 |
+| 가이드 §3-3 에서 `set -a && source .env && set +a` 제거됐는지 | **OK** — `grep -n "set -a\|source .env" docs/references/slack-coordinator-bot-setup.md` 결과 NO_HITS |
+| 토큰 마스킹 회귀 무결 | **OK** — `test_coordinator_config.py::test_masked_repr_does_not_leak_token` PASS. `_mask()` 무변경 |
+| 트레이딩 도메인 키워드 신규 노출 0건 | **OK** — PR diff 추가 라인 통합 grep 결과 NO_HITS |
+
+---
+
+## 4. 회귀 / 외부 노출 텍스트 / 문서 변경 요약
+
+### 회귀 (AC-R1)
+
+```
+$ python -m pytest ai/tests/ -q
+.......................................................................  [ 49%]
+.......................................................................  [ 99%]
+.                                                                        [100%]
+145 passed in 0.30s
+```
+
+- 기존 138개(또는 작성 시점 그 이상) + 신규 7개 = **145 passed**, 실패 0건.
+
+### Grep — 트레이딩 도메인 키워드 (AC-D3)
+
+```
+$ git diff main...pr-13 -- ai/coordinator/main.py ai/tests/test_coordinator_main_dotenv.py \
+    docs/references/slack-coordinator-bot-setup.md docs/prd/coordinator-dotenv-autoload.md \
+    | grep "^+" | grep -v "^+++" | grep -iE "\b(signal|trade|desk|order|position|portfolio)\b"
+NO_TRADING_KEYWORDS_ADDED
+```
+
+- 메모리 노트 `project_slack_bot_naming` 제약 — 회사 Slack 외부 가시성 텍스트에 트레이딩 도메인 키워드 노출 금지 — 위반 0건.
+
+### 가이드 문서 변경 요약 (`docs/references/slack-coordinator-bot-setup.md`)
+
+- §3-3 제목: "환경변수 로딩 + 데몬 실행" → "**데몬 실행**".
+- `set -a && source .env && set +a` 라인 **제거**.
+- "프로젝트 루트의 `.env` 는 데몬 시작 시 **자동 로딩**" 안내 추가.
+- "셸 export 우선순위" 인용 블록 추가 — 임시 토큰 한 줄 실행 예시(`SLACK_BOT_TOKEN=... python -m ai.coordinator.main`) + 컨테이너/CI 환경 안전성.
+- 트러블슈팅 표의 `SLACK_BOT_TOKEN 미설정` 행 — 원인을 "새 셸/창에서 `.env` 미로딩"에서 "프로젝트 루트가 아닌 곳에서 실행했거나 `.env` 가 없음"으로 갱신, 해결책도 자동 로딩 전제로 갱신.
+- §7 향후 확장 표의 `python-dotenv 자동 로딩` 항목을 "구현됨 + PRD 링크"로 변경.
+
+---
+
+## 5. 에지 케이스 점검
+
+| 시나리오 | 자동 테스트 / 수동 검증 | 판정 |
+|---|---|---|
+| 사용자가 프로젝트 루트가 아닌 하위 디렉토리에서 실행 | `test_loads_env_from_subdirectory` (자동) | **PASS** — `find_dotenv(usecwd=True)` 가 상위 디렉토리 탐색 |
+| `.env` 가 아예 없는 디렉토리 | `test_autoload_is_silent_when_no_dotenv` (자동) | **PASS** — 예외 미발생, 다음 단계 fail-fast 위임 |
+| 셸 export 와 `.env` 가 동시에 존재 | `test_shell_value_wins_over_dotenv` (자동) | **PASS** — 셸 값 우선(override=False) |
+| 셸에 일부만 export, 나머지는 `.env` | `test_partial_shell_export_merges_with_dotenv` (자동) | **PASS** — 셸 export + `.env` 머지 동작 |
+| 모든 환경변수 부재 | `test_run_returns_nonzero_when_dotenv_absent_and_shell_empty` (자동) | **PASS** — `run()` non-zero exit + 한 줄 메시지 + 트레이싱백 미노출 |
+| 운영 환경(systemd / 컨테이너) 셸 환경변수 주입 | (수동) — PRD §6 가정 + AC-O1 자동 검증으로 안전 보장. 컨테이너 실배포는 본 PRD 비범위 | **MANUAL** — §6-3 |
+| `.env` 에 다중 라인 / 변수 보간 등 비표준 포맷 | PRD §4 비범위 — `python-dotenv` 기본 파서 그대로 위임 | **OUT_OF_SCOPE** |
+| Slack API 레이트리밋 / 서버 다운 / 네트워크 지연 | dotenv 자동 로딩과 무관. 본 PR 변경 영역 외(handler 영역) | **OUT_OF_SCOPE** (별 PRD: `slack-coordinator-inbound`) |
+
+---
+
+## 6. 사용자 수동 체크리스트 (MANUAL)
+
+자동 검증으로 커버되지 않는, 실제 셸·환경에서 사용자가 직접 확인해야 하는 항목입니다. 모두 PASS 시 라벨을 `qa-passed`로 승격.
+
+### 6-1. 단일 명령 기동 (AC-A1 실환경 재확인)
+
+- [ ] 새 터미널 창을 연다 (셸에 `SLACK_BOT_TOKEN`/`SLACK_APP_TOKEN` 이 export 되어 있지 않음을 보장).
+- [ ] 프로젝트 루트(`/Applications/하영/code_source/trading-signal-engine`)에 유효한 `.env` 가 존재함을 확인 (`ls .env`).
+- [ ] **`source .env` 또는 `set -a && source .env && set +a` 를 실행하지 않은 채로** 다음을 실행:
+  ```
+  python -m ai.coordinator.main
+  ```
+- [ ] **기대**: `[INFO] ai.coordinator: 코디네이터를 시작합니다. CoordinatorConfig(bot_token=xoxb-***, app_token=xapp-***, ...)` 로그가 뜨고, Socket Mode 연결이 시도된다(에러 없이 기동).
+- [ ] **확인**: 평문 토큰이 stdout/stderr 어디에도 출력되지 않는다(prefix + `***` 만 노출).
+
+### 6-2. 셸 우선순위 (AC-O1 실환경 재확인)
+
+- [ ] 같은 셸에서 임시 토큰을 export:
+  ```
+  export SLACK_BOT_TOKEN=xoxb-IMPORTED-FROM-SHELL
+  ```
+- [ ] `python -m ai.coordinator.main` 실행 시, `with_masked_repr()` 로그의 `bot_token` 마스킹은 동일하게 `xoxb-***` 로만 보이지만, 내부적으로 셸 값이 `.env` 보다 우선되는지 검증하려면 일시적으로 잘못된 prefix(예: `xoxb-INVALID`)를 export 해 동일 명령을 실행:
+  ```
+  export SLACK_BOT_TOKEN=invalid-prefix
+  python -m ai.coordinator.main
+  ```
+- [ ] **기대**: `[코디네이터] 시작 실패: 환경변수 SLACK_BOT_TOKEN 의 prefix 가 올바르지 않습니다 (기대: 'xoxb-').` (셸 값이 우선되어 prefix 검증에 걸린다 ⇒ override=False 확인).
+- [ ] **정리**: `unset SLACK_BOT_TOKEN`.
+
+### 6-3. 가이드 문서 따라하기 (신규 합류자 시뮬레이션)
+
+- [ ] 가이드 [`docs/references/slack-coordinator-bot-setup.md`](../references/slack-coordinator-bot-setup.md) §3-3 만 보고 신규 합류자 입장에서 데몬을 띄울 수 있는지 따라가 본다.
+- [ ] **기대**: §3-3 의 단일 명령(`python -m ai.coordinator.main`)만으로 데몬이 시작되며, `set -a`/`source .env` 같은 사전 단계가 더는 필요 없다.
+- [ ] **기대**: §3-3 인용 블록에 "셸 export 우선" 안내가 보이고, 운영 환경 혼동 우려 없음.
+
+### 6-4. fail-fast 실환경 재확인 (AC-F1/F2)
+
+- [ ] 임시로 `.env` 를 다른 이름으로 옮긴다 (`mv .env .env.bak`).
+- [ ] 셸에도 `SLACK_BOT_TOKEN`/`SLACK_APP_TOKEN` 이 없는 상태에서 실행:
+  ```
+  unset SLACK_BOT_TOKEN SLACK_APP_TOKEN
+  python -m ai.coordinator.main
+  echo "exit code: $?"
+  ```
+- [ ] **기대**: 한 줄 에러 `[코디네이터] 시작 실패: 환경변수 SLACK_BOT_TOKEN 이 설정되지 않았습니다.` + `exit code: 2`.
+- [ ] **기대**: 트레이싱백(`Traceback (most recent call last):` 등)이 출력되지 않는다.
+- [ ] **정리**: `mv .env.bak .env`.
+
+---
+
+## 7. 실패 항목
+
+- **없음.** 자동 검증 가능한 모든 AC 가 PASS.
+
+---
+
+## 8. 최종 산출물 / 라벨 권고
+
+- **산출물 경로**: `/Applications/하영/code_source/trading-signal-engine/docs/qa/coordinator-dotenv-autoload.md`
+- **자동 판정**: `qa-auto-passed` (실패 0건). 사용자 수동 체크리스트 §6 통과 시 `qa-passed`로 승격 권고.
+- **권장 라벨 변경**: `impl-ready` 제거 → `qa-auto-passed` 추가.
+- **PR 코멘트**: 본 리포트 §6 수동 체크리스트 링크 + "자동 PASS, 수동 검증 후 머지 권한자 재량으로 `qa-passed` 승격 요청".

--- a/docs/references/slack-coordinator-bot-setup.md
+++ b/docs/references/slack-coordinator-bot-setup.md
@@ -134,12 +134,15 @@ LOG_LEVEL=INFO
 >
 > **본인 user id 확인**: Slack 프로필 → 더보기(⋯) → **Copy member ID**. 또는 Claude Code 세션에서 `mcp__slack__users_search`로 조회.
 
-### 3-3. 환경변수 로딩 + 데몬 실행
+### 3-3. 데몬 실행
+
+프로젝트 루트의 `.env` 는 데몬 시작 시 **자동 로딩**되므로 별도의 `source` 단계가 필요 없습니다.
 
 ```bash
-set -a && source .env && set +a
 python -m ai.coordinator.main
 ```
+
+> **셸 export 우선순위**: 셸에 이미 동일 이름의 환경변수가 export 되어 있으면 그 값이 우선이고, `.env` 값은 덮어쓰지 않습니다(`load_dotenv(override=False)`). 임시로 다른 토큰을 쓰고 싶으면 `SLACK_BOT_TOKEN=xoxb-... python -m ai.coordinator.main` 처럼 한 줄에 묶어 실행하면 됩니다. 컨테이너/CI 같은 운영 환경에서도 셸 환경변수 주입이 그대로 동작합니다.
 
 연결 성공 시 다음과 같은 로그가 뜹니다:
 
@@ -183,7 +186,7 @@ Slack에서 `Hayoung AI Coordinator` DM 채널 열고 입력:
 |---|---|---|
 | 봇 DM 입력창에 "이 앱으로 메시지를 보내는 기능이 꺼져 있습니다" | App Home → Messages Tab 토글 OFF | §2-2 토글 ON + 답장 허용 체크 |
 | 봇 메시지가 알림으로만 뜨고 사이드바에 DM 채널 안 보임 | 사용자가 봇 DM을 한 번도 안 연 상태 | Slack에서 봇 검색 → 프로필 → **Message** 한 번 보내면 정상 채널로 표시 |
-| `[코디네이터] 시작 실패: 환경변수 SLACK_BOT_TOKEN 이 설정되지 않았습니다.` | 새 셸/창에서 `.env` 미로딩 | `set -a && source .env && set +a` 다시 실행 |
+| `[코디네이터] 시작 실패: 환경변수 SLACK_BOT_TOKEN 이 설정되지 않았습니다.` | 프로젝트 루트가 아닌 곳에서 실행했거나 `.env` 가 없음 | 프로젝트 루트(또는 그 하위)에서 실행 + `.env` 파일 존재 확인. `.env` 는 자동 로딩됨 |
 | `pip: command not found` | venv에 pip 스크립트 누락 | `python -m pip ...` 형태로 호출, 또는 `python -m ensurepip --upgrade` |
 | `not_authed` / `invalid_auth` | 토큰 오타·만료·Reinstall 후 토큰 갱신 미반영 | OAuth & Permissions 페이지에서 최신 `xoxb` 다시 복사 |
 | `missing_scope` | Bot Token Scopes 부족 | §2-3 표 확인 후 추가 → **Reinstall to Workspace** |
@@ -222,7 +225,7 @@ ai/coordinator/
 - 명령 → ai/ 파이프라인 또는 backend/ 모듈 호출 연동
 - 슬래시 커맨드, Block Kit 인터랙티브 컴포넌트
 - 클라우드 배포 (Cloud Run / Lambda 등 — Socket Mode 대신 HTTP webhook으로 전환)
-- `python-dotenv` 자동 로딩 (매번 `source .env` 불필요하게)
+- `.env` 자동 로딩 — 구현됨 (PRD: [`coordinator-dotenv-autoload`](../prd/coordinator-dotenv-autoload.md))
 - 메시지 subtype 가드 — 구현됨 (PRD: [`slack-message-subtype-guard`](../prd/slack-message-subtype-guard.md))
 
 ---


### PR DESCRIPTION
## 요약
- 사용자가 매일 `set -a && source .env && set +a` 를 외울 필요 없이 `python -m ai.coordinator.main` **단일 명령**만으로 데몬 시작.
- `run()` 첫 줄에 `_autoload_dotenv()` 추가 — `find_dotenv(usecwd=True)` 로 cwd 및 상위 디렉토리에서 `.env` 탐색.
- `load_dotenv(override=False)` 명시 → **셸 export 가 항상 우선**(컨테이너/CI 워크플로 안전).
- `.env` 부재 시 조용히 무시 → 다음 단계의 기존 `ConfigError` fail-fast 그대로 작동.

## 핵심 결정사항
- **호출 위치**: `ai/coordinator/main.py::run()` 진입 첫 줄.
  - 이유: `config.py` 는 순수 환경변수 검증 책임만 유지(단위 테스트가 dotenv 의존성 없이 동작). 진입점 책임으로 분리하는 게 의존성 그래프와 테스트 격리 측면에서 깔끔.
- **`.env` 탐색 경로**: `find_dotenv(usecwd=True)` 기본 탐색.
  - 이유: 사용자가 프로젝트 루트(또는 그 하위)에서 실행한다고 가정. 명시적 경로 계산은 본 PRD §4 비범위.

## 변경 파일
- `ai/coordinator/main.py` — `_autoload_dotenv()` 추가, `run()` 진입 첫 줄에서 호출.
- `ai/requirements.txt` — `python-dotenv>=1.0` 등록.
- `ai/tests/test_coordinator_main_dotenv.py` — 신규 단위 테스트 7개.
- `docs/references/slack-coordinator-bot-setup.md` — §3-3 자동 로딩 안내, §7 향후 확장 항목 갱신, 트러블슈팅 표 갱신.
- `docs/prd/coordinator-dotenv-autoload.md` — PRD 추적 추가.

## 수용 기준 체크리스트 (PRD §5)
- [x] **AC-A1**: `.env` 만 있고 셸 환경변수가 없을 때 `python -m ai.coordinator.main` 단일 명령으로 토큰 적재 → `test_loads_env_from_cwd`, `test_loads_env_from_subdirectory`.
- [x] **AC-A2**: `.env` 부재 시 라이브러리 호출 자체가 예외를 던지지 않음 → `test_autoload_is_silent_when_no_dotenv`.
- [x] **AC-O1**: 셸 export 가 `.env` 보다 우선 → `test_shell_value_wins_over_dotenv`.
- [x] **AC-O2**: 셸 export 부재 시 `.env` 값 적용 → `test_loads_env_from_cwd`.
- [x] **AC-F1**: `.env` 부재 + 셸 부재 → 기존 `ConfigError` + non-zero exit → `test_run_returns_nonzero_when_dotenv_absent_and_shell_empty`, `test_load_config_raises_when_environment_empty`.
- [x] **AC-F2**: 한 줄 메시지, 트레이싱백 미노출 → 위 테스트에서 `Traceback not in stderr` 단언.
- [x] **AC-S1/S2**: 토큰 평문이 로그·에러에 노출되지 않음(기존 마스킹 동작 유지, `config.py` 미변경).
- [x] **AC-R1**: 기존 138개 + 신규 7개 = 145개 전부 통과.
- [x] **AC-R2**: 신규 dotenv 테스트 7개(AC-A/O/F 모두 커버).
- [x] **AC-D1/D2/D3**: 가이드 §3-3 갱신, 셸 우선순위 명시, 트레이딩 도메인 키워드 신규 추가 없음.
- [x] **AC-Dep1/2**: `python-dotenv>=1.0` 등록, `pip install -r ai/requirements.txt` 성공 확인(`python-dotenv-1.2.2` 설치).

## 테스트 결과
```
$ python -m pytest ai/tests/ -q
145 passed in 0.20s
```

## 가이드 문서 변경 요약
- §3-3 제목 "환경변수 로딩 + 데몬 실행" → "데몬 실행".
- `set -a && source .env && set +a` 줄 제거.
- "프로젝트 루트의 `.env` 는 데몬 시작 시 **자동 로딩**" 안내 추가.
- 셸 export 우선순위 인용 블록 추가(임시 토큰 한 줄 실행, 컨테이너/CI 안전성).
- 트러블슈팅 표의 SLACK_BOT_TOKEN 미설정 행을 자동 로딩 전제로 갱신.
- §7 향후 확장 표에서 dotenv 항목을 "구현됨 + PRD 링크"로 변경.

Closes #9