### PR TITLE
chore(dev-relay): audit.jsonl 0600 권한 + _RateLimiter 단위 테스트

### DIFF
--- a/ai/dev_relay/main.py
+++ b/ai/dev_relay/main.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import importlib
 import json
 import logging
+import os
 import sys
 import time
 from collections import deque
@@ -88,11 +89,23 @@ def _audit_log_path() -> Path:
 
 
 def _append_audit(record: dict[str, Any]) -> None:
-    """audit.jsonl 한 줄 append. user_id 는 호출 측이 마스킹한 값을 넘긴다."""
+    """audit.jsonl 한 줄 append. user_id 는 호출 측이 마스킹한 값을 넘긴다.
+
+    PRD §3.8 — 신규 파일 생성 시 0600 권한 적용. 이미 존재하는 파일은 사용자가
+    명시적으로 권한을 풀어둔 경우를 존중해 그대로 둔다 (강제로 좁히지 않음).
+    부모 디렉터리는 `default_db_path()` 호출 측에서 0700 으로 보장된다.
+    """
     path = _audit_log_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    is_new = not path.exists()
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    if is_new:
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            # Windows 등 chmod 의미가 다른 환경에서 실패해도 본문 동작 차단 금지.
+            pass
 
 
 def _setup_logging(level: str) -> logging.Logger:

--- a/ai/tests/dev_relay/test_rate_limiter.py
+++ b/ai/tests/dev_relay/test_rate_limiter.py
@@ -1,0 +1,84 @@
+"""`_RateLimiter` 단위 테스트 (AC-15 회귀 보호).
+
+PRD `docs/prd/slack-dev-relay.md` §3.5 — 같은 user_id 가 5초 슬라이딩 윈도우
+내에서 4번째 명령부터 차단된다. `time.monotonic` 의존을 회피하기 위해
+`check(now=...)` 로 결정론적 시각을 주입한다.
+
+추출은 의도적으로 하지 않는다 (이슈 #28 의 권고이지 요구사항 아님).
+모듈 추출은 별도 PR 로 다룬다.
+"""
+
+from __future__ import annotations
+
+from ai.dev_relay.main import _RateLimiter
+
+
+class TestRateLimiterAllowAndBlock:
+    """AC-15: 5초 윈도우 내 3회까지 통과, 4회째부터 차단."""
+
+    def test_first_three_attempts_pass_then_fourth_blocked(self) -> None:
+        limiter = _RateLimiter()
+        # 5초 윈도우 내 (now 동일) 4번 시도.
+        assert limiter.check("U1", now=0.0) is True
+        assert limiter.check("U1", now=1.0) is True
+        assert limiter.check("U1", now=2.0) is True
+        # 4번째 시도는 차단.
+        assert limiter.check("U1", now=3.0) is False
+
+
+class TestRateLimiterWindowExpiry:
+    """5초 윈도우 경과 후 카운터 리셋 — 다시 통과해야 한다."""
+
+    def test_counter_resets_after_window(self) -> None:
+        limiter = _RateLimiter()
+        assert limiter.check("U1", now=0.0) is True
+        assert limiter.check("U1", now=0.5) is True
+        assert limiter.check("U1", now=1.0) is True
+        # 4번째는 윈도우 내라서 차단.
+        assert limiter.check("U1", now=1.5) is False
+        # 첫 시도 (now=0.0) 대비 5초+α 경과 — 첫 두 슬롯은 만료, 다시 통과 가능.
+        # 단, now=0.5 슬롯은 5.6 시점에 cutoff=0.6 보다 작아서 만료, now=1.0
+        # 슬롯도 만료 → bucket 비어있는 상태.
+        assert limiter.check("U1", now=5.6) is True
+
+
+class TestRateLimiterPerUserIsolation:
+    """다른 user_id 는 독립 카운터 — A 가 차단되어도 B 는 영향 없음."""
+
+    def test_users_are_isolated(self) -> None:
+        limiter = _RateLimiter()
+        # U1 을 한도까지 채운다.
+        assert limiter.check("U1", now=0.0) is True
+        assert limiter.check("U1", now=0.1) is True
+        assert limiter.check("U1", now=0.2) is True
+        assert limiter.check("U1", now=0.3) is False
+        # U2 는 같은 시각이지만 별도 버킷 — 한도 내에서 통과.
+        assert limiter.check("U2", now=0.3) is True
+        assert limiter.check("U2", now=0.4) is True
+        assert limiter.check("U2", now=0.5) is True
+        # U2 도 4번째는 차단.
+        assert limiter.check("U2", now=0.6) is False
+        # U1 은 여전히 차단 상태 (윈도우 내).
+        assert limiter.check("U1", now=0.7) is False
+
+
+class TestRateLimiterBoundary:
+    """경계값: 정확히 윈도우 경계 시각에서의 동작 명세.
+
+    구현은 `bucket[0] < cutoff` 로 만료 판정 — 정확히 5.0 초 차이는 아직
+    만료되지 않는다 (`bucket[0] == cutoff` 이므로 `<` 가 False). 본 테스트는
+    이 경계 동작을 못박아 향후 의도치 않은 변경을 잡는다.
+    """
+
+    def test_exactly_window_seconds_does_not_expire(self) -> None:
+        limiter = _RateLimiter()
+        # t=0 에 첫 슬롯 적재.
+        assert limiter.check("U1", now=0.0) is True
+        assert limiter.check("U1", now=0.0) is True
+        assert limiter.check("U1", now=0.0) is True
+        # t=5.0 — 윈도우 정확히 일치 (cutoff = 5.0 - 5.0 = 0.0). bucket[0]=0.0
+        # 은 `< 0.0` 이 False → 만료 안 됨 → 4번째 시도는 차단.
+        assert limiter.check("U1", now=5.0) is False
+        # t=5.0 + epsilon — cutoff = 0.0 + epsilon, bucket[0]=0.0 < cutoff
+        # → 만료 → 통과.
+        assert limiter.check("U1", now=5.000_001) is True

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -185,3 +185,42 @@
   - A.3~A.8 마저 진행해 전체 부록 A QA 완료
   - QA 보고서 (`docs/qa/dev-relay-natural-language.md`) 작성 후 `qa-passed` 라벨
   - **shell metachar 정책 완화 후속 PR** (`feat/dev-relay-shell-pipe-allow`) — `| head` / `2>/dev/null` 같은 read-only 패턴 한정 허용. A.2 검증 중 LLM 이 `gh pr view ... 2>/dev/null || ...` 시도하다 차단된 사례 다수.
