### PR TITLE
코디네이터 코드 정리: dispatcher 추출 + placeholder 가드 + 미사용 import

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ SLACK_BOT_TOKEN=xoxb-여기에붙여넣기
 SLACK_APP_TOKEN=xapp-여기에붙여넣기
 
 # 응답 허용 사용자 ID (콤마로 구분, 화이트리스트)
-# 본인 user id 확인: 좀전 users_search로 받은 U0AE7A54NHL
+# 본인 user id 확인 방법은 docs/references/slack-coordinator-bot-setup.md §3-2 참조
 SLACK_ALLOWED_USER_IDS=U0AE7A54NHL
 
 # (선택) 로그 레벨 — DEBUG / INFO / WARNING / ERROR

--- a/ai/coordinator/config.py
+++ b/ai/coordinator/config.py
@@ -17,6 +17,16 @@ DEFAULT_ALLOWED_USER_IDS: tuple[str, ...] = ("U0AE7A54NHL",)
 _BOT_TOKEN_PREFIX = "xoxb-"
 _APP_TOKEN_PREFIX = "xapp-"
 
+# `.env.example` 의 placeholder 표현이 그대로 흘러들어오면 prefix 검사를 통과해버려
+# fail-fast 가 무력화된다. SSoT 는 본 frozenset 한 곳으로 두고, `.env.example` 표현이
+# 바뀌더라도 코드 가드가 우선해 차단한다.
+_PLACEHOLDER_TOKENS: frozenset[str] = frozenset(
+    {
+        "xoxb-여기에붙여넣기",
+        "xapp-여기에붙여넣기",
+    }
+)
+
 
 class ConfigError(ValueError):
     """환경변수 누락·형식 오류. 메시지에 토큰 값을 포함하지 않는다."""
@@ -87,6 +97,11 @@ def load_config(env: dict[str, str] | None = None) -> CoordinatorConfig:
             "환경변수 SLACK_BOT_TOKEN 의 prefix 가 올바르지 않습니다 "
             f"(기대: '{_BOT_TOKEN_PREFIX}')."
         )
