### PR TITLE
chore: Makefile — daemon/test/install 명령 정리

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: help install daemon test test-dev-relay test-coordinator
+
+help:
+	@echo "Available targets:"
+	@echo "  install          - Install Python dependencies (ai/requirements.txt)"
+	@echo "  daemon           - Run dev_relay daemon (python -m ai.dev_relay.main)"
+	@echo "  test             - Run all pytest suites under ai/tests/"
+	@echo "  test-dev-relay   - Run dev_relay tests only"
+	@echo "  test-coordinator - Run coordinator tests only"
+
+install:
+	pip install -r ai/requirements.txt
+
+daemon:
+	python -m ai.dev_relay.main
+
+test:
+	pytest ai/tests/ -v
+
+test-dev-relay:
+	pytest ai/tests/dev_relay/ -v
+
+test-coordinator:
+	pytest ai/tests/test_coordinator_*.py -v

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,25 @@
-.PHONY: help install daemon test test-dev-relay test-coordinator
+.PHONY: help install daemon daemon-dev-relay daemon-coordinator test test-dev-relay test-coordinator
 
 help:
 	@echo "Available targets:"
-	@echo "  install          - Install Python dependencies (ai/requirements.txt)"
-	@echo "  daemon           - Run dev_relay daemon (python -m ai.dev_relay.main)"
-	@echo "  test             - Run all pytest suites under ai/tests/"
-	@echo "  test-dev-relay   - Run dev_relay tests only"
-	@echo "  test-coordinator - Run coordinator tests only"
+	@echo "  install            - Install Python dependencies (ai/requirements.txt)"
+	@echo "  daemon             - Alias for daemon-dev-relay (most common)"
+	@echo "  daemon-dev-relay   - Run Hayoung Dev Manager bot (python -m ai.dev_relay.main)"
+	@echo "  daemon-coordinator - Run Hayoung AI Coordinator bot (python -m ai.coordinator.main)"
+	@echo "  test               - Run all pytest suites under ai/tests/"
+	@echo "  test-dev-relay     - Run dev_relay tests only"
+	@echo "  test-coordinator   - Run coordinator tests only"
 
 install:
 	pip install -r ai/requirements.txt
 
-daemon:
+daemon: daemon-dev-relay
+
+daemon-dev-relay:
 	python -m ai.dev_relay.main
+
+daemon-coordinator:
+	python -m ai.coordinator.main
 
 test:
 	pytest ai/tests/ -v


### PR DESCRIPTION
## Summary

데몬 실행·테스트 등 평문으로 PRD 부록 (`docs/prd/slack-coordinator-inbound.md` / `docs/prd/slack-dev-relay.md`) 에만 적혀 있던 명령을 루트 `Makefile` 한 장으로 모음. PR #32 (dev-relay-natural-language Phase 1) 범위 밖 작업이라 별도 chore PR 로 분리.

## 변경 범위

- 신규: `Makefile`
- 7개 타겟:
  - `make help` — 전체 타겟 출력
  - `make install` — `pip install -r ai/requirements.txt`
  - `make daemon` — `daemon-dev-relay` 의 alias (자주 쓰는 쪽)
  - `make daemon-dev-relay` — `python -m ai.dev_relay.main` (Hayoung Dev Manager)
  - `make daemon-coordinator` — `python -m ai.coordinator.main` (Hayoung AI Coordinator)
  - `make test` — `pytest ai/tests/ -v` (전체 484건)
  - `make test-dev-relay` / `make test-coordinator` — 봇별 분리

## 두 봇 데몬 타겟 분리 근거

코디네이터 + dev_relay 는 별도 Slack App + 별도 토큰 (`SLACK_BOT_TOKEN` vs `SLACK_DEV_RELAY_BOT_TOKEN`) + 별도 프로세스라 동시 실행 가능. 터미널 두 개에서 각각 띄워서 사용하는 패턴이 일상.

## 설계 메모

- pyproject.toml / `[project.scripts]` 콘솔 entry point 는 본 저장소가 패키징 구조 (`ai/` 가 namespace 식) 가 아니라 더 큰 변경이 필요해 보류. 명령 7개 정도면 Makefile 한 장이 가장 가벼움.
- `scripts/` 디렉토리에는 한 번만 쓰는 ops 스크립트 (`cleanup-merged-branches.sh`) 가 있어서 분리 유지. 일상 명령은 Makefile.

## Test plan

- [x] `make help` 가 7개 타겟 출력 확인
- [ ] `make daemon-dev-relay` 실행 시 기존 `python -m ai.dev_relay.main` 와 동일하게 데몬 기동 (사용자 수동)
- [ ] `make daemon-coordinator` 실행 시 기존 `python -m ai.coordinator.main` 와 동일하게 데몬 기동 (사용자 수동)
- [ ] `make test` 가 484건 통과 (회귀 0건) — 사용자 PC 에서 1회 검증

## 다음 작업

- 명령이 더 늘면 그때 pyproject.toml + 콘솔 entry point 로 마이그레이션 검토 (지금은 7개라 굳이)
- HANDOFF.md 또는 README.md 에 "make help 부터 보세요" 한 줄 추가 (별도 docs PR)