### PR TITLE
디자인 가이드를 DESIGN.md 포맷으로 표준화

### DIFF
--- a/.claude/agents/frontend-dev.md
+++ b/.claude/agents/frontend-dev.md
@@ -8,16 +8,20 @@ model: inherit
 너는 Trading Signal Engine의 **Frontend Dev** 에이전트다.
 
 ## 하는 일
-- 입력: `docs/prd/<slug>.md` + `docs/design/<slug>.md`
+- 입력: `docs/prd/<slug>.md` + `docs/design/<slug>.md` (DESIGN.md 포맷)
 - 대상: `frontend/`
 - 브랜치: `feature/<slug>` (또는 백엔드와 분리가 필요하면 `feature/<slug>-fe`)
-- 디자이너 가이드(shadcn/ui 토큰·컴포넌트)를 **그대로** 따른다.
+- 디자이너 가이드의 **DESIGN.md front matter 토큰을 그대로** 사용한다.
+  - Tailwind 등 테마가 필요하면 `npx @google/design.md export --format tailwind docs/design/<slug>.md`로 변환해 주입한다.
+  - 색·간격·라운드는 토큰 키(`colors.primary`, `spacing.md`)로만 참조하고 hex/px를 코드에 하드코딩하지 않는다.
+  - 토큰이 부족하거나 모호하면 직접 추가하지 말고 ux-designer에게 디자인 문서 갱신을 요청한다.
 - 커밋 메시지: **한글·요점만**.
 - PR 생성 + 라벨 `impl-ready`.
 
 ## 하지 않는 일
-- 디자인 의사결정 임의 변경. 필요 시 UX/UI와 합의 후 PRD/디자인 문서 갱신을 요청.
+- 디자인 의사결정 임의 변경 (토큰 추가·수정 포함). 필요 시 UX/UI와 합의 후 PRD/디자인 문서 갱신을 요청.
 - PRD 범위 초과 구현.
+- 디자인 토큰 우회(임의 hex/px 박기, 토큰 외 폰트 추가 등).
 
 ## 산출물 규약
 - 최종 응답에 **브랜치·PR URL**을 한 줄로 명시.

--- a/.claude/agents/ux-designer.md
+++ b/.claude/agents/ux-designer.md
@@ -1,7 +1,7 @@
 ---
 name: ux-designer
-description: PRD에 UI가 포함될 때 유저 시나리오·디자인 시스템 가이드를 docs/design/<slug>.md에 작성. 코드 구현 금지.
-tools: Read, Write, Edit, Glob, Grep, WebFetch
+description: PRD에 UI가 포함될 때 유저 시나리오·디자인 시스템 가이드를 docs/design/<slug>.md에 DESIGN.md 포맷으로 작성. 코드 구현 금지.
+tools: Read, Write, Edit, Glob, Grep, WebFetch, Bash
 model: inherit
 ---
 
@@ -11,17 +11,33 @@ model: inherit
 - 입력: `docs/prd/<slug>.md`
 - 출력: `docs/design/<slug>.md`에 다음을 작성한다.
   - **유저 시나리오**: 주요 태스크 플로우 (예: 신호 확인 → 승인 → 주문 실행)
-  - **디자인 시스템 가이드**: shadcn/ui 토큰(색·타이포·간격), 컴포넌트 선택, 상태 표현 규칙
+  - **디자인 시스템 가이드**: **Google Labs `DESIGN.md` 포맷**으로 토큰(colors / typography / rounded / spacing / components)과 근거 prose를 함께 기술
   - **핸드오프 명세**: Frontend Dev가 바로 구현 가능한 수준 — 화면별 상태, 로딩, 빈 상태, 에러 케이스 포함
 - Slack 인터랙션(버튼·모달 등)도 UI 범주로 본다.
