### PR TITLE
fix(dev-relay): AgentRunner.shutdown(timeout) watchdog 보강

### DIFF
--- a/ai/dev_relay/agent_runner.py
+++ b/ai/dev_relay/agent_runner.py
@@ -112,13 +112,45 @@ class AgentRunner:
     def shutdown(self, *, wait: bool = True, timeout: float | None = None) -> None:
         """graceful shutdown.
 
-        `wait=True` 면 진행 중·대기 중 task 가 모두 끝날 때까지 블록한다.
-        `timeout` 은 ThreadPoolExecutor 가 직접 지원하지 않으므로 본 PRD 범위에서는
-        호출자가 별도 watchdog thread 로 강제 종료를 구현한다.
+        - `wait=False`: executor 에 더 이상 task 를 받지 않게 표시하고 즉시 반환.
+        - `wait=True` + `timeout=None`: 진행 중·대기 중 task 가 모두 끝날 때까지 블록.
+        - `wait=True` + `timeout` 지정: 별도 worker thread 에서 `executor.shutdown(
+          wait=True)` 를 수행하고 `timeout` 초 동안만 join 한다. timeout 안에 끝나면
+          정상 반환, 안 끝나면 `executor.shutdown(wait=False)` 로 신규 작업만 차단한
+          뒤 WARNING 을 남기고 반환한다 (PRD §3.7 graceful shutdown 30초 보장).
+          ThreadPoolExecutor 는 진행 중인 task 를 강제 중단할 수 없으므로 worker
+          thread 자체는 task 가 끝날 때까지 살아 있을 수 있으나, 데몬 스레드라 호출
+          프로세스 종료를 막지는 않는다.
         """
         with self._lock:
             if self._closed:
                 return
             self._closed = True
-        # cancel_futures 는 Python 3.9+ 지원.
-        self._executor.shutdown(wait=wait, cancel_futures=False)
+
+        if not wait:
+            # 신규 task 만 거절하고 즉시 반환.
+            self._executor.shutdown(wait=False, cancel_futures=False)
+            return
+
+        if timeout is None:
+            # cancel_futures 는 Python 3.9+ 지원.
+            self._executor.shutdown(wait=True, cancel_futures=False)
+            return
+
+        # wait=True + timeout: 별도 thread 에서 wait=True shutdown 을 돌리고 join 으로 timeout.
+        def _drain() -> None:
+            self._executor.shutdown(wait=True, cancel_futures=False)
+
+        drainer = threading.Thread(
+            target=_drain,
+            name="dev-relay-agent-shutdown",
+            daemon=True,
+        )
+        drainer.start()
+        drainer.join(timeout)
+        if drainer.is_alive():
+            _LOGGER.warning(
+                "shutdown timeout exceeded (%.1fs) — forcing", timeout
+            )
+            # 신규 task 차단·worker 스레드는 task 종료 시 자연 회수된다.
+            self._executor.shutdown(wait=False, cancel_futures=False)

--- a/ai/dev_relay/main.py
+++ b/ai/dev_relay/main.py
@@ -93,7 +93,7 @@ def _append_audit(record: dict[str, Any]) -> None:
 
     PRD §3.8 — 신규 파일 생성 시 0600 권한 적용. 이미 존재하는 파일은 사용자가
     명시적으로 권한을 풀어둔 경우를 존중해 그대로 둔다 (강제로 좁히지 않음).
