### PR TITLE
docs(qa): handoff-session-notes 리포트 backfill

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -306,3 +306,34 @@
   - (선택) 다음 세션 시작 시 본 PR 의 SESSION_NOTES 최신 항목을 컨텍스트로 사용. 동작이 의도대로면 정책 정착, 아니면 옵션 1/2 추가 검토.
   - `dev-relay-agent-integration` PRD 초안 [별도 PR](docs/prd/dev-relay-agent-integration.md) 로 처리 (사용자 검토 후).
   - shell metachar 정책 완화 (`feat/dev-relay-shell-pipe-allow`) — 직전 세션 P1, 추천 다음 트랙 1순위.
+
+### 2026-05-05 — docs(qa): handoff-session-notes 리포트 backfill (#39)
+
+- **slug**: `qa-handoff-session-notes-backfill` · **author**: @HY0118
+- **PR**: https://github.com/deeptrading-lab/trading-signal-engine/pull/39
+- **요약**: docs(qa): handoff-session-notes 리포트 backfill
+- **현재 상태**: QA 통과 · 리뷰·머지 대기 (이 항목은 QA 통과 시점에 자동 기록됨)
+- **PR 본문 발췌**:
+  > ## Summary
+  > 
+  > - PR #38 머지 후 사후 작성된 QA 리포트(`docs/qa/handoff-session-notes.md`)를 단독 chore PR 로 backfill.
+  > - 리포트 자체는 PR #38 QA 통과 시점에 검증된 것 (5/5 AC PASS, 회귀 513 passed). 본 PR 에서 다시 검증 불필요.
+  > 
+  > ## 배경
+  > 
+  > PR #38 자체에 QA 리포트를 동봉하지 못한 이유 — QA 에이전트가 PR #38 머지 직후 리포트를 작성했고 (자동 hook 없음), main 으로 commit 되지 않은 채 워킹 디렉토리에만 남아 있었다. 새 세션에서 untracked 상태로 발견되어 분리 PR 로 처리.
+  > 
+  > ## Test plan
+  > 
+  > - [x] 파일 내용은 PR #38 QA 통과 시점에 이미 검증됨.
+  > - [ ] reviewer 가 본 PR 자체를 검토 (docs-only chore).
+  > 
+  > ## 다음 작업
+  > 
+  > - (구조 보강 후순위) QA 에이전트가 PR 머지 직후 리포트를 자동 동봉하도록 자동화 검토 — 본 PR 처럼 backfill 필요 사례가 반복되면 진행.
+  > 
+  > ## Refs
+  > 
+  > - PR #38 (SESSION_NOTES 도입, merged `3dbb3ca`)
+- **다음 작업 후보** (PR 본문 기반, 절대적 지시 아님):
+  - (구조 보강 후순위) QA 에이전트가 PR 머지 직후 리포트를 자동 동봉하도록 자동화 검토 — 본 PR 처럼 backfill 필요 사례가 반복되면 진행.