+
+## DESIGN.md 포맷 (필수)
+- **단일 진실 소스**: 모든 디자인 가이드는 `DESIGN.md` 포맷을 따른다. 포맷·섹션 순서·토큰 타입은 [`docs/rules/design-md.md`](../../docs/rules/design-md.md) 참조.
+- **YAML front matter**에 토큰을 정의하고, 본문은 `Overview → Colors → Typography → Layout → Elevation & Depth → Shapes → Components → Do's and Don'ts` 순서를 지킨다 (생략 가능, 순서는 고정).
+- 색·간격은 토큰으로만 표현한다. 컴포넌트 속성은 `{colors.primary}` 같은 **토큰 참조**로 연결한다.
+- 동일 slug 내에서는 기존 토큰 키(`primary`, `body-md`, `button-primary` 등)를 재사용한다. 새 키는 prose에서 도입 근거를 명시한다.
+
+## 산출 직전 검증 (필수)
+- `npx @google/design.md lint docs/design/<slug>.md`를 실행해 **error 0건**인지 확인한다.
+- warning은 무시 가능하나, `contrast-ratio` 경고는 prose에서 의도(예: 비활성 상태 표현)를 명시하지 않는 한 수정한다.
+- 최종 응답에 lint 요약(`errors`, `warnings`, `info` 카운트)을 포함한다.
 
 ## 하지 않는 일
 - 코드 구현·커밋·머지 승인.
 - PRD 범위 밖의 UI 임의 추가 (필요 시 PM에게 질문 → PRD 갱신 요청).
+- 토큰 없이 본문에 hex/px만 나열 (포맷 위반).
 
 ## 산출물 규약
 - 경로: `docs/design/<slug>.md`
-- 최종 응답에 파일 경로를 한 줄로 명시한다. 예: `산출물: docs/design/slack-signal-approval.md`
+- 최종 응답에 다음을 한 줄씩 명시한다.
+  - `산출물: docs/design/<slug>.md`
+  - `lint: errors=0 warnings=N info=M`
 
 ## 참고
+- 포맷 가이드: [`docs/rules/design-md.md`](../../docs/rules/design-md.md)
+- 스펙 원문: <https://github.com/google-labs-code/design.md>
 - `docs/agents/ux-designer.md`, `AGENTS.md`의 **UX/UI 디자이너 산출물** 절.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,10 +77,14 @@ PM은 PRD만 전달하고, 개발자(Frontend/Backend)는 **PRD에 없는 기능
 UI·유저 인터랙션이 PRD에 포함될 때 합류합니다.
 
 - **유저 시나리오**: 주요 태스크 플로우(예: 신호 확인 → 승인 → 주문 실행)
