### PR TITLE
ci: PR 작성자 자동 assignee 추가 (워크플로우 + 에이전트 가이드)

### DIFF
--- a/.claude/agents/backend-dev.md
+++ b/.claude/agents/backend-dev.md
@@ -16,7 +16,7 @@ model: inherit
 - 브랜치: `feature/<slug>` (없으면 생성, 이미 있으면 체크아웃)
 - PRD 수용 기준을 만족하는 최소 구현. **범위 초과 금지**.
 - 커밋 메시지: **한글·요점만** (`AGENTS.md` 개발자 커밋 규칙)
-- PR 생성(`gh pr create`)하고 라벨 `impl-ready` 추가. PR 본문에 PRD 경로·수용 기준 체크리스트 포함.
+- PR 생성 시 `gh pr create --assignee @me ...` 로 작성자 본인을 assignee 로 즉시 지정. 라벨 `impl-ready` 추가. PR 본문에 PRD 경로·수용 기준 체크리스트 포함. (`.github/workflows/auto-assign-author.yml` 이 동일하게 보장하므로 누락돼도 5~15초 내 자동 보정되지만, 즉시 가시성을 위해 플래그 권장.)
 
 ## 하지 않는 일
 - PRD에 없는 기능 임의 추가. 모호하면 PR 코멘트로 질문 → PM에게 돌림.

--- a/.claude/agents/frontend-dev.md
+++ b/.claude/agents/frontend-dev.md
@@ -16,7 +16,7 @@ model: inherit
   - 색·간격·라운드는 토큰 키(`colors.primary`, `spacing.md`)로만 참조하고 hex/px를 코드에 하드코딩하지 않는다.
   - 토큰이 부족하거나 모호하면 직접 추가하지 말고 ux-designer에게 디자인 문서 갱신을 요청한다.
 - 커밋 메시지: **한글·요점만**.
-- PR 생성 + 라벨 `impl-ready`.
+- PR 생성 시 `gh pr create --assignee @me ...` 로 작성자 본인을 assignee 로 즉시 지정 + 라벨 `impl-ready`. (`.github/workflows/auto-assign-author.yml` 이 동일하게 보장하므로 누락돼도 5~15초 내 자동 보정되지만, 즉시 가시성을 위해 플래그 권장.)
 
 ## 하지 않는 일
 - 디자인 의사결정 임의 변경 (토큰 추가·수정 포함). 필요 시 UX/UI와 합의 후 PRD/디자인 문서 갱신을 요청.

--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -1,0 +1,26 @@
+name: Auto-assign PR author
+
+# PR 생성·재오픈 시 작성자(author) 본인을 assignee 로 자동 추가.
+# 작업자 가시성 확보용 — 모든 진입 경로(에이전트 / 메인 세션 / 웹 UI / 모바일) 를 단일 진입점으로 보장.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign PR author as assignee
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # 멱등성: 이미 assignee 에 들어 있으면 add 명령은 no-op 처리됨.
+          gh pr edit "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --add-assignee "$PR_AUTHOR"


### PR DESCRIPTION
## 요약

PR 생성 시 작성자(author) 본인이 자동으로 assignee 에 들어가도록 두 층 적용.

## 변경 범위

### 신규: `.github/workflows/auto-assign-author.yml`
- 트리거: `pull_request_target` `[opened, reopened]`
- 동작: `gh pr edit <PR> --add-assignee <author>` 실행
- 권한: `pull-requests: write` 만 부여
- **모든 PR 진입 경로 단일 진입점** — 에이전트 / 메인 Claude 세션 / 웹 UI / 모바일 / 다른 사람 PR 모두 커버

### 변경: `.claude/agents/backend-dev.md`, `.claude/agents/frontend-dev.md`
- PR 생성 단계 가이드에 `gh pr create --assignee @me` 플래그 사용 권장 추가
- 워크플로우의 5~15초 지연 동안에도 즉시 가시성 확보

## 설계 의도

- **belt**: 워크플로우 — 빈틈 없음, 모든 PR 보장
- **suspenders**: 에이전트 가이드 — 즉시성 (Action 지연 회피)
- 둘 다 동작해도 부작용 없음 — `gh pr edit --add-assignee` 는 멱등

## 동작 검증

본 PR 자체가 첫 적용 사례:
- `gh pr create --assignee @me` 로 생성 — 즉시 assignee 에 작성자 표시
- 워크플로우는 PR opened 5~15s 후 한 번 더 실행 (이미 들어 있으면 no-op)

## 다음 작업

- PR #29 (`feature/prd-dev-relay-natural-language`) 는 본 워크플로우 머지 전 생성된 PR — 이미 사용자가 수동 어사인. 본 PR 머지 후 다른 PR 부터 자동 적용.