+    if bot_token in _PLACEHOLDER_TOKENS:
+        raise ConfigError(
+            "환경변수 SLACK_BOT_TOKEN 가 placeholder 값입니다. "
+            ".env 를 실제 토큰으로 채우세요."
+        )
 
     if not app_token:
         raise ConfigError(
@@ -96,6 +111,11 @@ def load_config(env: dict[str, str] | None = None) -> CoordinatorConfig:
         raise ConfigError(
             "환경변수 SLACK_APP_TOKEN 의 prefix 가 올바르지 않습니다 "
             f"(기대: '{_APP_TOKEN_PREFIX}')."
+        )
+    if app_token in _PLACEHOLDER_TOKENS:
+        raise ConfigError(
+            "환경변수 SLACK_APP_TOKEN 가 placeholder 값입니다. "
+            ".env 를 실제 토큰으로 채우세요."
         )
 
     return CoordinatorConfig(

--- a/ai/coordinator/handlers.py
+++ b/ai/coordinator/handlers.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import platform
 import socket
-import sys
 import time
 from datetime import datetime, timezone, timedelta
 from typing import Callable

--- a/ai/coordinator/main.py
+++ b/ai/coordinator/main.py
@@ -89,6 +89,59 @@ def _resolve_self_user_id(app: Any, logger: logging.Logger) -> str | None:
         return None
 
 
+def _dispatch_message(
+    event: dict,
+    *,
+    say: Any,
+    logger: logging.Logger,
+    config: CoordinatorConfig,
+    self_user_id: str | None,
+    safe_say_fn: Any = None,
+) -> None:
+    """`message.im` 이벤트 라우팅 본체.
+
+    `handle_message_im` 클로저에서 추출한 모듈 함수. 통합 테스트가 mock `say`
+    하나로 시나리오(정상/자기/비-IM/비처리 subtype/비허용)를 검증할 수 있도록
+    독립 호출 가능하게 분리했다. `safe_say_fn` 은 테스트에서 응답 발사 가드를
+    가로채기 위한 옵션이며, 기본값은 모듈의 `safe_say`.
+    """
+    safe_say_callable = safe_say_fn if safe_say_fn is not None else safe_say
+
+    # AC-9: 봇 자기 메시지는 즉시 반환.
+    if is_self_message(event, self_user_id):
+        return
+
+    # MVP 는 DM(IM)만 처리. 그 외 채널 타입은 무시.
+    if event.get("channel_type") != "im":
+        return
+
+    # PRD slack-message-subtype-guard: 편집·삭제·시스템 메시지 등은 조용히 무시.
+    if not is_handleable_message_subtype(event):
+        logger.info(
+            "처리 대상이 아닌 메시지 이벤트를 무시했습니다 "
+            "(subtype=%s, sender=%s, type=%s)",
+            event.get("subtype"),
+            mask_user_id(extract_sender(event)),
+            event.get("type"),
+        )
+        return
+
+    sender = extract_sender(event)
+
+    # AC-5: 화이트리스트 외 발신자는 무시 + INFO 로그.
+    if not is_allowed_sender(sender, config.allowed_user_ids):
+        logger.info(
+            "허용되지 않은 발신자 메시지를 무시했습니다 (sender=%s, type=%s)",
+            mask_user_id(sender),
+            event.get("type"),
+        )
+        return
+
+    text = event.get("text") or ""
+    reply = route_command(text)
+    safe_say_callable(say, reply, logger, context="route_command")
+
+
 def build_app(config: CoordinatorConfig, logger: logging.Logger) -> Any:
     """
     slack-bolt App 을 구성한다. 의존성 분리를 위해 별도 함수로 분리해 두면
@@ -104,39 +157,13 @@ def build_app(config: CoordinatorConfig, logger: logging.Logger) -> Any:
 
     @app.event("message")
     def handle_message_im(event: dict, say: Any, logger: logging.Logger = logger) -> None:
-        # AC-9: 봇 자기 메시지는 즉시 반환.
-        if is_self_message(event, self_user_id):
-            return
-
-        # MVP 는 DM(IM)만 처리. 그 외 채널 타입은 무시.
-        if event.get("channel_type") != "im":
-            return
-
-        # PRD slack-message-subtype-guard: 편집·삭제·시스템 메시지 등은 조용히 무시.
-        if not is_handleable_message_subtype(event):
-            logger.info(
-                "처리 대상이 아닌 메시지 이벤트를 무시했습니다 "
-                "(subtype=%s, sender=%s, type=%s)",
-                event.get("subtype"),
-                mask_user_id(extract_sender(event)),
-                event.get("type"),
-            )
-            return
-
-        sender = extract_sender(event)
-
-        # AC-5: 화이트리스트 외 발신자는 무시 + INFO 로그.
-        if not is_allowed_sender(sender, config.allowed_user_ids):
-            logger.info(
-                "허용되지 않은 발신자 메시지를 무시했습니다 (sender=%s, type=%s)",
-                mask_user_id(sender),
-                event.get("type"),
-            )
-            return
-
-        text = event.get("text") or ""
-        reply = route_command(text)
-        safe_say(say, reply, logger, context="route_command")
+        _dispatch_message(
+            event,
+            say=say,
+            logger=logger,
+            config=config,
+            self_user_id=self_user_id,
+        )
 
     # `app_mention` 이벤트가 들어와도 무시(스코프 회수 전 안전장치).
     @app.event("app_mention")

--- a/ai/tests/test_coordinator_config.py
+++ b/ai/tests/test_coordinator_config.py
@@ -118,3 +118,44 @@ class TestLoadConfig:
     def test_default_user_id_includes_pm(self):
         """PRD §3.1: 기본 화이트리스트는 PM user id 포함."""
         assert "U0AE7A54NHL" in DEFAULT_ALLOWED_USER_IDS
+
+
+class TestPlaceholderGuard:
+    """`.env.example` placeholder 값이 흘러들어왔을 때 fail-fast 회귀 차단."""
+
+    def test_bot_token_placeholder_raises(self):
+        with pytest.raises(ConfigError) as exc_info:
+            load_config(
+                {
+                    "SLACK_BOT_TOKEN": "xoxb-여기에붙여넣기",
+                    "SLACK_APP_TOKEN": VALID_APP,
+                }
+            )
+        message = str(exc_info.value)
+        assert "SLACK_BOT_TOKEN" in message
+        assert "placeholder" in message
+        assert ".env" in message
+
+    def test_app_token_placeholder_raises(self):
+        with pytest.raises(ConfigError) as exc_info:
+            load_config(
+                {
+                    "SLACK_BOT_TOKEN": VALID_BOT,
+                    "SLACK_APP_TOKEN": "xapp-여기에붙여넣기",
+                }
+            )
+        message = str(exc_info.value)
+        assert "SLACK_APP_TOKEN" in message
+        assert "placeholder" in message
+        assert ".env" in message
+
+    def test_real_tokens_pass_placeholder_guard(self):
+        """placeholder 가 아닌 정상 토큰은 가드를 통과한다."""
+        cfg = load_config(
+            {
+                "SLACK_BOT_TOKEN": VALID_BOT,
+                "SLACK_APP_TOKEN": VALID_APP,
+            }
+        )
+        assert cfg.bot_token == VALID_BOT
+        assert cfg.app_token == VALID_APP

--- a/ai/tests/test_coordinator_dispatch.py
+++ b/ai/tests/test_coordinator_dispatch.py
@@ -1,0 +1,217 @@
+"""코디네이터 dispatcher 통합 테스트.
+
+PRD: docs/prd/coordinator-code-chore.md (#6)
+
+`ai.coordinator.main._dispatch_message` 가 `handle_message_im` 클로저에서
+모듈 함수로 추출됨에 따라, mock `say` 기반으로 라우팅 분기 5종을 직접 검증한다.
+
+시나리오
+- 정상: IM + ping → safe_say 경유 pong 응답
+- 봇 자기 메시지: bot_id 채워짐 → 무응답
+- 비-IM 채널: channel_type=channel → 무응답
+- 비처리 subtype: subtype=message_changed → 무응답 + INFO 로그
+- 비허용 발신자: allowed_user_ids 외 user → 무응답 + INFO 로그
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from ai.coordinator.config import CoordinatorConfig
+from ai.coordinator.main import _dispatch_message
+
+
+# ---------------------------------------------------------------------------
+# fixture
+# ---------------------------------------------------------------------------
+
+
+SELF_USER_ID = "UBOTSELF"
+ALLOWED_USER_ID = "U0AE7A54NHL"
+
+
+@pytest.fixture
+def config() -> CoordinatorConfig:
+    return CoordinatorConfig(
+        bot_token="xoxb-test",
+        app_token="xapp-test",
+        allowed_user_ids=frozenset({ALLOWED_USER_ID}),
+        log_level="INFO",
+    )
+
+
+@pytest.fixture
+def say() -> MagicMock:
+    return MagicMock(name="say")
+
+
+@pytest.fixture
+def safe_say_fn() -> MagicMock:
+    return MagicMock(name="safe_say_fn")
+
+
+@pytest.fixture
+def logger() -> MagicMock:
+    return MagicMock(spec=logging.Logger)
+
+
+# ---------------------------------------------------------------------------
+# 1) 정상 ping → safe_say 호출 + pong 응답
+# ---------------------------------------------------------------------------
+
+
+class TestNormalPing:
+    def test_im_ping_invokes_safe_say_with_pong(
+        self, say, safe_say_fn, logger, config
+    ):
+        event = {
+            "type": "message",
+            "channel_type": "im",
+            "user": ALLOWED_USER_ID,
+            "text": "ping",
+        }
+
+        _dispatch_message(
+            event,
+            say=say,
+            logger=logger,
+            config=config,
+            self_user_id=SELF_USER_ID,
+            safe_say_fn=safe_say_fn,
+        )
+
+        assert safe_say_fn.call_count == 1
+        args, kwargs = safe_say_fn.call_args
+        # 시그니처: safe_say(say, text, logger, *, context=...)
+        assert args[0] is say
+        assert args[1] == "pong"
+        assert args[2] is logger
+        assert kwargs.get("context") == "route_command"
+        say.assert_not_called()  # 가드 wrapper 만 거치고 직접 say 는 호출되지 않는다.
+
+
+# ---------------------------------------------------------------------------
+# 2) 자기 메시지 → 응답 없음
+# ---------------------------------------------------------------------------
+
+
+class TestSelfMessageIgnored:
+    def test_bot_id_present_skips_dispatch(
+        self, say, safe_say_fn, logger, config
+    ):
+        event = {
+            "type": "message",
+            "channel_type": "im",
+            "user": SELF_USER_ID,
+            "bot_id": "B12345",  # 봇 자기 메시지 표지.
+            "text": "ping",
+        }
+
+        _dispatch_message(
+            event,
+            say=say,
+            logger=logger,
+            config=config,
+            self_user_id=SELF_USER_ID,
+            safe_say_fn=safe_say_fn,
+        )
+
+        safe_say_fn.assert_not_called()
+        say.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 3) 비-IM 채널 → 응답 없음
+# ---------------------------------------------------------------------------
+
+
+class TestNonImChannelIgnored:
+    def test_channel_type_channel_skips_dispatch(
+        self, say, safe_say_fn, logger, config
+    ):
+        event = {
+            "type": "message",
+            "channel_type": "channel",
+            "user": ALLOWED_USER_ID,
+            "text": "ping",
+        }
+
+        _dispatch_message(
+            event,
+            say=say,
+            logger=logger,
+            config=config,
+            self_user_id=SELF_USER_ID,
+            safe_say_fn=safe_say_fn,
+        )
+
+        safe_say_fn.assert_not_called()
+        say.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 4) 비처리 subtype → 응답 없음 + INFO 로그
+# ---------------------------------------------------------------------------
+
+
+class TestUnhandleableSubtypeIgnored:
+    def test_message_changed_skips_dispatch_and_logs_info(
+        self, say, safe_say_fn, logger, config
+    ):
+        event = {
+            "type": "message",
+            "channel_type": "im",
+            "subtype": "message_changed",
+            "message": {"user": ALLOWED_USER_ID, "text": "ping"},
+        }
+
+        _dispatch_message(
+            event,
+            say=say,
+            logger=logger,
+            config=config,
+            self_user_id=SELF_USER_ID,
+            safe_say_fn=safe_say_fn,
+        )
+
+        safe_say_fn.assert_not_called()
+        say.assert_not_called()
+        # INFO 로그 1회.
+        assert logger.info.called
+        first_format = logger.info.call_args_list[0].args[0]
+        assert "처리 대상이 아닌" in first_format
+
+
+# ---------------------------------------------------------------------------
+# 5) 비허용 발신자 → 응답 없음 + INFO 로그
+# ---------------------------------------------------------------------------
+
+
+class TestDisallowedSenderIgnored:
+    def test_unknown_user_skips_dispatch_and_logs_info(
+        self, say, safe_say_fn, logger, config
+    ):
+        event = {
+            "type": "message",
+            "channel_type": "im",
+            "user": "UUNKNOWN1",  # 화이트리스트 외.
+            "text": "ping",
+        }
+
+        _dispatch_message(
+            event,
+            say=say,
+            logger=logger,
+            config=config,
+            self_user_id=SELF_USER_ID,
+            safe_say_fn=safe_say_fn,
+        )
+
+        safe_say_fn.assert_not_called()
+        say.assert_not_called()
+        assert logger.info.called
+        first_format = logger.info.call_args_list[0].args[0]
+        assert "허용되지 않은 발신자" in first_format

--- a/ai/tests/test_coordinator_handlers.py
+++ b/ai/tests/test_coordinator_handlers.py
@@ -7,7 +7,7 @@ PRD: docs/prd/coordinator-compliance-module.md
 from __future__ import annotations
 
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from ai.coordinator._compliance import assert_no_forbidden
 from ai.coordinator.handlers import (

--- a/docs/prd/coordinator-code-chore.md
+++ b/docs/prd/coordinator-code-chore.md
@@ -1,0 +1,70 @@
+# PRD — Coordinator Code Chore (#6 + #10 + #7 묶음)
+
+> 본 PRD 본문에서 도메인 키워드 평문 노출은 회피하며, 정의 SSoT는 `ai/coordinator/_compliance.FORBIDDEN_KEYWORDS`다.
+
+- **Issues**: [#6](https://github.com/deeptrading-lab/trading-signal-engine/issues/6), [#10](https://github.com/deeptrading-lab/trading-signal-engine/issues/10), [#7](https://github.com/deeptrading-lab/trading-signal-engine/issues/7)
+- **Labels**: `tech-debt`, `chore`, `priority:P2`
+- **출처**: PR #3 리뷰 발견 2·3 + 재리뷰 권고 1·2
+- **UI 포함 여부**: no
+
+---
+
+## 1. 배경 / 문제
+
+코디네이터 영역에 P2 코드 정리 3건이 누적되어 있다. (a) `handle_message_im` 클로저가 통합 테스트 불가 구조, (b) `.env.example` placeholder가 prefix 검사를 통과해 fail-fast가 무력화, (c) 미사용 import가 잔존. 단건 PR로 쪼개기엔 변경량이 작아 한 PR로 묶어 처리한다.
+
+## 2. 목표
+
+세 P2 코드 정리를 한 PR로 묶어 코디네이터 코드 영역 기술부채를 정리하고, dispatcher 통합 테스트 및 placeholder 가드 회귀 테스트로 같은 종류의 잔존 위험을 차단한다.
+
+## 3. 범위 (In scope)
+
+1. **dispatcher 추출 (#6)** — `ai/coordinator/main.py`의 `handle_message_im` 클로저 로직을 `_dispatch_message(event, *, say, logger, config, self_user_id)` 모듈 함수로 추출하고, `handle_message_im`은 얇은 wrapper로 유지. 신규 통합 테스트 파일 `ai/tests/test_coordinator_dispatch.py`에 mock `say` 기반 시나리오 5개 이상(정상/자기 메시지/비-IM/비처리 subtype/비허용 발신자) 추가.
+2. **placeholder 가드 (#10)** — `ai/coordinator/config.py`에 명시적 placeholder 토큰 가드(방식 B) 추가: `_PLACEHOLDER_TOKENS = frozenset({"xoxb-여기에붙여넣기", "xapp-여기에붙여넣기"})` 매칭 시 `ConfigError`. `.env.example:18` 코멘트는 작업 노트 표현을 가이드 참조(`docs/references/slack-coordinator-bot-setup.md` §3-2) 형태로 정리.
+3. **미사용 import 정리 (#7)** — `ai/coordinator/handlers.py:13`의 `import sys` 제거, `ai/tests/test_coordinator_handlers.py:6`의 `timedelta`만 제거(나머지 datetime 임포트 유지).
+
+## 4. 비범위 (Out of scope)
+
+- 새 응답 명령·기능 추가.
+- 가이드 문서 본문 갱신(별도 정리 PR-2에서).
+- placeholder 가드 방식 A(.env.example 형식만 변경) — B로 결정.
+
+## 5. 수용 기준 (Acceptance criteria)
+
+- **AC-1**: `_dispatch_message` 모듈 함수가 존재하고 `handle_message_im`이 이를 호출한다.
+- **AC-2**: `ai/tests/test_coordinator_dispatch.py`에 통합 테스트 5개 이상이 추가되어 모두 통과한다(정상/자기/비-IM/비처리 subtype/비허용).
+- **AC-3**: placeholder(`xoxb-여기에붙여넣기` 또는 `xapp-여기에붙여넣기`)로 데몬을 시작하면 `ConfigError`가 발생하고 프로세스가 non-zero exit 한다.
+- **AC-4**: placeholder 가드 단위 테스트가 추가되어 통과한다(config 단계, 두 토큰 모두 커버).
+- **AC-5**: `.env.example:18` 코멘트가 작업 노트 표현 없이 가이드 §3-2 참조 형태로 정리되어 있다.
+- **AC-6**: `ai/coordinator/handlers.py`에 `import sys`가 없고, `ai/tests/test_coordinator_handlers.py`에 사용되지 않는 `timedelta`가 없다.
+- **AC-7**: 기존 `ai/tests/` 단위 테스트와 신규 추가 테스트가 모두 통과한다.
+- **AC-8**: PRD/PR/커밋 본문 어디에도 도메인 키워드 평문 노출이 없다(`_compliance.FORBIDDEN_KEYWORDS` 기준).
+- **AC-9**: PR 본문에 `Closes #6` `Closes #10` `Closes #7`이 모두 포함되어 머지 시 세 이슈가 자동 종료된다.
+
+## 6. 가정 / 제약
+
+- Python 3.11+, 의존성 추가 없음.
+- 기존 컴플라이언스 모듈(`ai/coordinator/_compliance.py`)·dotenv 자동 로딩 동작을 변경하지 않는다.
+- placeholder SSoT는 `ai/coordinator/config.py::_PLACEHOLDER_TOKENS`로 두며, `.env.example`의 placeholder 표현이 바뀌더라도 코드 가드가 우선한다.
+
+## 7. 참고
+
+- Issues: #6, #10, #7
+- 출처 PR: #3 (리뷰 발견 2·3, 재리뷰 권고 1·2)
+- 관련 파일:
+  - `ai/coordinator/main.py` (`handle_message_im` 클로저)
+  - `ai/coordinator/config.py` (placeholder 가드 추가 지점)
+  - `ai/coordinator/handlers.py:13` (`import sys` 제거)
+  - `ai/tests/test_coordinator_handlers.py:6` (`timedelta` 제거)
+  - `ai/tests/test_coordinator_dispatch.py` (신규)
+  - `.env.example:18` (코멘트 정리)
+  - `docs/references/slack-coordinator-bot-setup.md` §3-2 (참조 대상)
+- 사용자 메모리: `project_slack_bot_naming.md` (봇 표시명 도메인 노출 금지)
+
+---
+
+## 보고 — 핵심 결정 사항
+
+- **placeholder 가드 방식**: **B(코드 가드)** 채택. 이유는 (1) `.env.example` 표현이 어떻게 바뀌든 코드 단계에서 명시 차단이 가능하고, (2) 사용자 안내 문구(`.env.example` 코멘트)는 친절함을 유지할 수 있으며, (3) SSoT가 코드 한 곳(`config.py::_PLACEHOLDER_TOKENS`)으로 모인다. A는 미채택.
+- **테스트 파일 분리**: 신규 `ai/tests/test_coordinator_dispatch.py`로 분리 — 기존 `test_coordinator_main_dotenv.py`는 dotenv 로딩 책임에 집중되어 있어 dispatcher 시나리오 5건 추가 시 파일 책임이 흐려진다.
+- **import 정리 범위**: `handlers.py` `sys`와 테스트 `timedelta`만 핀포인트 제거. 광범위 lint 스윕은 본 PR 범위 밖.

--- a/docs/qa/coordinator-code-chore.md
+++ b/docs/qa/coordinator-code-chore.md
@@ -1,0 +1,361 @@
+# QA — Coordinator Code Chore (#6 + #10 + #7 묶음)
+
+> 검증 대상 PR: [#20](https://github.com/deeptrading-lab/trading-signal-engine/pull/20) (`feature/coordinator-code-chore`)
+> 커밋: `94164042c102f116ca9d83e5c7f2d3399b1863ae`
+> Issues: [#6](https://github.com/deeptrading-lab/trading-signal-engine/issues/6) (P2 dispatcher 테스트), [#10](https://github.com/deeptrading-lab/trading-signal-engine/issues/10) (P2 placeholder 가드), [#7](https://github.com/deeptrading-lab/trading-signal-engine/issues/7) (P2 미사용 import)
+> PRD: [`docs/prd/coordinator-code-chore.md`](../prd/coordinator-code-chore.md)
+> 검증일: 2026-05-01
+> 검증자: QA agent
+> 검증 환경: macOS Darwin 25.4.0, Python 3.11.15, pytest 9.0.3
+
+> 본 리포트도 도메인 키워드 평문은 직접 나열하지 않는다. 정의 SSoT 는 `ai/coordinator/_compliance.FORBIDDEN_KEYWORDS` 한 곳이며, 검사 결과 인용 시 grep 출력 영역에 한정한다.
+
+---
+
+## 1. 요약
+
+P2 코드 정리 3건 묶음 PR. 변경 파일 7개 (`main.py`, `config.py`, `handlers.py`, `.env.example`, 테스트 3종) 단일 커밋. PRD AC-1 ~ AC-9 중 AC-1·2·3·4·5·6·7·8·9 모두 **자동 검증으로 PASS**. AC-3 의 데몬 non-zero exit 까지 `python -m ai.coordinator.main` 직접 실행으로 확인되어 보조 수동 시나리오는 사용자 회귀 (데몬 기동 + ping/pong) 1건만 남음.
+
+**판정**: `qa-auto-passed` (자동 검증 9/9 PASS, 수동 1건 사용자 몫).
+
+---
+
+## 2. AC별 자동 검증 결과
+
+| AC | 항목 | 검증 방법 | 결과 |
+|---|---|---|---|
+| AC-1 | `_dispatch_message` 모듈 함수 존재 + `handle_message_im` 호출 | 코드 리뷰 (`main.py:92-142`, `:159-166`) | **PASS** |
+| AC-2 | `test_coordinator_dispatch.py` 통합 테스트 5개 통과 | pytest 단독 실행 | **PASS** (5 passed) |
+| AC-3 | placeholder 토큰으로 데몬 시작 시 ConfigError + non-zero exit | `python -m ai.coordinator.main` 실행 | **PASS** (exit_code=2) |
+| AC-4 | placeholder 가드 단위 테스트 추가 + 두 토큰 모두 커버 | pytest `TestPlaceholderGuard` 3종 | **PASS** (3 passed) |
+| AC-5 | `.env.example:18` 코멘트 가이드 §3-2 참조 형태로 정리 | `.env.example` 직접 확인 | **PASS** |
+| AC-6 | `handlers.py` 의 `import sys` 부재 + 테스트 `timedelta` 미사용 정리 | grep 0건 | **PASS** |
+| AC-7 | 회귀 — `pytest ai/tests/` 174 통과 | pytest 전체 실행 | **PASS** (174 passed in 0.30s) |
+| AC-8 | PRD/PR/커밋 본문 도메인 키워드 평문 0건 | `_compliance.find_forbidden_keywords` 적용 | **PASS** (저장소 URL 슬러그 노트) |
+| AC-9 | PR 본문에 `Closes #6` `Closes #10` `Closes #7` 포함 | `gh pr view 20 --json body` | **PASS** (3 라인 모두 확인) |
+
+---
+
+### AC-1 — `_dispatch_message` 모듈 함수 존재 + wrapper 호출
+
+**재현 절차**:
+```bash
+sed -n '92,142p;159,166p' ai/coordinator/main.py
+```
+
+**기대 결과**: 모듈 레벨에 `_dispatch_message(event, *, say, logger, config, self_user_id, safe_say_fn=None)` 정의가 있고, `handle_message_im` 클로저는 본문이 1회 호출(얇은 wrapper)이다.
+
+**실제 결과** — `main.py:92-142`에 모듈 함수 정의 존재. `handle_message_im` (`:159-166`) 본문은 단일 `_dispatch_message(...)` 호출만 포함:
+
+```python
+@app.event("message")
+def handle_message_im(event: dict, say: Any, logger: logging.Logger = logger) -> None:
+    _dispatch_message(
+        event,
+        say=say,
+        logger=logger,
+        config=config,
+        self_user_id=self_user_id,
+    )
+```
+
+**판정**: PASS
+
+---
+
+### AC-2 — 통합 테스트 5개 통과
+
+**재현 절차**:
+```bash
+python -m pytest ai/tests/test_coordinator_dispatch.py -v
+```
+
+**기대 결과**: 5건(정상 ping / 자기 메시지 / 비-IM / 비처리 subtype / 비허용 발신자) 모두 PASS.
+
+**실제 결과**:
+```
+ai/tests/test_coordinator_dispatch.py::TestNormalPing::test_im_ping_invokes_safe_say_with_pong PASSED
+ai/tests/test_coordinator_dispatch.py::TestSelfMessageIgnored::test_bot_id_present_skips_dispatch PASSED
+ai/tests/test_coordinator_dispatch.py::TestNonImChannelIgnored::test_channel_type_channel_skips_dispatch PASSED
+ai/tests/test_coordinator_dispatch.py::TestUnhandleableSubtypeIgnored::test_message_changed_skips_dispatch_and_logs_info PASSED
+ai/tests/test_coordinator_dispatch.py::TestDisallowedSenderIgnored::test_unknown_user_skips_dispatch_and_logs_info PASSED
+============================== 5 passed in <0.2s ==============================
+```
+
+PRD §3.1의 시나리오 5종 전부 커버. mock `say`/`safe_say_fn`/`logger` fixture 기반으로 클로저 분기를 직접 검증한다.
+
+**판정**: PASS
+
+---
+
+### AC-3 — placeholder 토큰으로 데몬 시작 시 ConfigError + non-zero exit
+
+**재현 절차**:
+```bash
+SLACK_BOT_TOKEN="xoxb-여기에붙여넣기" SLACK_APP_TOKEN="xapp-여기에붙여넣기" \
+  python -m ai.coordinator.main
+echo "exit_code=$?"
+```
+
+**기대 결과**: stderr 한 줄 안내(`[코디네이터] 시작 실패: ... placeholder ...`) 후 exit code != 0. 토큰 값은 출력되지 않는다.
+
+**실제 결과**:
+```
+[코디네이터] 시작 실패: 환경변수 SLACK_BOT_TOKEN 가 placeholder 값입니다. .env 를 실제 토큰으로 채우세요.
+exit_code=2
+```
+
+`config.py:100-104`의 `_PLACEHOLDER_TOKENS` 가드가 prefix 검사를 통과한 placeholder 를 차단했고, `main.run()`의 `ConfigError` 트랩(`:226-229`)이 stderr 한 줄 + return 2 흐름을 정상 수행했다. 토큰 값은 메시지에 포함되지 않는다.
+
+**판정**: PASS
+
+---
+
+### AC-4 — placeholder 가드 단위 테스트 추가 + 두 토큰 모두 커버
+
+**재현 절차**:
+```bash
+python -m pytest ai/tests/test_coordinator_config.py::TestPlaceholderGuard -v
+```
+
+**기대 결과**: bot/app 두 토큰 placeholder + 정상 토큰 통과의 3건 PASS.
+
+**실제 결과**:
+```
+ai/tests/test_coordinator_config.py::TestPlaceholderGuard::test_bot_token_placeholder_raises PASSED
+ai/tests/test_coordinator_config.py::TestPlaceholderGuard::test_app_token_placeholder_raises PASSED
+ai/tests/test_coordinator_config.py::TestPlaceholderGuard::test_real_tokens_pass_placeholder_guard PASSED
+============================== 3 passed in <0.2s ==============================
+```
+
+각 테스트는 에러 메시지에 `SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN` 환경변수명, `placeholder` 키워드, `.env` 안내가 포함됨을 단언한다.
+
+**판정**: PASS
+
+---
+
+### AC-5 — `.env.example:18` 코멘트 정리
+
+**재현 절차**:
+```bash
+sed -n '17,19p' .env.example
+```
+
+**기대 결과**: 작업 노트 표현(예: "TODO 본인 user id 확인" 류) 없이 가이드 §3-2 참조 형태로 정리.
+
+**실제 결과** — `.env.example:17-19`:
+```
+# 응답 허용 사용자 ID (콤마로 구분, 화이트리스트)
+# 본인 user id 확인 방법은 docs/references/slack-coordinator-bot-setup.md §3-2 참조
+SLACK_ALLOWED_USER_IDS=U0AE7A54NHL
+```
+
+가이드 문서 §3-2 경로가 명시 참조로 들어가 있고 작업 노트 표현은 제거됐다.
+
+**판정**: PASS
+
+---
+
+### AC-6 — `import sys` 제거 + `timedelta` 제거
+
+**재현 절차**:
+```bash
+grep -n "^import sys" ai/coordinator/handlers.py
+grep -n "timedelta" ai/tests/test_coordinator_handlers.py
+```
+
+**기대 결과**: 두 grep 모두 0건.
+
+**실제 결과**:
+```
+$ grep -n "^import sys" ai/coordinator/handlers.py
+(no output)
+
+$ grep -n "timedelta" ai/tests/test_coordinator_handlers.py
+(no output)
+```
+
+`handlers.py:13`에서 `import sys` 제거 확인 (사용처 없음). 테스트의 `from datetime import datetime, timezone` 은 유지(검증 단언에서 사용)하되 미사용 `timedelta` 만 제거된 것으로 grep 0건이 일관된다. 기존 `handlers.py:15` 의 `from datetime import datetime, timezone, timedelta` 는 `KST = timezone(timedelta(hours=9), ...)` 에서 직접 사용되므로 유지(범위 외).
+
+**판정**: PASS
+
+---
+
+### AC-7 — 기존 + 신규 테스트 모두 통과 (174/174)
+
+**재현 절차**:
+```bash
+python -m pytest ai/tests/ -v
+```
+
+**기대 결과**: 모든 테스트 PASS (PRD 기준 174건; 기존 166 + 신규 8 = 174).
+
+**실제 결과**:
+```
+============================= 174 passed in 0.30s ==============================
+```
+
+신규 추가분 = `test_coordinator_dispatch.py` 5종 + `TestPlaceholderGuard` 3종 = 8건. 합계 174 일치.
+
+**판정**: PASS
+
+---
+
+### AC-8 — PRD/PR/커밋 본문 도메인 키워드 평문 0건
+
+**재현 절차**:
+```python
+from ai.coordinator._compliance import find_forbidden_keywords
+import subprocess
+
+# PRD
+with open('docs/prd/coordinator-code-chore.md') as f:
+    print('PRD:', find_forbidden_keywords(f.read()))
+
+# 커밋 본문
+msg = subprocess.check_output(['git','log','-1','--format=%B','9416404']).decode()
+print('Commit:', find_forbidden_keywords(msg))
+
+# PR 본문
+import json
+body = json.loads(subprocess.check_output(['gh','pr','view','20','--json','body']))['body']
+print('PR:', find_forbidden_keywords(body))
+```
+
+**기대 결과**: 세 영역 모두 0건. 단, GitHub 저장소 URL 슬러그(`deeptrading-lab/trading-signal-engine`)는 외부 식별자 평문이라 정책 외 회색지대로 둔다 (PR #14 QA 선례 일관).
+
+**실제 결과**:
+```
+PRD: ['signal', 'trading']     # 두 매치 모두 같은 줄, GitHub 저장소 URL 슬러그
+Commit: []
+PR: []
+```
+
+PRD 매치 위치 — `docs/prd/coordinator-code-chore.md:5`:
+```
+- **Issues**: [#6](https://github.com/deeptrading-lab/trading-signal-engine/issues/6), [#10](...), [#7](...)
+```
+모든 매치가 GitHub URL 슬러그 안의 저장소 이름(`trading-signal-engine`)에서 발생. 본문 자유 텍스트에는 키워드 평문 노출 0건. PRD §1 첫 줄에 "본 PRD 본문에서 도메인 키워드 평문 노출은 회피하며 ..." 메타 표현이 명시되어 있어 정책 의도와 일치하며, PR #14 / #16 QA 에서 동일 회색지대를 PASS 처리한 선례를 따른다.
+
+**판정**: PASS (저장소 URL 슬러그 회색지대 노트, 본문 자유 텍스트 0건).
+
+---
+
+### AC-9 — PR 본문에 3개 `Closes` 라인 포함
+
+**재현 절차**:
+```bash
+gh pr view 20 --json body --jq '.body' | grep -E "^Closes #"
+```
+
+**기대 결과**:
+```
+Closes #6
+Closes #10
+Closes #7
+```
+
+**실제 결과**: 위와 정확히 일치. 머지 시 GitHub 가 자동으로 세 이슈를 close 처리한다.
+
+**판정**: PASS
+
+---
+
+## 3. 에지 케이스 (자동 검증)
+
+| 시나리오 | 검증 | 결과 |
+|---|---|---|
+| 봇 자기 메시지 (`bot_id` 채워짐) | `TestSelfMessageIgnored` | PASS — `safe_say_fn` 미호출 |
+| 비-IM 채널 (`channel_type=channel`) | `TestNonImChannelIgnored` | PASS — `safe_say_fn` 미호출 |
+| 비처리 subtype (`message_changed`) | `TestUnhandleableSubtypeIgnored` | PASS — INFO 로그 + `safe_say_fn` 미호출 |
+| 비허용 발신자 (`UUNKNOWN1`) | `TestDisallowedSenderIgnored` | PASS — INFO 로그 + `safe_say_fn` 미호출 |
+| placeholder 두 토큰 모두 fail-fast | `TestPlaceholderGuard` 2종 | PASS — `ConfigError` 메시지에 환경변수명·`placeholder`·`.env` 포함 |
+| 정상 토큰은 가드 통과 (false positive 없음) | `test_real_tokens_pass_placeholder_guard` | PASS |
+| 토큰 마스킹 — 에러 메시지에 토큰 값 미노출 | `test_error_message_does_not_contain_token_value` (회귀) | PASS |
+| dotenv 자동 로딩 회귀 | `test_coordinator_main_dotenv.py` 7종 (회귀) | PASS |
+| 컴플라이언스 모듈 회귀 | 라우팅 출력 모두 `assert_no_forbidden` 통과 | PASS |
+
+본 PR 은 외부 I/O 변경이 없어 거래소 서버 다운·네트워크 지연·API 레이트리밋·뉴스 피드 장애 류 에지는 PRD 범위 외로 비적용.
+
+---
+
+## 4. 사용자 수동 체크리스트
+
+자동 검증 9/9 통과. 사용자 환경에서 보조 회귀만 수행 권장.
+
+- [ ] **데몬 기동 + ping/pong**:
+  ```bash
+  set -a && source .env && set +a
+  python -m ai.coordinator.main
+  ```
+  Slack DM 으로 `ping` 발사 → `pong` 응답 확인. SIGINT 로 정상 종료(exit 0).
+
+- [ ] **(선택) placeholder fail-fast 사용자 환경 재현**: `.env` 의 `SLACK_BOT_TOKEN` 을 `xoxb-여기에붙여넣기` 로 일시 변경 → 데몬 기동 시 stderr 한 줄 메시지 + non-zero exit 확인. 검증 후 원복.
+
+- [ ] **(선택) `status` 명령 회귀**: DM 으로 `status` → 가동시간/호스트명/현재 시각(KST)/Python 버전 4종 모두 표시 확인.
+
+---
+
+## 5. 판정
+
+- 자동 검증: 9/9 PASS
+- 라벨 갱신: `impl-ready` → `qa-auto-passed`
+- 실패 항목: 0건
+- 사용자 수동: 1건(데몬 기동 + ping/pong 회귀, 보조)
+
+---
+
+## 6. 부록 — 실행 로그
+
+### 6.1 회귀 테스트 (174 passed)
+
+```
+$ python -m pytest ai/tests/ -v
+...
+============================= 174 passed in 0.30s ==============================
+```
+
+### 6.2 dispatch + placeholder 단독 (20 passed)
+
+```
+$ python -m pytest ai/tests/test_coordinator_dispatch.py ai/tests/test_coordinator_config.py -v
+...
+============================== 20 passed in 0.22s ==============================
+```
+
+### 6.3 placeholder 데몬 fail-fast
+
+```
+$ SLACK_BOT_TOKEN="xoxb-여기에붙여넣기" SLACK_APP_TOKEN="xapp-여기에붙여넣기" \
+    python -m ai.coordinator.main
+[코디네이터] 시작 실패: 환경변수 SLACK_BOT_TOKEN 가 placeholder 값입니다. .env 를 실제 토큰으로 채우세요.
+$ echo "exit_code=$?"
+exit_code=2
+```
+
+### 6.4 grep — `import sys` / `timedelta` 제거 확인
+
+```
+$ grep -n "^import sys" ai/coordinator/handlers.py
+(no output — 0건)
+
+$ grep -n "timedelta" ai/tests/test_coordinator_handlers.py
+(no output — 0건)
+```
+
+### 6.5 컴플라이언스 grep — PRD/커밋/PR
+
+```
+PRD matches : ['signal', 'trading']    # 모두 docs/prd/coordinator-code-chore.md:5 의 GitHub URL 슬러그
+Commit body : []
+PR body     : []
+```
+
+### 6.6 PR 본문 `Closes` 라인
+
+```
+$ gh pr view 20 --json body --jq '.body' | grep -E "^Closes #"
+Closes #6
+Closes #10
+Closes #7
+```


### PR DESCRIPTION
## Summary
- `_dispatch_message` 모듈 함수 추출로 `handle_message_im` 클로저 통합 테스트 가능 (#6)
- `config.py` 의 `_PLACEHOLDER_TOKENS` 가드로 .env.example placeholder 그대로 실행 시 fail-fast (#10)
- `handlers.py:13` `import sys`, `test_coordinator_handlers.py` 미사용 `timedelta` 제거 (#7)
- `.env.example` 의 작업 노트 코멘트를 가이드 §3-2 참조로 정리

## 변경 파일
- `ai/coordinator/main.py` — `_dispatch_message` 추출, `handle_message_im` 1행 wrapper
- `ai/coordinator/config.py` — `_PLACEHOLDER_TOKENS` frozenset + 가드
- `ai/coordinator/handlers.py` — `import sys` 제거
- `.env.example` — 코멘트 정리
- `ai/tests/test_coordinator_dispatch.py` (신규) — 라우팅 분기 5종
- `ai/tests/test_coordinator_config.py` — placeholder 가드 3종
- `ai/tests/test_coordinator_handlers.py` — `timedelta` 제거

## Test plan
- [x] `pytest ai/tests/` 174 passed (기존 166 + 신규 8)
- [x] placeholder 토큰으로 데몬 시작 시 한 줄 에러 + non-zero exit 확인
- [ ] 머지 후 사용자 회귀: 데몬 기동 + ping/pong 정상

Closes #6
Closes #10
Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)