-- **디자인 시스템 가이드**: 사용할 컴포넌트(shadcn/ui 등), 토큰(색·타이포·간격), 상태 표현 규칙
-- **핸드오프 산출물**: Frontend Dev가 바로 구현할 수 있는 수준의 명세(스펙·상태·에러 케이스 포함)
+- **디자인 시스템 가이드 (DESIGN.md 포맷 필수)**:
+  - 단일 진실 소스: 모든 `docs/design/<slug>.md`는 [Google Labs **DESIGN.md**](https://github.com/google-labs-code/design.md) 포맷을 따릅니다. 포맷 상세는 [`docs/rules/design-md.md`](docs/rules/design-md.md) 참조.
+  - YAML front matter에 토큰(`colors`, `typography`, `rounded`, `spacing`, `components`)을 정의하고, 본문은 표준 섹션 순서(Overview → Colors → Typography → Layout → Elevation & Depth → Shapes → Components → Do's and Don'ts)로 작성합니다.
+  - 색·간격은 토큰 참조(`{colors.primary}`)로만 연결합니다. 코드·컴포넌트에 hex/px를 직접 박지 않습니다.
+- **검증**: 산출 직전 `npx @google/design.md lint docs/design/<slug>.md`를 실행하고 **error 0건**을 확인합니다. lint 요약을 PR/응답에 첨부합니다.
+- **핸드오프 산출물**: Frontend Dev가 바로 구현할 수 있는 수준의 명세(스펙·상태·에러 케이스 포함). Frontend는 front matter의 토큰을 그대로 사용합니다.
 
-디자이너는 코드 커밋·머지 승인을 하지 않습니다. Frontend Dev가 가이드를 따르지 않는다고 판단되면 Code Reviewer와 함께 변경을 요청합니다.
+디자이너는 코드 커밋·머지 승인을 하지 않습니다. Frontend Dev가 가이드를 따르지 않는다고 판단되면(예: 토큰 미사용, 임의 hex) Code Reviewer와 함께 변경을 요청합니다.
 
 ---
 

--- a/docs/agents/ux-designer.md
+++ b/docs/agents/ux-designer.md
@@ -3,8 +3,13 @@
 - **합류 시점**: UI·유저 인터랙션이 PRD에 포함될 때. Slack 인터랙션(버튼·모달 등)도 포함.
 - **산출물**:
   - 유저 시나리오(주요 태스크 플로우)
-  - 디자인 시스템 가이드(shadcn/ui 토큰·컴포넌트 선택·상태 표현 규칙)
-  - Frontend Dev가 바로 구현 가능한 수준의 핸드오프 명세(상태·에러 케이스 포함)
+  - **디자인 시스템 가이드 (DESIGN.md 포맷 필수)**
+    - 단일 진실 소스: 모든 `docs/design/<slug>.md`는 [Google Labs `DESIGN.md`](https://github.com/google-labs-code/design.md) 포맷을 따른다.
+    - YAML front matter에 토큰(`colors`, `typography`, `rounded`, `spacing`, `components`)을 정의하고, 본문은 표준 섹션 순서(Overview → Colors → Typography → Layout → Elevation & Depth → Shapes → Components → Do's and Don'ts)로 작성한다.
+    - 색·간격은 토큰 참조(`{colors.primary}`)로만 연결한다.
+  - Frontend Dev가 바로 구현 가능한 수준의 핸드오프 명세(상태·에러 케이스 포함).
+- **검증**: 산출 직전 `npx @google/design.md lint docs/design/<slug>.md`를 실행하고, **error 0건**을 확인한다. 결과 요약을 응답에 첨부.
 - **하지 않는 일**: 코드 구현·머지 승인.
-- **참고**: `AGENTS.md`의 **UX/UI 디자이너 산출물** 절.
-
+- **참고**:
+  - 포맷·룰: [`docs/rules/design-md.md`](../rules/design-md.md)
+  - `AGENTS.md`의 **UX/UI 디자이너 산출물** 절.

--- a/docs/rules/design-md.md
+++ b/docs/rules/design-md.md
@@ -1,0 +1,166 @@
+# DESIGN.md 포맷 가이드
+
+이 저장소의 모든 디자인 가이드(`docs/design/<slug>.md`)는 **Google Labs `DESIGN.md` 포맷**을 따른다.
+원본 스펙: <https://github.com/google-labs-code/design.md> (현재 버전 `alpha`).
+
+## 왜 이 포맷인가
+- **에이전트 간 일관성**: ux-designer가 정의한 토큰을 frontend-dev·reviewer가 동일한 키로 참조한다.
+- **자동 검증**: `npx @google/design.md lint`가 깨진 토큰 참조·WCAG AA 대비비(4.5:1)·고립 토큰을 잡아준다.
+- **상호운용성**: Tailwind theme / W3C DTCG `tokens.json`으로 export 가능 → frontend 구현 시 토큰을 코드에 직접 주입.
+
+## 파일 구조
+
+한 파일에 두 레이어가 들어간다.
+
+1. **YAML front matter** — 머신 판독용 디자인 토큰 (정규값). `---` 펜스로 감싼다.
+2. **Markdown 본문** — "왜 이 값인가"를 사람·에이전트가 읽는 근거.
+
+```md
+---
+version: alpha
+name: <디자인 시스템 이름>
+description: <한 줄 요약, 선택>
+colors:
+  primary: "#1A1C1E"
+  secondary: "#6C7278"
+  tertiary: "#B8422E"
+  neutral: "#F7F5F2"
+typography:
+  h1:
+    fontFamily: Public Sans
+    fontSize: 48px
+    fontWeight: 600
+    lineHeight: 1.1
+    letterSpacing: -0.02em
+  body-md:
+    fontFamily: Public Sans
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.6
+rounded:
+  sm: 4px
+  md: 8px
+spacing:
+  sm: 8px
+  md: 16px
+components:
+  button-primary:
+    backgroundColor: "{colors.tertiary}"
+    textColor: "{colors.neutral}"
+    rounded: "{rounded.sm}"
+    padding: 12px
+  button-primary-hover:
+    backgroundColor: "{colors.primary}"
+---
+
+# <slug> 디자인 가이드
+
+## Overview
+브랜드 톤·타겟 사용자·느낌의 방향 (예: "전문 트레이더용, 정보 밀도 우선, 차분한 톤").
+
+## Colors
+- **Primary (#1A1C1E)**: 핵심 텍스트·헤드라인. ...
+- **Tertiary (#B8422E)**: 액션 트리거 전용. ...
+
+## Typography
+- **Headlines**: Public Sans Semi-Bold — 신뢰감.
+- **Body**: Public Sans Regular 16px — 가독성.
+
+## Layout
+12-col grid, 8px 베이스라인. ...
+
+## Components
+- `button-primary`: CTA 한 화면에 1개 원칙. ...
+
+## Do's and Don'ts
+- ✅ 토큰 참조(`{colors.primary}`)로만 색을 사용한다.
+- ❌ 원시 hex 값을 컴포넌트 영역에 직접 박지 않는다.
+```
+
+## 토큰 타입
+
+| 타입 | 형식 | 예시 |
+|:---|:---|:---|
+| Color | `#` + sRGB 헥스 | `"#1A1C1E"` |
+| Dimension | 숫자 + 단위(`px`, `em`, `rem`) | `48px`, `-0.02em` |
+| Token Reference | `{path.to.token}` | `{colors.primary}` |
+| Typography | `fontFamily`, `fontSize`, `fontWeight`, `lineHeight`, `letterSpacing`, `fontFeature`, `fontVariation` 객체 | 위 예시 참조 |
+
+`components` 영역에서만 합성 토큰 참조(`{typography.label-md}`)가 허용된다. 그 외에는 원시 값으로 해석된다.
+
+## 섹션 순서 (고정)
+
+존재하는 섹션은 아래 순서를 지켜야 한다 (생략은 허용).
+
+1. **Overview** (alias: "Brand & Style")
+2. **Colors**
+3. **Typography**
+4. **Layout** (alias: "Layout & Spacing")
+5. **Elevation & Depth** (alias: "Elevation")
+6. **Shapes**
+7. **Components**
+8. **Do's and Don'ts**
+
+## 컴포넌트 변형
+
+hover/active/pressed 등 상태는 별도 컴포넌트 키로 표현한다.
+
+```yaml
+components:
+  button-primary:
+    backgroundColor: "{colors.tertiary}"
+  button-primary-hover:
+    backgroundColor: "{colors.primary}"
+  button-primary-disabled:
+    backgroundColor: "{colors.secondary}"
+```
+
+허용 속성: `backgroundColor`, `textColor`, `typography`, `rounded`, `padding`, `size`, `height`, `width`.
+
+## 검증 (CLI)
+
+작성·수정 후 lint를 통과해야 한다. ux-designer는 산출 직전, frontend-dev는 구현 시작 전 실행.
+
+```bash
+npx @google/design.md lint docs/design/<slug>.md
+```
+
+| 룰 | 심각도 | 검사 내용 |
+|:---|:---|:---|
+| `broken-ref` | error | `{colors.primary}` 참조가 정의된 토큰을 가리키지 않음 |
+| `missing-primary` | warning | `colors`에 `primary` 누락 |
+| `contrast-ratio` | warning | 컴포넌트 `backgroundColor`/`textColor` 쌍이 WCAG AA(4.5:1) 미달 |
+| `orphaned-tokens` | warning | 정의됐지만 어떤 컴포넌트도 참조하지 않는 색 토큰 |
+| `missing-typography` | warning | 색만 있고 타이포가 없음 (에이전트가 기본 폰트로 폴백) |
+| `section-order` | warning | 섹션 순서가 표준에서 벗어남 |
+| `token-summary` | info | 섹션별 토큰 개수 요약 |
+
+PR 본문에 lint 결과(JSON 또는 요약)를 첨부한다.
+
+### 두 버전 비교
+
+기존 디자인을 수정할 때는 회귀 검사를 돌린다.
+
+```bash
+npx @google/design.md diff docs/design/<slug>.md docs/design/<slug>-v2.md
+```
+
+### 코드 동기화 (필요 시)
+
+frontend가 Tailwind를 쓸 경우, 토큰을 직접 export 해서 테마에 주입한다.
+
+```bash
+npx @google/design.md export --format tailwind docs/design/<slug>.md > frontend/tailwind.theme.json
+npx @google/design.md export --format dtcg docs/design/<slug>.md > frontend/tokens.json
+```
+
+## 에이전트별 책임
+
+- **ux-designer**: `docs/design/<slug>.md`를 위 포맷으로 작성. 산출 직전 `lint` 통과 필수. 토큰 이름은 `primary`/`secondary`/`tertiary`/`neutral` 컨벤션 우선.
+- **frontend-dev**: front matter의 토큰을 **그대로** 사용. 색·간격을 코드에 하드코딩하지 않는다. 토큰 부족 시 ux-designer에게 PRD·디자인 문서 갱신 요청.
+- **reviewer**: 디자인 토큰 미준수(하드코딩된 hex/px) 발견 시 변경 요청.
+
+## 참고
+
+- 스펙 원문: <https://github.com/google-labs-code/design.md/blob/main/docs/spec.md>
+- 영감을 받은 표준: [W3C Design Token Format Module](https://tr.designtokens.org/format/)


### PR DESCRIPTION
## Summary
- ux-designer/frontend-dev 에이전트가 [Google Labs **DESIGN.md**](https://github.com/google-labs-code/design.md) 포맷을 따르도록 책임을 갱신했습니다. 토큰(YAML front matter) + 근거 prose가 단일 진실 소스가 됩니다.
- `docs/rules/design-md.md`에 포맷·섹션 순서·토큰 타입·7개 lint 룰·CLI 사용법을 정리했습니다.
- AGENTS.md UX/UI 디자이너 절을 토큰 강제·`npx @google/design.md lint` 검증 흐름으로 업데이트했습니다.

## 변경 파일
- 신규: `docs/rules/design-md.md`
- 수정: `.claude/agents/ux-designer.md`, `.claude/agents/frontend-dev.md`, `docs/agents/ux-designer.md`, `AGENTS.md`

## 효과
- 에이전트 간 디자인 일관성: ux-designer가 정의한 토큰 키를 frontend-dev/reviewer가 동일하게 참조.
- 자동 검증: WCAG AA 대비비, 깨진 토큰 참조, 고립 토큰 등 lint로 차단.
- 상호운용성: Tailwind theme / W3C DTCG `tokens.json`으로 export 가능.

## Test plan
- [ ] `docs/rules/design-md.md` 가이드만 보고 신규 slug `docs/design/<slug>.md`를 작성할 수 있는지 확인
- [ ] `npx @google/design.md lint <샘플>`로 errors=0 통과 확인
- [ ] frontend-dev 에이전트 호출 시 토큰 외 hex/px 하드코딩이 발생하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)