--- a/docs/qa/handoff-session-notes.md
+++ b/docs/qa/handoff-session-notes.md
@@ -1,0 +1,132 @@
+# QA: SESSION_NOTES.md 신설 + 직전·당일 세션 backfill (PR #38)
+
+- **slug**: `handoff-session-notes`
+- **PR**: [#38 docs: SESSION_NOTES.md 신설 + 직전·당일 세션 backfill](https://github.com/deeptrading-lab/trading-signal-engine/pull/38)
+- **브랜치**: `feature/handoff-session-notes` @ `ae41f30`
+- **PRD**: 신규 PRD 없음 — PR 본문이 spec 역할 (docs-only PR).
+- **QA**: Codex (자동), 2026-05-06
+- **판정**: **qa-passed**
+
+---
+
+## 1. 변경 범위 요약
+
+| 파일 | 종류 | 라인 수 |
+|------|------|---------|
+| `docs/SESSION_NOTES.md` | 신규 (형식 가이드 + 2건 backfill) | +109 |
+| `docs/HANDOFF.md` | 수정 (안내 문구 — SESSION_NOTES 참조 1줄 추가, 수동 append 문구 1줄 정리) | +3 / -2 |
+| `docs/qa/slack-dev-relay-audit-perm-ratelimit-test.md` | 신규 (PR #36 누락 동봉) | +168 |
+| `docs/qa/slack-dev-relay-shutdown-watchdog.md` | 신규 (PR #37 누락 동봉) | +111 |
+
+`.github/workflows/` 변경 0건. `ai/**`, `scripts/**` 코드 변경 0건 — 순수 docs PR.
+
+---
+
+## 2. 수용 기준 → 검증 매핑
+
+| # | AC | 검증 방법 | 결과 |
+|---|----|-----------|------|
+| AC-1 | `docs/SESSION_NOTES.md` 존재 + 형식 가이드(작성 시점·작성 형식·정책) 명확 | `Read docs/SESSION_NOTES.md` — L1-48 가이드 블록에 `## 작성 시점`, `## 작성 형식`, `## 정책` 세 소섹션이 채워져 있고, 형식 예시 코드블록(L24-42)에 `## YYYY-MM-DD — 세션 제목` / `### 처리한 일` / `### 결정·합의 사항` / `### 다음 세션 시작 포인트 (follow-up 표)` / `### 미결·블록` 골격 명시. | PASS |
+| AC-2 | backfill 정확성 — 직전 세션 P1/P2/P3 5건 표 + 당일 세션 PR #36/#37 SHA·PRD 경로 일치 | (a) 2026-05-05 backfill 표 (L64-70): P1×2, P2×2, P3×1 = **5건** 일치. (b) 2026-05-06 항목 (L80-83): PR #36 SHA `59e6001` ↔ `gh pr view 36 --json mergeCommit` = `59e6001a5d01d1a4a22c619df5a97b3a184400a0` (선두 7자 일치). PR #37 SHA `6024eb3` ↔ `6024eb3cc2c9ec8ccbd2a35b86e9252533779849` (일치). PRD 경로 `prd/dev-relay-agent-integration.md` ↔ 실제 파일 (별도 PR로 처리 예정 — 본 PR 시점에 미존재이나 본문에 명시). Issue #28 OPEN ↔ `gh issue view 28` = OPEN. | PASS |
+| AC-3 | HANDOFF.md 변경이 기존 자동화에 영향 없음 | `git diff main...feature/handoff-session-notes -- .github/` → 출력 0건 (워크플로우 파일 무수정). HANDOFF.md diff 는 안내 문구(`> ...`) 두 줄 변경만으로 `handoff-append.yml` 의 `## 다음 작업` 추출 정규식 대상은 PR 본문이라 무관. 추출 로직과 형식 (`### YYYY-MM-DD — 제목 (#PR / slug)`) 헤더는 무수정. | PASS |
+| AC-4 | QA 리포트 2건 동봉 정합성 — qa-passed 판정 + AC 매핑 명시 | `docs/qa/slack-dev-relay-audit-perm-ratelimit-test.md` L8 = `**판정**: **qa-passed**`, AC-1/AC-2/AC-15-a~d 6항목 매핑 + 각각 PASS. `docs/qa/slack-dev-relay-shutdown-watchdog.md` L10 = `**판정**: **qa-passed**`, AC-1~AC-5 5항목 매핑 + 각각 PASS. 양쪽 모두 재현 절차/명령/실제 결과 로그 동봉. | PASS |
+| AC-5 | 컴플라이언스 — 본문에 도메인 키워드 평문 노출 없음 (`ai/coordinator/_compliance.py::FORBIDDEN_KEYWORDS`) | `find_forbidden_keywords` 매치 결과: `['signal', 'trading']` — 단, 매치는 모두 GitHub URL 의 리포지토리명 `trading-signal-engine` 에서만 발생 (브랜드/리포 식별자, `main` 브랜치 HANDOFF.md 도 동일 패턴 보유). 본 가드의 정책 대상은 코디네이터/dev-relay 가 Slack 으로 외부 발사하는 텍스트이며, 사내 docs 파일은 적용 대상이 아님. URL 외 평문 노출 0건 (`grep -v 'trading-signal-engine'` → empty). | PASS |
+
+---
+
+## 3. 재현 절차
+
+### 3.1 환경 셋업
+
+```bash
+git fetch origin
+git checkout feature/handoff-session-notes
+```
+
+브랜치 상태: HEAD = `ae41f30 docs: SESSION_NOTES.md 신설 + 직전·당일 세션 backfill`.
+
+### 3.2 메타 사실관계 (SHA·이슈 상태)
+
+```bash
+gh pr view 36 --json mergeCommit         # → 59e6001a5d01d1a4a22c619df5a97b3a184400a0
+gh pr view 37 --json mergeCommit         # → 6024eb3cc2c9ec8ccbd2a35b86e9252533779849
+gh issue view 28 --json state            # → OPEN
+```
+
+`docs/SESSION_NOTES.md` L80/L81 기재 SHA 와 일치. Issue #28 미클로즈 정책(항목 3 미완) 일치.
+
+### 3.3 워크플로우 무영향 확인
+
+```bash
+git diff main...feature/handoff-session-notes --stat -- .github/
+# (출력 없음 → 워크플로우 파일 변경 0건)
+```
+
+### 3.4 컴플라이언스 가드 통과 확인
+
+```bash
+python -c "
+from ai.coordinator._compliance import find_forbidden_keywords
+for path in ['docs/SESSION_NOTES.md', 'docs/HANDOFF.md',
+             'docs/qa/slack-dev-relay-audit-perm-ratelimit-test.md',
+             'docs/qa/slack-dev-relay-shutdown-watchdog.md']:
+    text = open(path).read()
+    print(path, '->', find_forbidden_keywords(text))
+"
+```
+
+기대 결과: 모든 파일에서 매치는 `['signal', 'trading']` 두 단어뿐이며, 출처는 GitHub URL `trading-signal-engine` (브랜드/리포명) 만.
+
+URL 외 잔존 검사:
+
+```bash
+grep -nEi '\b(signal|trade|trading|desk|quant|finance|market|ticker|pnl)\b' \
+  docs/SESSION_NOTES.md docs/qa/slack-dev-relay-audit-perm-ratelimit-test.md \
+  docs/qa/slack-dev-relay-shutdown-watchdog.md \
+  | grep -v 'trading-signal-engine'
+# (출력 없음 → URL 외 평문 노출 0건)
+```
+
+### 3.5 회귀 테스트
+
+docs-only 변경이라 강제 아님. 안전 차원에서 수행:
+
+```bash
+python -m pytest -q
+# 513 passed in 0.76s
+```
+
+기존 회귀 (PR #37 머지 시점 513 passed) 와 동일 — 회귀 0건.
+
+---
+
+## 4. 에지 케이스 점검
+
+| 시나리오 | 처리 | 결과 |
+|----------|------|------|
+| **handoff-append.yml 자동 트리거 — 본 PR 자체에 `qa-passed` 라벨이 붙을 때 자기 자신 entry 생성** | PR #27 (`handoff-system`) 머지 시점에 같은 케이스 (`자가 트리거`) 가 검증 통과한 사례 있음 (PR #27 본문 Test plan 참조). 본 PR 도 동일 흐름으로 처리되며, append 대상은 HANDOFF.md 이고 SESSION_NOTES.md 와 무간섭. | OK (사례 검증됨) |
+| **HANDOFF.md 안내 문구 변경 후 `## 다음 작업` 추출 로직** | 추출 대상은 PR description (GitHub API), HANDOFF.md 텍스트 아님. 안내 문구 변경은 워크플로우 입력에 영향 없음. | OK (정적 무관) |
+| **SESSION_NOTES.md 형식 일탈 (다음 세션이 가이드와 다른 형식으로 append)** | 본 PR 정책(L46-48) 이 "절대적 지시 아님" 명시 — 다음 세션 작성자 자유 판단. 자동화 검증 대상 아님. | 정책상 허용 |
+| **이미지 기반 backfill — 직전 세션 P1/P2/P3 5건 출처는 사용자 캡처 이미지** | 사용자 측 1차 사실관계. 본 QA 는 PR 본문 + 표 형식이 spec 과 일치하는지만 검증. 5건 카운트·우선순위 라벨(P1/P2/P3) 일관성은 표 자체에서 확인 (P1×2 + P2×2 + P3×1 = 5). | OK (형식 검증) |
+| **Issue #28 클로즈 시점 — SESSION_NOTES.md L107 "OPEN 유지" 기재** | `gh issue view 28 --json state` = OPEN, 일치. 항목 3 (deferred AC 통합) PRD 만 작성하고 구현 미착수 — SESSION_NOTES L82, L107 두 곳에 일관 기재. | OK (정합) |
+| **거래소 서버 다운·네트워크 지연·API 레이트리밋·뉴스 피드 장애** | docs-only PR 로 외부 시스템 호출 경로 무관. dev-relay 내부 회귀는 §3.5 pytest 513 passed 로 갈음. | 비해당 |
+| **컴플라이언스 — 새 슬러그(`handoff-session-notes`) 가 키워드 매치** | `handoff` / `session` / `notes` 모두 `FORBIDDEN_KEYWORDS` 미포함. | OK |
+
+---
+
+## 5. 실행 환경
+
+- Python: 시스템 default
+- 작업 디렉토리: `/Applications/하영/code_source/trading-signal-engine`
+- 브랜치: `feature/handoff-session-notes` @ `ae41f30`
+
+---
+
+## 6. 결론
+
+- 5개 AC 모두 PASS (실패 0건).
+- 회귀 테스트 513/513 통과.
+- 워크플로우 자동화 무영향 확인.
+- 컴플라이언스 가드 — URL 외 평문 노출 0건.
+
+**판정: qa-passed**. `qa-passed` 라벨 부여, `impl-ready` 라벨이 있으면 제거.


### PR DESCRIPTION
## Summary

- PR #38 머지 후 사후 작성된 QA 리포트(`docs/qa/handoff-session-notes.md`)를 단독 chore PR 로 backfill.
- 리포트 자체는 PR #38 QA 통과 시점에 검증된 것 (5/5 AC PASS, 회귀 513 passed). 본 PR 에서 다시 검증 불필요.

## 배경

PR #38 자체에 QA 리포트를 동봉하지 못한 이유 — QA 에이전트가 PR #38 머지 직후 리포트를 작성했고 (자동 hook 없음), main 으로 commit 되지 않은 채 워킹 디렉토리에만 남아 있었다. 새 세션에서 untracked 상태로 발견되어 분리 PR 로 처리.

## Test plan

- [x] 파일 내용은 PR #38 QA 통과 시점에 이미 검증됨.
- [ ] reviewer 가 본 PR 자체를 검토 (docs-only chore).

## 다음 작업

- (구조 보강 후순위) QA 에이전트가 PR 머지 직후 리포트를 자동 동봉하도록 자동화 검토 — 본 PR 처럼 backfill 필요 사례가 반복되면 진행.

## Refs

- PR #38 (SESSION_NOTES 도입, merged `3dbb3ca`)