### PR TITLE
docs: feature 브랜치 산출물 commit 규칙 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,7 @@ gh label create prd-requested prd-ready design-ready impl-wip impl-ready \
 - **브랜치는 슬러그 하나당 하나**: `feature/<slug>`. 두 역할(예: FE + BE)이 같은 slug면 같은 브랜치에서 작업하거나 `feature/<slug>-fe`, `feature/<slug>-be`로 분리.
 - **PRD 수정은 PM만**. 구현 중 모호함이 나오면 QA/개발자는 PR·Issue 코멘트로 질문 → PM이 PRD를 갱신 → 라벨 되돌림.
 - **리뷰어 독립성**: PR 작성자와 다른 사람(또는 별도 cmux 패널/워크트리의 Reviewer 에이전트)이 리뷰. 본인 PR 자가-승인 금지.
+- **slug 산출물은 feature 브랜치에**: `docs/prd/<slug>.md`, `docs/qa/<slug>.md`, `docs/design/<slug>.md` 등 특정 slug에 귀속되는 산출물은 그 slug의 `feature/<slug>` 브랜치에 commit한다. main에 직접 commit·push 금지. 메인 Claude가 sub-agent 산출물(QA 리포트 등)을 push할 때는 `git branch --show-current` 로 현재 브랜치를 먼저 확인하고, 잘못 main에 들어간 commit이 있으면 즉시 cherry-pick → reset 으로 정정한다.
 
 ---
 


### PR DESCRIPTION
## Summary
- AGENTS.md \"두 사람 작업 규칙\"에 한 줄 추가: slug 귀속 산출물(`docs/prd/`/`docs/qa/`/`docs/design/`)은 항상 `feature/<slug>` 브랜치에 commit, main 직접 push 금지
- 메인 Claude 가 sub-agent 산출물을 push 할 때 현재 브랜치를 먼저 점검하도록 명시

## 배경
이번 세션에서 두 번 같은 실수가 발생:
1. `feature/coordinator-dotenv-autoload` QA 리포트가 main 에 commit
2. `feature/coordinator-compliance-cleanup` QA 리포트가 main 에 commit

두 번 모두 cherry-pick → reset 으로 수습했으나, 명시적 룰이 없어서 재발 위험. 룰 한 줄로 못 박는다.

## Test plan
- [x] 본 PR 자체가 룰을 따라 chore/<slug> 브랜치에서 작업되어 있음
- [ ] 다음 sub-agent 산출물 commit 시 메인 Claude 가 현재 브랜치를 점검하는지 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)