### PR TITLE
chore(makefile): pip → python -m pip 교체 + PYTHON override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,35 @@
+PYTHON ?= python
+
 .PHONY: help install daemon daemon-dev-relay daemon-coordinator test test-dev-relay test-coordinator
 
 help:
 	@echo "Available targets:"
 	@echo "  install            - Install Python dependencies (ai/requirements.txt)"
 	@echo "  daemon             - Alias for daemon-dev-relay (most common)"
-	@echo "  daemon-dev-relay   - Run Hayoung Dev Manager bot (python -m ai.dev_relay.main)"
-	@echo "  daemon-coordinator - Run Hayoung AI Coordinator bot (python -m ai.coordinator.main)"
+	@echo "  daemon-dev-relay   - Run Hayoung Dev Manager bot ($(PYTHON) -m ai.dev_relay.main)"
+	@echo "  daemon-coordinator - Run Hayoung AI Coordinator bot ($(PYTHON) -m ai.coordinator.main)"
 	@echo "  test               - Run all pytest suites under ai/tests/"
 	@echo "  test-dev-relay     - Run dev_relay tests only"
 	@echo "  test-coordinator   - Run coordinator tests only"
+	@echo ""
+	@echo "Override interpreter via PYTHON=... (default: python from active venv/PATH)."
 
 install:
-	pip install -r ai/requirements.txt
+	$(PYTHON) -m pip install -r ai/requirements.txt
 
 daemon: daemon-dev-relay
 
 daemon-dev-relay:
-	python -m ai.dev_relay.main
+	$(PYTHON) -m ai.dev_relay.main
 
 daemon-coordinator:
-	python -m ai.coordinator.main
+	$(PYTHON) -m ai.coordinator.main
 
 test:
-	pytest ai/tests/ -v
+	$(PYTHON) -m pytest ai/tests/ -v
 
 test-dev-relay:
-	pytest ai/tests/dev_relay/ -v
+	$(PYTHON) -m pytest ai/tests/dev_relay/ -v
 
 test-coordinator:
-	pytest ai/tests/test_coordinator_*.py -v
+	$(PYTHON) -m pytest ai/tests/test_coordinator_*.py -v


### PR DESCRIPTION
## Summary

PR #33 직후 발견된 회귀 수정. uv-managed venv 처럼 `pip` shim 이 없는 환경에서 `make install` 이 다음 에러로 실패:

```
make: pip: No such file or directory
make: *** [install] Error 1
```

## 변경 범위

- `pip install ...` → `$(PYTHON) -m pip install ...`
- `pytest ...` → `$(PYTHON) -m pytest ...`
- `python -m ai.dev_relay.main` → `$(PYTHON) -m ai.dev_relay.main`
- `PYTHON ?= python` 변수 도입 — `make test PYTHON=python3.12` 같은 override 허용
- `make help` 마지막 줄에 override 사용법 한 줄 추가

## 동작 원리

`pip` shim 의 존재 여부와 무관하게 venv 의 `python` 만 PATH 에 있으면 모든 타겟이 동작. 이는 Python 패키징 표준 권장 방식이기도 함 (`pip` 대신 `python -m pip`).

## Test plan

- [x] `make help` 출력 갱신 확인
- [ ] `(.venv) $ make install` 가 `pip` shim 없이도 통과 (사용자 PC 에서 회귀 검증)
- [ ] `make test`, `make daemon-dev-relay`, `make daemon-coordinator` 정상 동작

## 다음 작업

- 사용자 환경에서 회귀 fix 가 통과하면 #33 의 follow-up 으로 종결
- venv 활성화 가이드 (HANDOFF.md / README.md) 가 필요해지면 별도 docs PR