-    부모 디렉터리는 `default_db_path()` 호출 측에서 0700 으로 보장된다.
+    부모 디렉터리(0700) 는 `JobQueue::_ensure_dir_secure` 가 보장한다.
     """
     path = _audit_log_path()
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/ai/tests/dev_relay/test_agent_runner_shutdown.py
+++ b/ai/tests/dev_relay/test_agent_runner_shutdown.py
@@ -1,0 +1,93 @@
+"""`AgentRunner.shutdown(timeout)` watchdog 단위 테스트 (Issue #28 항목 2).
+
+PRD §3.7 graceful shutdown 30초 timeout 의 코드 보장. ThreadPoolExecutor 자체는
+timeout 을 지원하지 않으므로 별도 watchdog timer 가 강제 종료를 책임진다.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from ai.dev_relay.agent_runner import AgentRunner, AgentTask
+
+
+_LOGGER_NAME = "ai.dev_relay.agent_runner"
+
+
+def _task(job_id: int = 1) -> AgentTask:
+    return AgentTask(job_id=job_id, command="echo")
+
+
+class TestShutdownWatchdog:
+    def test_fast_task_completes_within_timeout(self, caplog: pytest.LogCaptureFixture) -> None:
+        """빠른 task — watchdog 발동 없이 정상 종료."""
+        runner = AgentRunner()
+        future = runner.run_callable(_task(), lambda: time.sleep(0.05) or "ok")
+
+        caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+        start = time.monotonic()
+        runner.shutdown(wait=True, timeout=1.0)
+        elapsed = time.monotonic() - start
+
+        assert future.result(timeout=0.5) == "ok"
+        assert elapsed < 0.5, f"shutdown 이 너무 오래 걸림: {elapsed:.3f}s"
+        # watchdog WARNING 이 남지 않아야 한다.
+        forced = [
+            rec for rec in caplog.records
+            if rec.name == _LOGGER_NAME and "forcing" in rec.getMessage()
+        ]
+        assert forced == []
+
+    def test_slow_task_triggers_force_shutdown(self, caplog: pytest.LogCaptureFixture) -> None:
+        """느린 task — timeout 직후 watchdog 이 강제 종료를 발동."""
+        runner = AgentRunner()
+        runner.run_callable(_task(), lambda: time.sleep(2.0))
+
+        caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+        start = time.monotonic()
+        runner.shutdown(wait=True, timeout=0.2)
+        elapsed = time.monotonic() - start
+
+        # timeout=0.2 직후에 풀려나야 한다 (~0.3초 이내).
+        assert elapsed < 0.5, f"watchdog 이 강제 종료를 못 함: {elapsed:.3f}s"
+        forced = [
+            rec for rec in caplog.records
+            if rec.name == _LOGGER_NAME and "forcing" in rec.getMessage()
+        ]
+        assert len(forced) == 1, f"WARNING 1건 기대, got: {[r.getMessage() for r in caplog.records]}"
+        assert "0.2" in forced[0].getMessage()
+
+    def test_no_timeout_does_not_register_watchdog(self, caplog: pytest.LogCaptureFixture) -> None:
+        """`timeout=None` — 기존 동작 유지, watchdog 미등록."""
+        runner = AgentRunner()
+        runner.run_callable(_task(), lambda: time.sleep(0.05))
+
+        caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+        runner.shutdown(wait=True)  # timeout=None default
+
+        forced = [
+            rec for rec in caplog.records
+            if rec.name == _LOGGER_NAME and "forcing" in rec.getMessage()
+        ]
+        assert forced == []
+
+    def test_wait_false_skips_watchdog(self, caplog: pytest.LogCaptureFixture) -> None:
+        """`wait=False` — watchdog 미등록, 즉시 반환."""
+        runner = AgentRunner()
+        runner.run_callable(_task(), lambda: time.sleep(0.5))
+
+        caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+        start = time.monotonic()
+        runner.shutdown(wait=False, timeout=0.1)
+        elapsed = time.monotonic() - start
+
+        # wait=False 면 즉시 반환되어야 한다 — timeout 인자는 무시.
+        assert elapsed < 0.1
+        forced = [
+            rec for rec in caplog.records
+            if rec.name == _LOGGER_NAME and "forcing" in rec.getMessage()
+        ]
+        assert forced == []

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -224,3 +224,42 @@
   > ## 참고
   > 
 - **다음 작업 후보**: _PR 본문에 별도 섹션 없음. 본문 참고하여 판단._
+
+### 2026-05-05 — fix(dev-relay): AgentRunner.shutdown(timeout) watchdog 보강 (#37)
+
+- **slug**: `slack-dev-relay-shutdown-watchdog` · **author**: @HY0118
+- **PR**: https://github.com/deeptrading-lab/trading-signal-engine/pull/37
+- **요약**: fix(dev-relay): AgentRunner.shutdown(timeout) watchdog 보강
+- **현재 상태**: QA 통과 · 리뷰·머지 대기 (이 항목은 QA 통과 시점에 자동 기록됨)
+- **PR 본문 발췌**:
+  > ## 범위
+  > Issue #28 항목 2 (shutdown watchdog) + PR #36 nit 이월 1건.
+  > 
+  > ## 배경
+  > `AgentRunner.shutdown(timeout=...)` 은 timeout 인자를 받지만 `ThreadPoolExecutor.shutdown` 이 timeout 을 지원하지 않아 무시되고 있었다. 호출 측 `ai/dev_relay/main.py:809` 에서 30초 timeout 을 넘기지만 실제로는 무한 대기. PRD `docs/prd/slack-dev-relay.md` §3.7 (graceful shutdown 30초 timeout) 의 의도를 코드로 보장한다.
+  > 
+  > ## 변경
+  > ### 1) `AgentRunner.shutdown` watchdog (`ai/dev_relay/agent_runner.py`)
+  > - `wait=True` + `timeout` 지정: 별도 daemon thread (`dev-relay-agent-shutdown`) 에서 `executor.shutdown(wait=True)` 를 수행하고 `thread.join(timeout)` 로 대기. timeout 만료 시 `executor.shutdown(wait=False)` 로 신규 task 만 차단하고 WARNING 로그 (`shutdown timeout exceeded (%.1fs) — forcing`).
+  > - `wait=True` + `timeout=None`: 기존 동작 (무한 대기) 유지.
+  > - `wait=False`: 기존 동작 (즉시 반환) 유지.
+  > - docstring 의 "호출자가 별도 watchdog thread 로 강제 종료를 구현한다" 문구 제거.
+  > - 호출 측 `main.py:809` 는 손대지 않음 (회귀 보호).
+  > 
+  > ### 2) PR #36 nit 이월 (`ai/dev_relay/main.py::_append_audit`)
+  > - docstring 한 줄: `"부모 디렉터리는 default_db_path() 호출 측에서 0700 으로 보장된다"` → `"부모 디렉터리(0700) 는 JobQueue::_ensure_dir_secure 가 보장한다."`. 코드 동작 변경 없음.
+  > 
+  > ## 테스트 (`ai/tests/dev_relay/test_agent_runner_shutdown.py`, 신규)
+  > - 빠른 task → timeout 안 걸림, watchdog WARNING 0건.
+  > - 느린 task (2s sleep) → `timeout=0.2` 만료 후 ~0.3초 이내 반환 + WARNING 1건.
+  > - `timeout=None` → watchdog 미등록, 정상 종료.
+  > - `wait=False` → watchdog 미등록, 즉시 반환.
+  > 
+  > 전체 회귀: `pytest -q` → 513 passed, 0 failures.
+  > 
+  > ## 수용 기준
+  > - [x] `AgentRunner.shutdown(wait=True, timeout=T)` 가 T 초 안에 반환된다 (worker task 가 더 오래 걸려도).
+  > - [x] timeout 만료 시 WARNING 로그 (`shutdown timeout exceeded`) 가 한 번 남는다.
+  > - [x] `wait=True, timeout=None` / `wait=False` 기존 호출은 회귀 없음.
+  > - [x] 호출 측 `main.py:809` 무수정.
+- **다음 작업 후보**: _PR 본문에 별도 섹션 없음. 본문 참고하여 판단._


### PR DESCRIPTION
## 범위
Issue #28 항목 2 (shutdown watchdog) + PR #36 nit 이월 1건.

## 배경
`AgentRunner.shutdown(timeout=...)` 은 timeout 인자를 받지만 `ThreadPoolExecutor.shutdown` 이 timeout 을 지원하지 않아 무시되고 있었다. 호출 측 `ai/dev_relay/main.py:809` 에서 30초 timeout 을 넘기지만 실제로는 무한 대기. PRD `docs/prd/slack-dev-relay.md` §3.7 (graceful shutdown 30초 timeout) 의 의도를 코드로 보장한다.

## 변경
### 1) `AgentRunner.shutdown` watchdog (`ai/dev_relay/agent_runner.py`)
- `wait=True` + `timeout` 지정: 별도 daemon thread (`dev-relay-agent-shutdown`) 에서 `executor.shutdown(wait=True)` 를 수행하고 `thread.join(timeout)` 로 대기. timeout 만료 시 `executor.shutdown(wait=False)` 로 신규 task 만 차단하고 WARNING 로그 (`shutdown timeout exceeded (%.1fs) — forcing`).
- `wait=True` + `timeout=None`: 기존 동작 (무한 대기) 유지.
- `wait=False`: 기존 동작 (즉시 반환) 유지.
- docstring 의 "호출자가 별도 watchdog thread 로 강제 종료를 구현한다" 문구 제거.
- 호출 측 `main.py:809` 는 손대지 않음 (회귀 보호).

### 2) PR #36 nit 이월 (`ai/dev_relay/main.py::_append_audit`)
- docstring 한 줄: `"부모 디렉터리는 default_db_path() 호출 측에서 0700 으로 보장된다"` → `"부모 디렉터리(0700) 는 JobQueue::_ensure_dir_secure 가 보장한다."`. 코드 동작 변경 없음.

## 테스트 (`ai/tests/dev_relay/test_agent_runner_shutdown.py`, 신규)
- 빠른 task → timeout 안 걸림, watchdog WARNING 0건.
- 느린 task (2s sleep) → `timeout=0.2` 만료 후 ~0.3초 이내 반환 + WARNING 1건.
- `timeout=None` → watchdog 미등록, 정상 종료.
- `wait=False` → watchdog 미등록, 즉시 반환.

전체 회귀: `pytest -q` → 513 passed, 0 failures.

## 수용 기준
- [x] `AgentRunner.shutdown(wait=True, timeout=T)` 가 T 초 안에 반환된다 (worker task 가 더 오래 걸려도).
- [x] timeout 만료 시 WARNING 로그 (`shutdown timeout exceeded`) 가 한 번 남는다.
- [x] `wait=True, timeout=None` / `wait=False` 기존 호출은 회귀 없음.
- [x] 호출 측 `main.py:809` 무수정.
- [x] docstring 의 잘못된 책임 위치 정정 (PR #36 이월).

## 비고
- Issue #28 항목 3 (deferred AC 통합) 은 본 PR 범위 밖. 따라서 이슈 클로즈 안 함.
- 한국어 docstring·커밋·PR 본문 (`AGENTS.md` 규칙).

Refs #28