+
+### 2026-05-05 — chore(dev-relay): audit.jsonl 0600 권한 + _RateLimiter 단위 테스트 (#36)
+
+- **slug**: `slack-dev-relay-audit-perm-ratelimit-test` · **author**: @HY0118
+- **PR**: https://github.com/deeptrading-lab/trading-signal-engine/pull/36
+- **요약**: chore(dev-relay): audit.jsonl 0600 권한 + _RateLimiter 단위 테스트
+- **현재 상태**: QA 통과 · 리뷰·머지 대기 (이 항목은 QA 통과 시점에 자동 기록됨)
+- **PR 본문 발췌**:
+  > ## 요약
+  > 
+  > 이슈 #28 follow-up 의 1번 항목 (audit 0600 + RateLimiter 테스트) 만 처리하는 mini-PR. shutdown watchdog (#28 의 다른 항목) 은 별도 PR 로 다룬다.
+  > 
+  > ## 변경 사항
+  > 
+  > 1. **`audit.jsonl` 0600 권한 적용** — `ai/dev_relay/main.py::_append_audit` 가 신규 파일 생성 시 `os.chmod(path, 0o600)` 호출. 이미 존재하는 파일은 사용자가 명시적으로 권한을 풀어둔 경우를 존중해 건드리지 않음. PRD `docs/prd/slack-dev-relay.md` §3.8 "로컬 파일 권한 — 파일 0600" 준수.
+  > 2. **`_RateLimiter` 단위 테스트 추가** — `ai/tests/dev_relay/test_rate_limiter.py`. AC-15 회귀 보호 4 케이스:
+  >    - 같은 user_id 5초 내 3회 통과 / 4회째 차단
+  >    - 윈도우 경과 후 카운터 리셋
+  >    - 다른 user_id 독립 카운터
+  >    - 정확히 윈도우 경계 시각 (5.0초) 동작 명세 (`bucket[0] < cutoff` 동작 못박기)
+  > 
+  > `time.monotonic` 의존 회피를 위해 `now=` 인자를 주입해 결정론적 테스트.
+  > 
+  > ## 의도적으로 하지 않은 것
+  > 
+  > - `_RateLimiter` 모듈 추출 — 이슈 #28 본문의 권고이지 요구사항이 아님. blast radius 최소화를 위해 별도 PR 로 다룬다.
+  > - shutdown watchdog (#28 의 별도 항목) — 다음 PR.
+  > 
+  > ## 수용 기준 체크리스트
+  > 
+  > - [x] 신규 audit.jsonl 파일이 0600 권한으로 생성된다
+  > - [x] 기존 파일은 chmod 호출 없이 그대로 둔다
+  > - [x] `_RateLimiter` 4 케이스 테스트 통과
+  > - [x] 전체 회귀: `pytest ai/tests/ -q` 509 passed
+  > - [x] 빠른 재현: `pytest ai/tests/dev_relay/test_rate_limiter.py -v`
+  > 
+  > ## 참고
+  > 
+- **다음 작업 후보**: _PR 본문에 별도 섹션 없음. 본문 참고하여 판단._


### PR DESCRIPTION
## 요약

이슈 #28 follow-up 의 1번 항목 (audit 0600 + RateLimiter 테스트) 만 처리하는 mini-PR. shutdown watchdog (#28 의 다른 항목) 은 별도 PR 로 다룬다.

## 변경 사항

1. **`audit.jsonl` 0600 권한 적용** — `ai/dev_relay/main.py::_append_audit` 가 신규 파일 생성 시 `os.chmod(path, 0o600)` 호출. 이미 존재하는 파일은 사용자가 명시적으로 권한을 풀어둔 경우를 존중해 건드리지 않음. PRD `docs/prd/slack-dev-relay.md` §3.8 "로컬 파일 권한 — 파일 0600" 준수.
2. **`_RateLimiter` 단위 테스트 추가** — `ai/tests/dev_relay/test_rate_limiter.py`. AC-15 회귀 보호 4 케이스:
   - 같은 user_id 5초 내 3회 통과 / 4회째 차단
   - 윈도우 경과 후 카운터 리셋
   - 다른 user_id 독립 카운터
   - 정확히 윈도우 경계 시각 (5.0초) 동작 명세 (`bucket[0] < cutoff` 동작 못박기)

`time.monotonic` 의존 회피를 위해 `now=` 인자를 주입해 결정론적 테스트.

## 의도적으로 하지 않은 것

- `_RateLimiter` 모듈 추출 — 이슈 #28 본문의 권고이지 요구사항이 아님. blast radius 최소화를 위해 별도 PR 로 다룬다.
- shutdown watchdog (#28 의 별도 항목) — 다음 PR.

## 수용 기준 체크리스트

- [x] 신규 audit.jsonl 파일이 0600 권한으로 생성된다
- [x] 기존 파일은 chmod 호출 없이 그대로 둔다
- [x] `_RateLimiter` 4 케이스 테스트 통과
- [x] 전체 회귀: `pytest ai/tests/ -q` 509 passed
- [x] 빠른 재현: `pytest ai/tests/dev_relay/test_rate_limiter.py -v`

## 참고

- PRD: `docs/prd/slack-dev-relay.md` §3.5 (rate limit), §3.8 (파일 권한)
- 테스트: `ai/tests/dev_relay/test_rate_limiter.py`

Refs #28