### PR TITLE
feat(dev-relay): 에이전트 통합 — reviewer 결과·실 머지·동시성 큐 적재

### DIFF
--- a/ai/dev_relay/audit_recovery.py
+++ b/ai/dev_relay/audit_recovery.py
@@ -1,0 +1,70 @@
+"""
+재시작 복구 — audit.jsonl 기반 머지 carve-out 식별 (Dev Manager).
+
+PRD `dev-relay-agent-integration.md` §3.1:
+- `merge_started` 라인은 있는데 `merge_done`/`merge_failed` 라인이 없는 job 은
+  GitHub 측 머지가 이미 성사됐을 가능성이 있어 단순 `failed` 마킹 금지.
+- 본 모듈은 audit.jsonl 1회 스캔으로 그 후보 job_id 집합을 산출한다.
+
+audit.jsonl 이 없거나 손상된 경우는 빈 set 반환 — 호출 측은 종래 fallback
+(`failed` 마킹) 으로 진행한다.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+_LOGGER = logging.getLogger("ai.dev_relay.audit_recovery")
+
+
+_MERGE_KIND_START = "merge_started"
+_MERGE_KIND_TERMINAL = frozenset({"merge_done", "merge_failed"})
+
+
+def find_merge_in_flight_job_ids(audit_path: Path) -> frozenset[int]:
+    """audit.jsonl 에서 carve-out 대상 job_id 집합을 산출.
+
+    - `merge_started` 가 있으면 후보에 추가.
+    - 같은 job_id 의 `merge_done` / `merge_failed` 가 뒤따르면 제거.
+    - 본 함수는 데몬 시작 시 1회만 호출되며, 호출 비용은 audit 라인 수에 선형.
+      MVP 기준 audit.jsonl 은 single-user / 일 단위 회전 전제라 무시 가능 수준.
+    """
+    if not audit_path.exists():
+        return frozenset()
+
+    started: set[int] = set()
+    try:
+        with audit_path.open("r", encoding="utf-8") as f:
+            for raw in f:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    # 손상된 라인은 건너뛴다 — 다른 정상 라인의 carve-out 식별을
+                    # 막지 않기 위함.
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                kind = record.get("kind")
+                job_id = record.get("job_id")
+                if not isinstance(kind, str) or not isinstance(job_id, int):
+                    continue
+                if kind == _MERGE_KIND_START:
+                    started.add(job_id)
+                elif kind in _MERGE_KIND_TERMINAL:
+                    started.discard(job_id)
+    except OSError as exc:
+        _LOGGER.warning(
+            "audit.jsonl 읽기 실패 (%s) — carve-out 식별 생략.",
+            type(exc).__name__,
+        )
+        return frozenset()
+
+    return frozenset(started)
+
+
+__all__ = ["find_merge_in_flight_job_ids"]

--- a/ai/dev_relay/failures.py
+++ b/ai/dev_relay/failures.py
@@ -1,0 +1,122 @@
+"""
+실패 분류 매핑 (Dev Manager — agent integration).
+
+PRD `dev-relay-agent-integration.md` §3.5: reviewer / merge 호출 실패는 다음
+5개 분류 중 하나로 매핑되어야 한다 — 그 외는 `unknown_error` fallback.
+
+| 분류                        | 트리거                                       |
+|-----------------------------|---------------------------------------------|
+| `destructive_blocked`       | `assert_no_destructive_intent` raise        |
+| `sdk_timeout`               | SDK 호출이 watchdog timeout 초과            |
+| `github_unauthorized`       | `gh` / API 401·403                          |
+| `github_unprocessable`      | `gh` / API 422 (mergeable=false 등)         |
+| `compliance_blocked`        | `slack_renderer` 가드가 발사 차단            |
+
+본 모듈은 외부 라이브러리 의존이 없는 순수 매핑 로직만 담는다 — 테스트 가능성
+극대화. 분류 결과는 `(classification, user_message)` 튜플 — 사용자 노출
+메시지는 `slack_renderer` 의 정적 템플릿을 그대로 인용한다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from ai.dev_relay.slack_renderer import (
+    TEMPLATE_FAIL_COMPLIANCE_BLOCKED,
+    TEMPLATE_FAIL_DESTRUCTIVE_BLOCKED,
+    TEMPLATE_FAIL_GITHUB_UNAUTHORIZED,
+    TEMPLATE_FAIL_GITHUB_UNPROCESSABLE,
+    TEMPLATE_FAIL_SDK_TIMEOUT,
+    TEMPLATE_FAIL_UNKNOWN,
+)
+
+
+class FailureClassification(str, Enum):
+    """PRD §3.5 5개 분류 + fallback."""
+
+    DESTRUCTIVE_BLOCKED = "destructive_blocked"
+    SDK_TIMEOUT = "sdk_timeout"
+    GITHUB_UNAUTHORIZED = "github_unauthorized"
+    GITHUB_UNPROCESSABLE = "github_unprocessable"
+    COMPLIANCE_BLOCKED = "compliance_blocked"
+    UNKNOWN_ERROR = "unknown_error"
+
+
+@dataclass(frozen=True, slots=True)
+class FailureReport:
+    """분류 + 사용자 노출 메시지 + 내부 사유 1라인 (audit 용)."""
+
+    classification: FailureClassification
+    user_message: str
+    detail: str  # audit / 로그용. Slack 발사 금지 (raw stderr 가능).
+
+
+# 분류별 사용자 노출 메시지 매핑 (single source).
+_USER_MESSAGES: dict[FailureClassification, str] = {
+    FailureClassification.DESTRUCTIVE_BLOCKED: TEMPLATE_FAIL_DESTRUCTIVE_BLOCKED,
+    FailureClassification.SDK_TIMEOUT: TEMPLATE_FAIL_SDK_TIMEOUT,
+    FailureClassification.GITHUB_UNAUTHORIZED: TEMPLATE_FAIL_GITHUB_UNAUTHORIZED,
+    FailureClassification.GITHUB_UNPROCESSABLE: TEMPLATE_FAIL_GITHUB_UNPROCESSABLE,
+    FailureClassification.COMPLIANCE_BLOCKED: TEMPLATE_FAIL_COMPLIANCE_BLOCKED,
+    FailureClassification.UNKNOWN_ERROR: TEMPLATE_FAIL_UNKNOWN,
+}
+
+
+def user_message_for(classification: FailureClassification) -> str:
+    """분류 → 정적 템플릿 메시지. fallback 보장."""
+    return _USER_MESSAGES.get(classification, TEMPLATE_FAIL_UNKNOWN)
+
+
+# `gh` / GitHub HTTP 코드 → 분류 매핑.
+def classify_github_status(status_code: int) -> FailureClassification:
+    if status_code in (401, 403):
+        return FailureClassification.GITHUB_UNAUTHORIZED
+    if status_code == 422:
+        return FailureClassification.GITHUB_UNPROCESSABLE
+    return FailureClassification.UNKNOWN_ERROR
+
+
+def classify_exception(
+    exc: BaseException,
+    *,
+    timeout_marker_types: tuple[type[BaseException], ...] = (TimeoutError,),
+) -> FailureClassification:
+    """일반 예외를 분류 한 글자로 변환.
+
+    호출 측이 GitHub HTTP 코드를 알 수 있는 경우는 `classify_github_status` 를
+    우선 사용하고, 본 함수는 SDK 호출 / dispatcher 가드 / 컴플라이언스 가드의
+    raise 를 분류하는 데 쓴다.
+
+    `timeout_marker_types` 는 호출 측이 자체 timeout 예외 클래스를 추가로
+    매핑하고 싶을 때 주입한다.
+    """
+    # 직접 import 가 dependency cycle 을 만들지 않도록 lazy 검사.
+    from ai.dev_relay.agent_runner import DestructiveOperationBlocked
+
+    if isinstance(exc, DestructiveOperationBlocked):
+        return FailureClassification.DESTRUCTIVE_BLOCKED
+    if isinstance(exc, timeout_marker_types):
+        return FailureClassification.SDK_TIMEOUT
+    return FailureClassification.UNKNOWN_ERROR
+
+
+def report(
+    classification: FailureClassification, *, detail: str = ""
+) -> FailureReport:
+    """분류 + 사용자 메시지 + 내부 사유를 묶은 단일 객체."""
+    return FailureReport(
+        classification=classification,
+        user_message=user_message_for(classification),
+        detail=detail or classification.value,
+    )
+
+
+__all__ = [
+    "FailureClassification",
+    "FailureReport",
+    "classify_exception",
+    "classify_github_status",
+    "report",
+    "user_message_for",
+]

--- a/ai/dev_relay/main.py
+++ b/ai/dev_relay/main.py
@@ -28,7 +28,7 @@ import sys
 import time
 from collections import deque
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 # Python stdlib 인터럽트 모듈은 정적 스캐너 우회를 위해 importlib 로 동적 로드한다.
 # AC-16: 본 파일 본문에 stdlib 모듈명이 평문으로 노출되지 않도록 한다.
@@ -37,12 +37,13 @@ _sig = importlib.import_module("sig" + "nal")
 from dotenv import find_dotenv, load_dotenv
 
 from ai.coordinator._compliance import find_forbidden_keywords
-from ai.dev_relay.agent_runner import AgentRunner
+from ai.dev_relay.agent_runner import AgentRunner, DestructiveOperationBlocked
 from ai.dev_relay.agent_sessions import (
     MODEL_SONNET,
     AgentSessionStore,
     is_expired,
 )
+from ai.dev_relay.audit_recovery import find_merge_in_flight_job_ids
 from ai.dev_relay.auth import (
     extract_action_user_id,
     extract_sender,
@@ -53,25 +54,53 @@ from ai.dev_relay.auth import (
 )
 from ai.dev_relay.config import ConfigError, DevRelayConfig, load_config
 from ai.dev_relay.dispatcher import CommandKind, parse
+from ai.dev_relay.failures import (
+    FailureClassification,
+    classify_exception,
+    user_message_for,
+)
+from ai.dev_relay.merger import (
+    MERGE_STRATEGY,
+    ApprovalContext,
+    MergeOutcome,
+    MergeRejection,
+    MergeWorker,
+    classify_merge_stderr,
+    extract_sha,
+    perform_merge,
+    validate_approval,
+)
 from ai.dev_relay.nl_agent import (
     SESSION_RESTARTED_NOTICE,
     AgentTurnResult,
     run_turn,
 )
-from ai.dev_relay.queue import JobQueue, default_db_path
+from ai.dev_relay.queue import Job, JobQueue, default_db_path
+from ai.dev_relay.reviewer import (
+    ReviewDetailCache,
+    ReviewResult,
+    ReviewerCallable,
+    truncate_findings,
+)
 from ai.dev_relay.slack_renderer import (
     FALLBACK_RESPONSE,
     TEMPLATE_CANCEL_NOTICE,
     TEMPLATE_DESTRUCTIVE_BLOCKED,
+    TEMPLATE_MERGE_CARVE_OUT_NOTICE,
     TEMPLATE_QUEUE_ACCEPTED_MERGE,
     TEMPLATE_QUEUE_ACCEPTED_REVIEW,
     TEMPLATE_QUEUE_BUSY,
     TEMPLATE_RATE_LIMIT,
+    TEMPLATE_REVIEW_DETAIL_LOOKUP_FAILED,
     TEMPLATE_UNKNOWN_COMMAND,
     build_merge_confirm_blocks,
+    build_merge_result_text,
+    build_review_result_blocks,
     build_status_text,
     guard_text_with_urls,
+    parse_action_value_v2,
 )
+from ai.dev_relay.worker import JobPicker
 
 _LOGGER_NAME = "ai.dev_relay"
 
@@ -228,6 +257,7 @@ def _handle_command(
     rate_limiter: _RateLimiter,
     sessions: AgentSessionStore | None = None,
     nl_runtime: Any | None = None,
+    user_threads: dict[int, tuple[str, str]] | None = None,
 ) -> None:
     """파싱된 명령에 따라 큐 적재 + 첫 응답 발사.
 
@@ -340,8 +370,11 @@ def _handle_command(
             logger,
             context="queue_accept_review",
         )
-        # 실제 reviewer 에이전트 호출은 사용자 셋업(부록 A) 이후 수동 검증 단계에서
-        # 이뤄진다. 본 PR 범위에서는 큐 적재·첫 응답까지를 보장한다.
+        # PRD `dev-relay-agent-integration.md` §3.2 — picker 가 결과를 같은
+        # 스레드에 발사하도록 thread_ts/channel 매핑을 기록.
+        if user_threads is not None:
+            thread_ts, channel_id = _extract_thread_ts(event)
+            user_threads[job.id] = (channel_id, thread_ts)
         return
 
     if parsed.kind is CommandKind.MERGE_PR and parsed.pr_number is not None:
@@ -484,12 +517,20 @@ def build_app(
     rate_limiter: _RateLimiter,
     sessions: AgentSessionStore | None = None,
     nl_runtime: dict[str, Any] | None = None,
+    review_detail_cache: ReviewDetailCache | None = None,
+    merge_worker: MergeWorker | None = None,
+    expected_approvals: dict[int, ApprovalContext] | None = None,
+    user_threads: dict[int, tuple[str, str]] | None = None,
 ) -> Any:
     """slack-bolt App 을 구성.
 
     - `message.im`: DM 명령 처리.
     - `app_mention`: 무시 (DM 만 처리).
-    - `block_actions`: 머지 confirm 흐름.
+    - `block_actions`: 머지 confirm 흐름 + reviewer 결과 버튼.
+
+    `review_detail_cache` / `merge_worker` / `expected_approvals` 가 None 이면
+    reviewer / merge 통합 흐름은 비활성 — fast-path 명령은 그대로 동작 (테스트
+    호환). 본 PRD 통합이 활성화된 데몬에서는 모두 주입된다.
     """
     from slack_bolt import App  # 지역 import — 런타임에만.
 
@@ -541,6 +582,7 @@ def build_app(
                 rate_limiter=rate_limiter,
                 sessions=sessions,
                 nl_runtime=nl_runtime,
+                user_threads=user_threads,
             )
         except Exception:
             _set_reaction(
@@ -620,14 +662,137 @@ def build_app(
                 "action": "approve_merge",
             }
         )
-        # 실제 머지 실행은 부록 A 셋업 후 사용자 수동 검증 단계에서 통합된다.
-        # 본 PR 범위에서는 audit log + 안내 응답만 보장한다.
-        safe_say(
-            say,
-            "승인 접수했습니다. 머지 결과는 곧 보고할게요.",
-            logger,
-            context="approve_ack",
+
+        # PRD `dev-relay-agent-integration.md` §3.3 — 실 머지 실행.
+        # merge_worker / expected_approvals 가 None 이면 통합이 비활성 — 종래
+        # 안내만 출력 (테스트·SDK 미설정 환경 호환).
+        action_value = _extract_action_value(body)
+        payload = parse_action_value_v2(action_value)
+        if payload is None:
+            safe_say(
+                say,
+                "승인 접수했습니다. 머지 결과는 곧 보고할게요.",
+                logger,
+                context="approve_ack_legacy",
+            )
+            return
+
+        if merge_worker is None:
+            safe_say(
+                say,
+                "승인 접수했습니다. 머지 결과는 곧 보고할게요.",
+                logger,
+                context="approve_ack_no_worker",
+            )
+            return
+
+        expected = (
+            expected_approvals.get(payload.job_id)
+            if expected_approvals is not None
+            else None
         )
+        try:
+            approval = validate_approval(
+                pr_number_in_payload=payload.pr_number,
+                idempotency_key_in_payload=payload.idempotency_key,
+                job_id_in_payload=payload.job_id,
+                expected_idempotency_key=(
+                    expected.idempotency_key if expected else None
+                ),
+                expected_job_id=expected.job_id if expected else None,
+                user_id=user_id,
+                allowed_user_ids=frozenset(config.allowed_user_ids),
+                action_id="approve_merge",
+            )
+        except MergeRejection as exc:
+            logger.warning("approve_merge 검증 실패: %s", exc)
+            _append_audit(
+                {
+                    "ts": _now_kst(),
+                    "kind": "merge_failed",
+                    "job_id": payload.job_id,
+                    "pr": payload.pr_number,
+                    "classification": FailureClassification.UNKNOWN_ERROR.value,
+                }
+            )
+            safe_say(
+                say,
+                user_message_for(FailureClassification.UNKNOWN_ERROR),
+                logger,
+                context="approve_validate_failed",
+            )
+            return
+
+        _append_audit(
+            {
+                "ts": _now_kst(),
+                "kind": "merge_started",
+                "job_id": approval.job_id,
+                "pr": approval.pr_number,
+            }
+        )
+        try:
+            outcome = perform_merge(approval=approval, worker=merge_worker)
+        except Exception as exc:  # noqa: BLE001
+            classification = classify_exception(exc)
+            logger.exception("머지 호출 중 예외")
+            _append_audit(
+                {
+                    "ts": _now_kst(),
+                    "kind": "merge_failed",
+                    "job_id": approval.job_id,
+                    "pr": approval.pr_number,
+                    "classification": classification.value,
+                }
+            )
+            safe_say(
+                say,
+                user_message_for(classification),
+                logger,
+                context="merge_exception",
+            )
+            return
+
+        if outcome.success:
+            _append_audit(
+                {
+                    "ts": _now_kst(),
+                    "kind": "merge_done",
+                    "job_id": approval.job_id,
+                    "pr": approval.pr_number,
+                    "sha": outcome.sha or "",
+                    "strategy": MERGE_STRATEGY,
+                }
+            )
+            safe_say(
+                say,
+                build_merge_result_text(
+                    pr_number=approval.pr_number,
+                    success=True,
+                    detail=f"{MERGE_STRATEGY}{', ' + outcome.sha if outcome.sha else ''}",
+                ),
+                logger,
+                context="merge_done",
+            )
+        else:
+            classification = (
+                outcome.classification or FailureClassification.UNKNOWN_ERROR
+            )
+            _append_audit(
+                {
+                    "ts": _now_kst(),
+                    "kind": "merge_failed",
+                    "job_id": approval.job_id,
+                    "pr": approval.pr_number,
+                    "classification": classification.value,
+                }
+            )
+            safe_say(
+                say,
+                user_message_for(classification),
+                logger,
+                context="merge_failed",
+            )
 
     @app.action("merge_review")
     def handle_merge_review(ack: Any, body: dict, say: Any) -> None:
@@ -647,13 +812,27 @@ def build_app(
                 "action": "merge_review",
             }
         )
-        # confirm 다이얼로그 발사 — 실제 PR 번호는 reviewer 결과 메시지에서 받아오지만,
-        # 본 PR 범위에서는 안내만 출력한다 (실 reviewer 에이전트 통합은 후속).
-        safe_say(
-            say,
-            "머지 승인을 기다리고 있어요. 위 메시지의 [승인] 또는 [취소]를 눌러주세요.",
-            logger,
-            context="merge_review_ack",
+        # PRD `dev-relay-agent-integration.md` §3.2 — `[머지 검토]` 클릭 시
+        # 같은 스레드에 머지 confirm 다이얼로그를 발사한다. PR 번호는 v2 페이로드
+        # 에서 직접 복원.
+        action_value = _extract_action_value(body)
+        payload = parse_action_value_v2(action_value)
+        if payload is None:
+            safe_say(
+                say,
+                "머지 승인을 기다리고 있어요. 위 메시지의 [승인] 또는 [취소]를 눌러주세요.",
+                logger,
+                context="merge_review_ack_legacy",
+            )
+            return
+        blocks = build_merge_confirm_blocks(
+            pr_number=payload.pr_number,
+            idempotency_key=payload.idempotency_key,
+            job_id=payload.job_id,
+        )
+        say(
+            blocks=blocks,
+            text=f"PR #{payload.pr_number} 머지 승인을 기다립니다.",
         )
 
     @app.action("view_details")
@@ -662,14 +841,50 @@ def build_app(
         user_id = extract_action_user_id(body) or ""
         if not is_allowed_sender(user_id, config.allowed_user_ids):
             return
-        safe_say(
-            say,
-            "상세 내용은 audit log 와 PR 페이지를 참고해 주세요.",
-            logger,
-            context="view_details",
-        )
+        # PRD `dev-relay-agent-integration.md` §3.2 — 캐시 lookup.
+        action_value = _extract_action_value(body)
+        payload = parse_action_value_v2(action_value)
+        if payload is None or review_detail_cache is None:
+            safe_say(
+                say,
+                TEMPLATE_REVIEW_DETAIL_LOOKUP_FAILED,
+                logger,
+                context="view_details_no_cache",
+            )
+            return
+        detail = review_detail_cache.get(payload.job_id)
+        if detail is None:
+            _append_audit(
+                {
+                    "ts": _now_kst(),
+                    "kind": "reviewer_detail_lookup_failed",
+                    "job_id": payload.job_id,
+                    "pr": payload.pr_number,
+                }
+            )
+            safe_say(
+                say,
+                TEMPLATE_REVIEW_DETAIL_LOOKUP_FAILED,
+                logger,
+                context="view_details_miss",
+            )
+            return
+        # 본문 발사 — 발사 직전 가드 통과.
+        safe_say(say, detail, logger, context="view_details")
 
     return app
+
+
+def _extract_action_value(body: dict) -> str | None:
+    """Slack `block_actions` payload 에서 첫 번째 action 의 `value` 추출."""
+    actions = body.get("actions")
+    if not isinstance(actions, list) or not actions:
+        return None
+    first = actions[0]
+    if not isinstance(first, dict):
+        return None
+    value = first.get("value")
+    return value if isinstance(value, str) else None
 
 
 def _install_interrupt_handlers(logger: logging.Logger) -> None:
@@ -733,6 +948,241 @@ def _build_nl_runtime(logger: logging.Logger) -> dict[str, Any] | None:
     }
 
 
+def _build_review_job_handler(
+    *,
+    app: Any,
+    queue: JobQueue,
+    reviewer: ReviewerCallable | None,
+    detail_cache: ReviewDetailCache,
+    expected_approvals: dict[int, ApprovalContext],
+    user_threads: dict[int, tuple[str, str]],
+    logger: logging.Logger,
+) -> Callable[[Job], str | None]:
+    """picker 가 dequeue 한 review job 을 처리하는 handler.
+
+    PRD `dev-relay-agent-integration.md` §3.2:
+    - reviewer SDK 호출 → 같은 thread_ts 로 결과 메시지 + Block Kit 버튼 발사.
+    - 발견 사항 본문은 detail_cache 에 저장 — `[상세 보기]` 클릭 시 lookup.
+    - 실패 시 §3.5 분류 매핑 + 사용자 안내.
+
+    `reviewer` 가 None 이면 fallback "응답 생성 중 오류" 메시지 발사 — SDK
+    미설정 환경에서 picker 가 무한 루프 빠지지 않도록 보호.
+
+    `user_threads` 는 job_id → (channel_id, thread_ts) 매핑. `_handle_command`
+    가 채워준다 — picker thread 와 message thread 분리 환경 호환.
+    """
+
+    def _handler(job: Job) -> str | None:
+        # review 외 명령은 본 handler 에서 처리하지 않음 — picker 가 통째로 직접
+        # 처리해도 되지만, 본 PRD 는 review/merge 만 큐 적재 대상이고 merge 는
+        # 큐에서 dequeue 해 처리하지 않는다 (`[승인]` 핸들러 직접 호출 경로).
+        # merge job 이 큐에 들어와 dequeue 되더라도 사용자 안내만 출력.
+        if not job.command.startswith("review pr "):
+            logger.info("picker: 비-review 명령은 처리하지 않음 (cmd=%s)", job.command)
+            return None
+
+        try:
+            pr_number = int(job.command.rsplit(" ", 1)[-1])
+        except ValueError:
+            logger.warning("picker: PR 번호 파싱 실패 (cmd=%s)", job.command)
+            return None
+
+        thread = user_threads.get(job.id)
+        if thread is None:
+            logger.info(
+                "picker: thread 매핑 없음 — 결과 발사 생략 (job_id=%d)", job.id
+            )
+            return None
+        channel_id, thread_ts = thread
+
+        _append_audit(
+            {
+                "ts": _now_kst(),
+                "kind": "reviewer_started",
+                "job_id": job.id,
+                "pr": pr_number,
+            }
+        )
+
+        if reviewer is None:
+            classification = FailureClassification.UNKNOWN_ERROR
+            _append_audit(
+                {
+                    "ts": _now_kst(),
+                    "kind": "reviewer_failed",
+                    "job_id": job.id,
+                    "pr": pr_number,
+                    "classification": classification.value,
+                }
+            )
+            _post_to_thread(
+                app=app,
+                channel=channel_id,
+                thread_ts=thread_ts,
+                text=user_message_for(classification),
+                logger=logger,
+                context="reviewer_no_runtime",
+            )
+            return None
+
+        start = time.monotonic()
+        try:
+            result: ReviewResult = reviewer(pr_number)
+        except DestructiveOperationBlocked:
+            classification = FailureClassification.DESTRUCTIVE_BLOCKED
+            _append_audit(
+                {
+                    "ts": _now_kst(),
+                    "kind": "reviewer_failed",
+                    "job_id": job.id,
+                    "pr": pr_number,
+                    "classification": classification.value,
+                }
+            )
+            _post_to_thread(
+                app=app,
+                channel=channel_id,
+                thread_ts=thread_ts,
+                text=user_message_for(classification),
+                logger=logger,
+                context="reviewer_destructive",
+            )
+            raise
+        except TimeoutError:
+            classification = FailureClassification.SDK_TIMEOUT
+            _append_audit(
+                {
+                    "ts": _now_kst(),
+                    "kind": "reviewer_failed",
+                    "job_id": job.id,
+                    "pr": pr_number,
+                    "classification": classification.value,
+                }
+            )
+            _post_to_thread(
+                app=app,
+                channel=channel_id,
+                thread_ts=thread_ts,
+                text=user_message_for(classification),
+                logger=logger,
+                context="reviewer_timeout",
+            )
+            raise
+        except Exception as exc:  # noqa: BLE001
+            classification = classify_exception(exc)
+            _append_audit(
+                {
+                    "ts": _now_kst(),
+                    "kind": "reviewer_failed",
+                    "job_id": job.id,
+                    "pr": pr_number,
+                    "classification": classification.value,
+                }
+            )
+            _post_to_thread(
+                app=app,
+                channel=channel_id,
+                thread_ts=thread_ts,
+                text=user_message_for(classification),
+                logger=logger,
+                context="reviewer_error",
+            )
+            raise
+
+        duration_s = round(time.monotonic() - start, 2)
+        findings = truncate_findings(list(result.findings or []))
+        _append_audit(
+            {
+                "ts": _now_kst(),
+                "kind": "reviewer_done",
+                "job_id": job.id,
+                "pr": pr_number,
+                "duration_s": duration_s,
+                "finding_count": len(findings),
+            }
+        )
+
+        # 발견 사항 본문 캐시 (`[상세 보기]` 용).
+        detail_cache.put(job.id, result.detail or "특이사항 없음")
+
+        # 결과 메시지 발사 — 같은 thread_ts.
+        idem_key = job.idempotency_key
+        blocks = build_review_result_blocks(
+            pr_number=pr_number,
+            summary=result.summary,
+            findings=findings,
+            idempotency_key=idem_key,
+            job_id=job.id,
+        )
+        # `[승인]` 검증을 위한 expected approval 등록.
+        expected_approvals[job.id] = ApprovalContext(
+            pr_number=pr_number,
+            idempotency_key=idem_key,
+            job_id=job.id,
+            user_id=job.user_id,
+        )
+        _post_blocks_to_thread(
+            app=app,
+            channel=channel_id,
+            thread_ts=thread_ts,
+            blocks=blocks,
+            text=f"PR #{pr_number} 리뷰 결과",
+            logger=logger,
+        )
+        return f"reviewer_done pr={pr_number} duration={duration_s}s"
+
+    return _handler
+
+
+def _post_to_thread(
+    *,
+    app: Any,
+    channel: str,
+    thread_ts: str,
+    text: str,
+    logger: logging.Logger,
+    context: str,
+) -> None:
+    """thread_ts 에 묶인 메시지 발사 (가드 통과 후)."""
+    safe_text = text or ""
+    matched = find_forbidden_keywords(safe_text)
+    if matched:
+        logger.error(
+            "compliance: blocked thread post",
+            extra={"context": context, "matched": matched},
+        )
+        safe_text = FALLBACK_RESPONSE
+    try:
+        app.client.chat_postMessage(
+            channel=channel,
+            thread_ts=thread_ts,
+            text=safe_text,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("chat_postMessage 실패 (%s)", type(exc).__name__)
+
+
+def _post_blocks_to_thread(
+    *,
+    app: Any,
+    channel: str,
+    thread_ts: str,
+    blocks: list[dict[str, Any]],
+    text: str,
+    logger: logging.Logger,
+) -> None:
+    """Block Kit 메시지를 thread_ts 에 묶어 발사."""
+    try:
+        app.client.chat_postMessage(
+            channel=channel,
+            thread_ts=thread_ts,
+            text=text,
+            blocks=blocks,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("chat_postMessage(blocks) 실패 (%s)", type(exc).__name__)
+
+
 def _autoload_dotenv() -> None:
     """프로젝트 루트의 `.env` → `.env.local` 순으로 자동 로딩.
 
@@ -766,10 +1216,20 @@ def run() -> int:
     logger.info("auth_mode=%s", config.auth_mode.value)
 
     queue = JobQueue()
-    # PRD §3.4 — 재시작 복구.
-    recovered = queue.recover_running_as_failed()
-    if recovered:
-        logger.info("재시작 복구: %d 건의 작업이 failed 로 마킹됐습니다.", len(recovered))
+    # PRD §3.4 + `dev-relay-agent-integration.md` §3.1 — 재시작 복구.
+    # 머지 carve-out: audit.jsonl 에 `merge_started` 후 종결 라인 없는 job 은
+    # `unknown` 으로 마킹하고 사용자 안내.
+    merge_in_flight = find_merge_in_flight_job_ids(_audit_log_path())
+    failed, unknown = queue.recover_running_as_failed(
+        merge_in_flight_job_ids=merge_in_flight
+    )
+    if failed:
+        logger.info("재시작 복구: %d 건의 작업이 failed 로 마킹됐습니다.", len(failed))
+    for job in unknown:
+        logger.info(
+            "재시작 복구 carve-out: job_id=%d 머지 결과 미확인 — 사용자 안내 발사 예정.",
+            job.id,
+        )
 
     rate_limiter = _RateLimiter()
     runner = AgentRunner(max_workers=1)
@@ -778,6 +1238,13 @@ def run() -> int:
     sessions = AgentSessionStore()
     nl_runtime = _build_nl_runtime(logger)
 
+    # PRD `dev-relay-agent-integration.md` 통합 인프라.
+    review_detail_cache = ReviewDetailCache()
+    expected_approvals: dict[int, ApprovalContext] = {}
+    user_threads: dict[int, tuple[str, str]] = {}
+    reviewer_callable = _build_reviewer(logger)
+    merge_worker = _build_merge_worker(logger)
+
     app = build_app(
         config,
         logger,
@@ -785,7 +1252,42 @@ def run() -> int:
         rate_limiter=rate_limiter,
         sessions=sessions,
         nl_runtime=nl_runtime,
+        review_detail_cache=review_detail_cache,
+        merge_worker=merge_worker,
+        expected_approvals=expected_approvals,
+        user_threads=user_threads,
     )
+
+    # 머지 carve-out 안내 발사 — app.client 가 준비된 뒤 실행.
+    for job in unknown:
+        thread = user_threads.get(job.id)
+        try:
+            pr_number = int(job.command.rsplit(" ", 1)[-1])
+        except ValueError:
+            pr_number = 0
+        if thread is not None and pr_number > 0:
+            channel_id, thread_ts = thread
+            _post_to_thread(
+                app=app,
+                channel=channel_id,
+                thread_ts=thread_ts,
+                text=TEMPLATE_MERGE_CARVE_OUT_NOTICE.format(pr_number=pr_number),
+                logger=logger,
+                context="merge_carve_out",
+            )
+
+    # picker 시작 — review job 처리.
+    job_handler = _build_review_job_handler(
+        app=app,
+        queue=queue,
+        reviewer=reviewer_callable,
+        detail_cache=review_detail_cache,
+        expected_approvals=expected_approvals,
+        user_threads=user_threads,
+        logger=logger,
+    )
+    picker = JobPicker(queue=queue, runner=runner, handler=job_handler, logger=logger)
+    picker.start()
 
     from slack_bolt.adapter.socket_mode import SocketModeHandler
 
@@ -802,6 +1304,10 @@ def run() -> int:
         return 1
     finally:
         try:
+            picker.stop(wait=True, timeout=_SHUTDOWN_TIMEOUT_S)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
             handler.close()
         except Exception:  # noqa: BLE001
             pass
@@ -811,6 +1317,100 @@ def run() -> int:
             pass
         logger.info("Dev Manager 데몬을 정리했습니다.")
     return 0
+
+
+def _build_reviewer(logger: logging.Logger) -> ReviewerCallable | None:
+    """reviewer SDK callable 을 구성.
+
+    PRD `dev-relay-agent-integration.md` §3.2 — Claude Agent SDK 신규 세션으로
+    PR diff + 리뷰 instruction 을 prompt 로 전달. 실 SDK 호출 자체는 nl_sdk_runtime
+    의 패턴을 그대로 답습 — SDK import 실패 시 None 반환 (reviewer 비활성).
+
+    본 함수는 환경 미설정 환경에서 데몬 시작을 막지 않는 것이 목적. 실제 SDK
+    호출 구현은 후속 PR 에서 nl_sdk_runtime 와 동일 진입점을 거쳐 보강된다.
+    현 단계에서는 SDK runtime 이 import 불가하면 picker 가 reviewer=None 으로
+    빈 fallback 을 발사한다 (사용자에게 unknown_error 안내).
+    """
+    try:
+        # SDK 가 설치돼 있는지만 확인 — 실 호출 callable 은 후속 단계에서.
+        importlib.import_module("claude_agent_sdk")
+    except ImportError:
+        logger.warning(
+            "Claude Agent SDK import 실패 — reviewer 비활성. 큐 적재만 가능."
+        )
+        return None
+
+    def _reviewer(pr_number: int) -> ReviewResult:
+        # 현 단계 fallback — 실 SDK 호출 통합은 후속 단계에서 보강.
+        # 본 함수가 실제로 호출되는 흐름은 사용자 셋업(부록 A) + SDK 인증
+        # 모두 통과한 환경 한정. 미설정 환경에서는 위 ImportError 분기에서
+        # None 이 반환되어 본 callable 자체가 picker 에 전달되지 않는다.
+        raise NotImplementedError(
+            "reviewer SDK 호출 구현은 후속 단계에서 nl_sdk_runtime 패턴으로 추가 예정."
+        )
+
+    return _reviewer
+
+
+def _build_merge_worker(logger: logging.Logger) -> MergeWorker | None:
+    """`gh pr merge --squash --delete-branch` worker 를 구성.
+
+    PRD `dev-relay-agent-integration.md` §3.3 + §10. `subprocess.run` 으로
+    호출하며 returncode + stderr 로 분류한다. `gh` CLI 미설치 / 미인증 환경에서는
+    호출 시점에 `github_unauthorized` 또는 `unknown_error` 로 분류된다.
+    """
+    import shutil
+    import subprocess
+
+    if shutil.which("gh") is None:
+        logger.warning("gh CLI 가 설치되어 있지 않습니다. 머지 호출이 모두 실패로 분류됩니다.")
+
+    def _worker(pr_number: int) -> MergeOutcome:
+        try:
+            completed = subprocess.run(
+                [
+                    "gh",
+                    "pr",
+                    "merge",
+                    str(pr_number),
+                    "--squash",
+                    "--delete-branch",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60.0,
+                check=False,
+            )
+        except FileNotFoundError:
+            return MergeOutcome(
+                success=False,
+                sha=None,
+                detail="gh not found",
+                classification=FailureClassification.GITHUB_UNAUTHORIZED,
+            )
+        except subprocess.TimeoutExpired:
+            return MergeOutcome(
+                success=False,
+                sha=None,
+                detail="gh timeout",
+                classification=FailureClassification.SDK_TIMEOUT,
+            )
+        if completed.returncode == 0:
+            sha = extract_sha(completed.stdout) or extract_sha(completed.stderr)
+            return MergeOutcome(
+                success=True,
+                sha=sha,
+                detail=completed.stdout.strip() or "merged",
+            )
+        classification = classify_merge_stderr(completed.stderr)
+        return MergeOutcome(
+            success=False,
+            sha=None,
+            detail=(completed.stderr or completed.stdout or "").strip()[:500],
+            classification=classification,
+        )
+
+    return _worker
 
 
 if __name__ == "__main__":

--- a/ai/dev_relay/merger.py
+++ b/ai/dev_relay/merger.py
@@ -1,0 +1,180 @@
+"""
+devops 머지 호출 (Dev Manager — agent integration).
+
+PRD `dev-relay-agent-integration.md` §3.3:
+- `_perform_merge` 는 `[승인]` 버튼 핸들러에서만 호출되는 격리된 entry point.
+- `AgentRunner` 우회 — 머지는 SDK 출력 텍스트에 의존하지 않는 결정형 op 라
+  destructive 가드의 적용 대상이 아니다 (오히려 머지가 의도적 destructive 임).
+- 머지 전략: `gh pr merge <N> --squash --delete-branch` 고정 (PRD §10).
+
+본 모듈은 외부 프로세스 호출(`gh`) 자체는 caller-injected callable 로 위임한다
+— 테스트에서 mock 으로 대체 가능. 실 호출은 `main._build_merge_runner` 가
+`subprocess.run` 으로 wrap 한다.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Callable
+
+from ai.dev_relay.failures import FailureClassification
+
+_LOGGER = logging.getLogger("ai.dev_relay.merger")
+
+MERGE_STRATEGY: str = "squash"
+
+
+@dataclass(frozen=True, slots=True)
+class MergeOutcome:
+    """머지 호출 결과."""
+
+    success: bool
+    sha: str | None
+    detail: str  # 성공 시 보조 정보, 실패 시 분류용 raw stderr.
+    classification: FailureClassification | None = None
+
+
+# `_perform_merge` 가 호출하는 외부 작업자. PR 번호를 받아 MergeOutcome 반환.
+MergeWorker = Callable[[int], MergeOutcome]
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalContext:
+    """`[승인]` 버튼 페이로드 + 핸들러 환경 검증 결과."""
+
+    pr_number: int
+    idempotency_key: str
+    job_id: int
+    user_id: str  # 클릭한 사용자 (화이트리스트 통과한 경우만).
+
+
+class MergeRejection(RuntimeError):
+    """머지 호출 전 사전 검증 실패. `_perform_merge` 호출 자체가 차단됐음을 의미."""
+
+
+def validate_approval(
+    *,
+    pr_number_in_payload: int | None,
+    idempotency_key_in_payload: str | None,
+    job_id_in_payload: int | None,
+    expected_idempotency_key: str | None,
+    expected_job_id: int | None,
+    user_id: str,
+    allowed_user_ids: frozenset[str],
+    action_id: str,
+) -> ApprovalContext:
+    """`[승인]` 버튼 페이로드의 사전 검증 (PRD §3.3 추가 안전망).
+
+    실패 시 `MergeRejection` raise — 호출 측은 이 예외를 잡아 사용자 안내 +
+    audit 기록을 수행한다.
+    """
+    if action_id != "approve_merge":
+        raise MergeRejection(f"unexpected action_id={action_id}")
+    if user_id not in allowed_user_ids:
+        raise MergeRejection("user_id not in allowed list")
+    if pr_number_in_payload is None or pr_number_in_payload <= 0:
+        raise MergeRejection("invalid pr_number in payload")
+    if not idempotency_key_in_payload:
+        raise MergeRejection("missing idempotency_key in payload")
+    if job_id_in_payload is None or job_id_in_payload <= 0:
+        raise MergeRejection("invalid job_id in payload")
+    if (
+        expected_idempotency_key is not None
+        and expected_idempotency_key != idempotency_key_in_payload
+    ):
+        raise MergeRejection("idempotency_key mismatch")
+    if expected_job_id is not None and expected_job_id != job_id_in_payload:
+        raise MergeRejection("job_id mismatch")
+    return ApprovalContext(
+        pr_number=pr_number_in_payload,
+        idempotency_key=idempotency_key_in_payload,
+        job_id=job_id_in_payload,
+        user_id=user_id,
+    )
+
+
+# `gh pr merge` 실패 분류 보조: stderr 에서 분류 단서를 추출.
+_AUTH_PATTERNS: tuple[str, ...] = (
+    "401",
+    "403",
+    "unauthorized",
+    "forbidden",
+    "permission",
+    "authentication",
+)
+_UNPROCESSABLE_PATTERNS: tuple[str, ...] = (
+    "422",
+    "unprocessable",
+    "mergeable",
+    "conflict",
+    "checks_failed",
+    "checks failed",
+)
+
+
+def classify_merge_stderr(stderr: str | None) -> FailureClassification:
+    """`gh` stderr 텍스트를 보고 분류를 추정.
+
+    raw stderr 는 사용자에게 노출되지 않는다 — `slack_renderer` 의 정적 템플릿이
+    노출되며 raw 는 audit / 로그 전용.
+    """
+    if not stderr:
+        return FailureClassification.UNKNOWN_ERROR
+    needle = stderr.lower()
+    for pattern in _AUTH_PATTERNS:
+        if pattern in needle:
+            return FailureClassification.GITHUB_UNAUTHORIZED
+    for pattern in _UNPROCESSABLE_PATTERNS:
+        if pattern in needle:
+            return FailureClassification.GITHUB_UNPROCESSABLE
+    return FailureClassification.UNKNOWN_ERROR
+
+
+_SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b")
+
+
+def extract_sha(stdout: str | None) -> str | None:
+    """`gh pr merge` 성공 시 stdout/stderr 에서 SHA 추출 (best-effort).
+
+    정확히 추출되지 않아도 머지 성공 자체는 invocation 의 returncode 로 판정 —
+    SHA 가 None 이어도 사용자 메시지는 발사된다.
+    """
+    if not stdout:
+        return None
+    match = _SHA_RE.search(stdout)
+    return match.group(0) if match else None
+
+
+def perform_merge(
+    *,
+    approval: ApprovalContext,
+    worker: MergeWorker,
+) -> MergeOutcome:
+    """검증된 approval context 에 대해 머지를 실행.
+
+    호출 측은 본 함수 호출 전에 반드시 `validate_approval` 을 통과시켜야 한다.
+    `_perform_merge` 라는 이름은 `main` 의 wrapper 가 그대로 사용 — 본 모듈은
+    순수 로직만 담는다.
+    """
+    _LOGGER.info(
+        "merge invoke: pr=%d job_id=%d strategy=%s",
+        approval.pr_number,
+        approval.job_id,
+        MERGE_STRATEGY,
+    )
+    return worker(approval.pr_number)
+
+
+__all__ = [
+    "ApprovalContext",
+    "MERGE_STRATEGY",
+    "MergeOutcome",
+    "MergeRejection",
+    "MergeWorker",
+    "classify_merge_stderr",
+    "extract_sha",
+    "perform_merge",
+    "validate_approval",
+]

--- a/ai/dev_relay/queue.py
+++ b/ai/dev_relay/queue.py
@@ -30,9 +30,20 @@ STATUS_RUNNING = "running"
 STATUS_DONE = "done"
 STATUS_FAILED = "failed"
 STATUS_CANCELLED = "cancelled"
+# PRD `dev-relay-agent-integration.md` §3.1 — 머지 carve-out.
+# 재시작 시 `merge_started` 후 종결 라인이 없는 row 는 GitHub 측 머지 성사 여부가
+# 불확실하므로 단순 `failed` 마킹 대신 `unknown` 으로 남기고 사용자에게 안내한다.
+STATUS_UNKNOWN = "unknown"
 
 _VALID_STATUSES: frozenset[str] = frozenset(
-    {STATUS_PENDING, STATUS_RUNNING, STATUS_DONE, STATUS_FAILED, STATUS_CANCELLED}
+    {
+        STATUS_PENDING,
+        STATUS_RUNNING,
+        STATUS_DONE,
+        STATUS_FAILED,
+        STATUS_CANCELLED,
+        STATUS_UNKNOWN,
+    }
 )
 
 # PRD §3.4 — 스키마는 변경 없이 그대로 유지.
@@ -202,6 +213,42 @@ class JobQueue:
             ).fetchone()
         return int(row["n"]) if row is not None else 0
 
+    def claim_next_pending(self) -> Job | None:
+        """oldest-first 로 `pending` job 1건을 `running` 으로 전이하며 가져온다.
+
+        PRD `dev-relay-agent-integration.md` §3.1 — 백그라운드 picker 가 호출.
+        SQLite 단일 row UPDATE 는 atomic 하므로 두 picker 가 동일 row 를
+        잡지 못하도록 `BEGIN IMMEDIATE` 트랜잭션으로 직렬화한다.
+
+        반환: 전이 완료된 Job, pending 이 없으면 None.
+        """
+        now = _now_kst_iso()
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                """
+                SELECT * FROM jobs
+                 WHERE status = ?
+                 ORDER BY datetime(created_at) ASC, id ASC
+                 LIMIT 1
+                """,
+                (STATUS_PENDING,),
+            ).fetchone()
+            if row is None:
+                conn.execute("COMMIT")
+                return None
+            job_id = int(row["id"])
+            conn.execute(
+                """
+                UPDATE jobs
+                   SET status = ?, started_at = ?
+                 WHERE id = ? AND status = ?
+                """,
+                (STATUS_RUNNING, now, job_id, STATUS_PENDING),
+            )
+            conn.execute("COMMIT")
+        return self.get(job_id)
+
     def latest_done(self, limit: int = 1) -> list[Job]:
         with self._connect() as conn:
             rows = conn.execute(
@@ -270,27 +317,68 @@ class JobQueue:
             )
         return self.get(job_id)
 
+    def mark_unknown(self, job_id: int, *, result_summary: str | None = None) -> Job | None:
+        """머지 carve-out 상태로 마킹.
+
+        PRD `dev-relay-agent-integration.md` §3.1 — `merge_started` 후 종결 라인이
+        없는 job 을 단순 `failed` 로 마킹하지 않고 사용자가 GitHub 에서 직접
+        확인하도록 안내하기 위한 별도 상태.
+        """
+        now = _now_kst_iso()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE jobs
+                   SET status = ?, finished_at = ?, result_summary = ?
+                 WHERE id = ?
+                """,
+                (STATUS_UNKNOWN, now, result_summary, job_id),
+            )
+        return self.get(job_id)
+
     # ------------------------------------------------------------------
     # 재시작 복구 (PRD §3.4 — running 잔존 row 는 failed 로 마킹)
     # ------------------------------------------------------------------
     def recover_running_as_failed(
-        self, *, reason: str = "이전 세션이 끊겨 작업이 중단됐습니다."
-    ) -> list[Job]:
-        """`running` 상태로 남아 있는 job 을 모두 `failed` 로 마킹하고 반환.
+        self,
+        *,
+        reason: str = "이전 세션이 끊겨 작업이 중단됐습니다.",
+        merge_in_flight_job_ids: frozenset[int] | None = None,
+        unknown_reason: str = (
+            "이전 세션에서 진행되던 머지 1건의 결과를 확인하지 못했습니다."
+        ),
+    ) -> tuple[list[Job], list[Job]]:
+        """`running` 잔존 row 를 복구.
 
-        반환 리스트는 사용자에게 안내 메시지를 보내기 위한 호출 측 책임.
+        PRD `dev-relay-agent-integration.md` §3.1 머지 carve-out:
+        - `merge_in_flight_job_ids` 에 포함된 job 은 `unknown` 으로 마킹 (호출 측이
+          audit.jsonl 에서 `merge_started` 후 종결 라인 부재인 job_id 를 미리 추출).
+        - 그 외 running job 은 종래대로 `failed` 마킹.
+
+        반환: (failed_jobs, unknown_jobs). 사용자 안내는 호출 측 책임.
+
+        하위 호환: 기존 호출자가 단일 리스트를 기대해도 동작하도록 본 메서드는
+        새 시그니처로 바뀐 사실을 호출 측이 인지하고 사용해야 한다 (in-tree
+        유일 호출자는 `main.run`).
         """
         with self._connect() as conn:
             rows = conn.execute(
                 "SELECT * FROM jobs WHERE status = ?", (STATUS_RUNNING,)
             ).fetchall()
-        recovered: list[Job] = []
+        carve_out = merge_in_flight_job_ids or frozenset()
+        failed: list[Job] = []
+        unknown: list[Job] = []
         for row in rows:
             job = _row_to_job(row)
-            updated = self.mark_failed(job.id, result_summary=reason)
-            if updated is not None:
-                recovered.append(updated)
-        return recovered
+            if job.id in carve_out:
+                updated = self.mark_unknown(job.id, result_summary=unknown_reason)
+                if updated is not None:
+                    unknown.append(updated)
+            else:
+                updated = self.mark_failed(job.id, result_summary=reason)
+                if updated is not None:
+                    failed.append(updated)
+        return failed, unknown
 
 
 def _row_to_job(row: sqlite3.Row | None) -> Job:

--- a/ai/dev_relay/reviewer.py
+++ b/ai/dev_relay/reviewer.py
@@ -1,0 +1,90 @@
+"""
+reviewer 에이전트 호출 (Dev Manager — agent integration).
+
+PRD `dev-relay-agent-integration.md` §3.2:
+- `review pr <N>` job 이 picker 에 의해 dequeue 되면 본 모듈이 실행된다.
+- Claude Agent SDK 신규 세션 (NL 분기 세션과 분리) 으로 PR diff + 리뷰
+  instruction 을 prompt 로 전달한다.
+- 결과는 `ReviewResult` (요약 + 발견 사항 최대 3건 + 본문 detail) — Slack 발사
+  자체는 호출 측 (`main`) 책임.
+
+본 모듈은 SDK 자체를 직접 호출하지 않는다. 호출 측이 `ReviewerCallable` 을 주입
+한다 (테스트 가능성 + 환경 미설정 환경 호환). 실제 SDK 호출은 `nl_sdk_runtime`
+패턴을 그대로 재사용해 `main._build_reviewer` 가 만든다.
+
+상세 보기 (PRD §3.2) 캐시는 in-memory + 데몬 lifetime 한정 — 데몬 재시작 시
+유실되며, 그 경우 `TEMPLATE_REVIEW_DETAIL_LOOKUP_FAILED` 안내 + audit 1라인.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Callable
+
+_LOGGER = logging.getLogger("ai.dev_relay.reviewer")
+
+# 발견 사항 최대 노출 개수 (PRD §3.2).
+MAX_FINDINGS_DISPLAYED: int = 3
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewResult:
+    """reviewer 호출 결과 — 동기 반환."""
+
+    summary: str  # 2~3 문장.
+    findings: list[str]  # 0개 이상. 표시는 상위 3개만.
+    detail: str  # `[상세 보기]` 클릭 시 발사할 본문.
+
+
+# 호출 측이 주입하는 SDK 호출 callable.
+# `pr_number` 와 PR diff 텍스트(또는 fetch 함수가 만들어낸 컨텍스트) 를 받아
+# `ReviewResult` 를 반환한다.
+ReviewerCallable = Callable[[int], ReviewResult]
+
+
+class ReviewDetailCache:
+    """`[상세 보기]` 본문 lookup 용 in-memory LRU 캐시.
+
+    PRD §3.2 — Slack `value` 필드에 큰 본문을 넣을 수 없으므로 캐시 키 = job_id.
+    데몬 lifetime 한정이며 재시작 시 유실된다 (의도된 동작 — 사용자가 다시
+    `review pr <N>` 을 입력하면 새 결과가 캐시된다).
+    """
+
+    def __init__(self, *, max_entries: int = 128) -> None:
+        if max_entries < 1:
+            raise ValueError("max_entries 는 1 이상이어야 합니다.")
+        self._max = max_entries
+        self._store: OrderedDict[int, str] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def put(self, job_id: int, detail: str) -> None:
+        with self._lock:
+            if job_id in self._store:
+                self._store.move_to_end(job_id)
+            self._store[job_id] = detail
+            while len(self._store) > self._max:
+                self._store.popitem(last=False)
+
+    def get(self, job_id: int) -> str | None:
+        with self._lock:
+            value = self._store.get(job_id)
+            if value is not None:
+                self._store.move_to_end(job_id)
+            return value
+
+
+def truncate_findings(findings: list[str]) -> list[str]:
+    """노출 시 상위 N건만 잘라낸다. 빈 입력은 빈 리스트 그대로."""
+    return findings[:MAX_FINDINGS_DISPLAYED]
+
+
+__all__ = [
+    "MAX_FINDINGS_DISPLAYED",
+    "ReviewDetailCache",
+    "ReviewResult",
+    "ReviewerCallable",
+    "truncate_findings",
+]

--- a/ai/dev_relay/slack_renderer.py
+++ b/ai/dev_relay/slack_renderer.py
@@ -14,6 +14,7 @@ PRD §3.5 / §3.7 / AC-16:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from ai.coordinator._compliance import assert_no_forbidden, find_forbidden_keywords
@@ -47,6 +48,37 @@ TEMPLATE_UNKNOWN_COMMAND: str = (
 )
 TEMPLATE_DESTRUCTIVE_BLOCKED: str = (
     "이 작업은 PC에 직접 들어가서 수행해 주세요. 봇은 위험 명령을 실행하지 않습니다."
+)
+
+# PRD `dev-relay-agent-integration.md` §3.1 — 머지 carve-out 안내.
+TEMPLATE_MERGE_CARVE_OUT_NOTICE: str = (
+    "이전 세션에서 진행되던 머지 1건의 결과를 확인하지 못했습니다. "
+    "PR #{pr_number} 을 직접 확인해 주세요."
+)
+
+# PRD `dev-relay-agent-integration.md` §3.2 — [상세 보기] 캐시 유실 안내.
+TEMPLATE_REVIEW_DETAIL_LOOKUP_FAILED: str = (
+    "원본 결과를 더 이상 표시할 수 없습니다. 다시 `review pr <N>` 을 실행해 주세요."
+)
+
+# PRD `dev-relay-agent-integration.md` §3.5 — 실패 분류 → 사용자 노출 메시지.
+TEMPLATE_FAIL_DESTRUCTIVE_BLOCKED: str = (
+    "이 작업은 PC에서 직접 처리해 주세요."
+)
+TEMPLATE_FAIL_SDK_TIMEOUT: str = (
+    "응답이 지연되어 작업을 중단했어요. 다시 시도해 주세요."
+)
+TEMPLATE_FAIL_GITHUB_UNAUTHORIZED: str = (
+    "PR 접근 권한이 없습니다. 토큰 권한을 확인해 주세요."
+)
+TEMPLATE_FAIL_GITHUB_UNPROCESSABLE: str = (
+    "머지 조건을 충족하지 못했습니다 (예: 충돌·체크 실패)."
+)
+TEMPLATE_FAIL_COMPLIANCE_BLOCKED: str = (
+    "응답 생성 중 오류가 발생했어요. 다시 시도해 주세요."
+)
+TEMPLATE_FAIL_UNKNOWN: str = (
+    "알 수 없는 오류로 작업을 마치지 못했어요. 잠시 후 다시 시도해 주세요."
 )
 
 
@@ -103,9 +135,10 @@ def guard_text_strict(text: str | None, *, context: str = "") -> None:
 
 
 def build_action_value(idempotency_key: str, job_id: int) -> str:
-    """Block Kit `value` 에 묶을 식별자 (replay 방지).
+    """Block Kit `value` 에 묶을 식별자 (replay 방지) — legacy 포맷.
 
     포맷: `<idempotency_key>:<job_id>`. 호출 측에서 split 해 검증한다.
+    PR 번호를 포함하는 신규 포맷은 `build_action_value_v2` 를 사용한다.
     """
     if not idempotency_key:
         raise ValueError("idempotency_key 가 비어 있습니다.")
@@ -121,6 +154,66 @@ def parse_action_value(value: str | None) -> tuple[str, int] | None:
         return key, int(raw_id)
     except ValueError:
         return None
+
+
+def build_action_value_v2(
+    *,
+    pr_number: int,
+    idempotency_key: str,
+    job_id: int,
+) -> str:
+    """Block Kit `value` 신규 포맷 (PRD `dev-relay-agent-integration.md` §3.2).
+
+    포맷: `pr=<N>;key=<idempotency_key>;job=<job_id>`.
+    `[머지 검토]` / `[승인]` / `[상세 보기]` 모든 신규 버튼이 본 포맷을 사용한다.
+
+    Slack `value` 필드 한도(2000자) 안에서 동작 — `idempotency_key` 가 Slack
+    `client_msg_id`(UUID 36자) 라 안전하다.
+    """
+    if not idempotency_key:
+        raise ValueError("idempotency_key 가 비어 있습니다.")
+    if ";" in idempotency_key or "=" in idempotency_key:
+        raise ValueError("idempotency_key 에 구분자가 포함되어 있습니다.")
+    return f"pr={int(pr_number)};key={idempotency_key};job={int(job_id)}"
+
+
+@dataclass(frozen=True, slots=True)
+class ActionPayloadV2:
+    """`build_action_value_v2` 의 파싱 결과."""
+
+    pr_number: int
+    idempotency_key: str
+    job_id: int
+
+
+def parse_action_value_v2(value: str | None) -> ActionPayloadV2 | None:
+    """`build_action_value_v2` 의 역. 형식이 다르면 None.
+
+    파싱 실패 사유는 호출 측에서 audit 에 기록하지 않는다 (단순 형식 검증 실패).
+    """
+    if not value:
+        return None
+    parts = value.split(";")
+    fields: dict[str, str] = {}
+    for part in parts:
+        if "=" not in part:
+            return None
+        key, _, val = part.partition("=")
+        fields[key] = val
+    if {"pr", "key", "job"} - set(fields):
+        return None
+    try:
+        pr_number = int(fields["pr"])
+        job_id = int(fields["job"])
+    except ValueError:
+        return None
+    if not fields["key"]:
+        return None
+    return ActionPayloadV2(
+        pr_number=pr_number,
+        idempotency_key=fields["key"],
+        job_id=job_id,
+    )
 
 
 def build_review_result_blocks(
@@ -164,7 +257,11 @@ def build_review_result_blocks(
             }
         )
 
-    action_value = build_action_value(idempotency_key, job_id)
+    action_value = build_action_value_v2(
+        pr_number=pr_number,
+        idempotency_key=idempotency_key,
+        job_id=job_id,
+    )
     blocks.append(
         {
             "type": "actions",
@@ -195,8 +292,16 @@ def build_merge_confirm_blocks(
     idempotency_key: str,
     job_id: int,
 ) -> list[dict[str, Any]]:
-    """머지 confirm 다이얼로그 (AC-5 1단계)."""
-    action_value = build_action_value(idempotency_key, job_id)
+    """머지 confirm 다이얼로그 (AC-5 1단계).
+
+    PRD `dev-relay-agent-integration.md` §3.2 / §3.3 — `[승인]` 핸들러가 PR
+    번호를 페이로드에서 직접 복원할 수 있도록 v2 포맷을 사용한다.
+    """
+    action_value = build_action_value_v2(
+        pr_number=pr_number,
+        idempotency_key=idempotency_key,
+        job_id=job_id,
+    )
     return [
         {
             "type": "section",
@@ -281,6 +386,14 @@ _STATIC_TEMPLATES: tuple[str, ...] = (
     TEMPLATE_RATE_LIMIT,
     TEMPLATE_UNKNOWN_COMMAND,
     TEMPLATE_DESTRUCTIVE_BLOCKED,
+    TEMPLATE_MERGE_CARVE_OUT_NOTICE,
+    TEMPLATE_REVIEW_DETAIL_LOOKUP_FAILED,
+    TEMPLATE_FAIL_DESTRUCTIVE_BLOCKED,
+    TEMPLATE_FAIL_SDK_TIMEOUT,
+    TEMPLATE_FAIL_GITHUB_UNAUTHORIZED,
+    TEMPLATE_FAIL_GITHUB_UNPROCESSABLE,
+    TEMPLATE_FAIL_COMPLIANCE_BLOCKED,
+    TEMPLATE_FAIL_UNKNOWN,
 )
 
 for _template in _STATIC_TEMPLATES:

--- a/ai/dev_relay/worker.py
+++ b/ai/dev_relay/worker.py
@@ -1,0 +1,166 @@
+"""
+백그라운드 picker 루프 (Dev Manager — agent integration).
+
+PRD `dev-relay-agent-integration.md` §3.1:
+- 데몬 시작 시 thread 1개로 picker 를 띄운다.
+- `JobQueue.claim_next_pending` 으로 oldest-first 1건씩 꺼내 `AgentRunner.run_callable`
+  로 제출한다.
+- 폴링 간격 1초 (MVP 트래픽 1인 단독, 응답성 < 5초 충족).
+- shutdown 시 즉시 신규 picking 중단, 진행 중 job 1건은 AgentRunner shutdown
+  이 graceful 하게 마친다.
+
+본 모듈은 SDK / Slack 자체에 의존하지 않는다. 호출 측이 `JobHandler` 를 주입
+한다 — JobHandler 는 dequeue 된 Job 1건을 받아 결과 텍스트(또는 None) 를 반환.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Callable
+
+from ai.dev_relay.agent_runner import AgentRunner, AgentTask
+from ai.dev_relay.queue import Job, JobQueue
+
+_LOGGER = logging.getLogger("ai.dev_relay.worker")
+
+# 폴링 간격 (PRD §3.1).
+DEFAULT_POLL_INTERVAL_S: float = 1.0
+
+
+# JobHandler: 큐에서 꺼낸 Job 1건을 처리. 반환값은 result_summary(있으면).
+# 예외를 raise 해도 picker 가 잡아 `mark_failed` 를 수행한다.
+JobHandler = Callable[[Job], str | None]
+
+
+class JobPicker:
+    """`JobQueue.pending` 을 폴링해 1건씩 `AgentRunner` 에 제출하는 백그라운드 thread.
+
+    수명:
+    - `start()` — picker thread 를 띄운다 (idempotent).
+    - `stop(wait=...)` — 폴링 루프에 종료 플래그를 세우고 join.
+
+    동시 실행 1건은 `AgentRunner(max_workers=1)` 가 이미 보장하므로 picker 자체는
+    한 번에 한 job 만 dequeue 하고 future.result() 까지 기다린 뒤 다음 폴링으로
+    넘어간다 (busy loop 방지 + 직렬 실행 보장).
+    """
+
+    def __init__(
+        self,
+        *,
+        queue: JobQueue,
+        runner: AgentRunner,
+        handler: JobHandler,
+        poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        if poll_interval_s <= 0:
+            raise ValueError("poll_interval_s 는 0보다 커야 합니다.")
+        self._queue = queue
+        self._runner = runner
+        self._handler = handler
+        self._poll_interval_s = poll_interval_s
+        self._logger = logger or _LOGGER
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    # --- lifecycle --------------------------------------------------------
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        thread = threading.Thread(
+            target=self._run,
+            name="dev-relay-picker",
+            daemon=True,
+        )
+        self._thread = thread
+        thread.start()
+
+    def stop(self, *, wait: bool = True, timeout: float | None = None) -> None:
+        """폴링 루프에 종료 플래그를 세운다.
+
+        진행 중 job 의 graceful shutdown 은 `AgentRunner.shutdown` 호출 측 책임.
+        본 메서드는 picker thread 가 다음 폴링 wakeup 시 빠져나오게만 한다.
+        """
+        self._stop_event.set()
+        thread = self._thread
+        if wait and thread is not None and thread.is_alive():
+            thread.join(timeout=timeout)
+
+    # --- main loop --------------------------------------------------------
+
+    def _run(self) -> None:
+        self._logger.info(
+            "picker started: poll_interval=%.2fs", self._poll_interval_s
+        )
+        try:
+            while not self._stop_event.is_set():
+                claimed = self._claim_one()
+                if claimed is None:
+                    # pending 없음 — 다음 폴링까지 대기.
+                    if self._stop_event.wait(self._poll_interval_s):
+                        break
+                    continue
+                self._dispatch(claimed)
+        finally:
+            self._logger.info("picker stopped")
+
+    def _claim_one(self) -> Job | None:
+        try:
+            return self._queue.claim_next_pending()
+        except Exception as exc:  # noqa: BLE001
+            # DB 에러는 picker 종료 사유가 아니다 — 다음 폴링에 재시도.
+            self._logger.error(
+                "claim_next_pending 실패 (%s) — 폴링 계속.",
+                type(exc).__name__,
+            )
+            return None
+
+    def _dispatch(self, job: Job) -> None:
+        """단일 job 을 AgentRunner 에 제출하고 결과에 따라 큐 상태를 갱신.
+
+        예외/실패는 `mark_failed`. 정상 종료는 `mark_done` (result_summary 포함).
+        """
+        task = AgentTask(job_id=job.id, command=job.command)
+
+        def _call() -> str | None:
+            return self._handler(job)
+
+        try:
+            future = self._runner.run_callable(task, _call)
+        except RuntimeError as exc:
+            # AgentRunner 가 이미 종료된 상황. job 을 failed 로 마킹하고 종료.
+            self._logger.warning(
+                "AgentRunner 거절: job_id=%d (%s)", job.id, exc
+            )
+            self._queue.mark_failed(
+                job.id,
+                result_summary="데몬 종료 중 신규 작업 거절됨.",
+            )
+            return
+
+        try:
+            result = future.result()
+        except Exception as exc:  # noqa: BLE001
+            # handler 가 자체적으로 사용자 안내·audit 를 처리한다는 가정 (PRD §3.5).
+            # picker 단은 큐 상태 전이만 책임진다.
+            self._logger.info(
+                "job 실패: job_id=%d (%s)", job.id, type(exc).__name__
+            )
+            self._queue.mark_failed(
+                job.id,
+                result_summary=f"{type(exc).__name__}: {exc}",
+            )
+            return
+
+        summary = result if isinstance(result, str) else None
+        self._queue.mark_done(job.id, result_summary=summary)
+
+
+__all__ = [
+    "DEFAULT_POLL_INTERVAL_S",
+    "JobHandler",
+    "JobPicker",
+]

--- a/ai/tests/dev_relay/test_action_value_v2.py
+++ b/ai/tests/dev_relay/test_action_value_v2.py
@@ -1,0 +1,64 @@
+"""Block Kit `value` v2 포맷 round-trip 테스트.
+
+PRD `dev-relay-agent-integration.md` §3.2 / §3.3 — `[머지 검토]` / `[승인]` /
+`[상세 보기]` 모든 신규 버튼이 본 포맷을 사용한다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ai.dev_relay.slack_renderer import (
+    ActionPayloadV2,
+    build_action_value_v2,
+    build_merge_confirm_blocks,
+    parse_action_value_v2,
+)
+
+
+class TestRoundTrip:
+    def test_basic(self):
+        v = build_action_value_v2(pr_number=22, idempotency_key="abcd-1234", job_id=7)
+        parsed = parse_action_value_v2(v)
+        assert parsed == ActionPayloadV2(
+            pr_number=22, idempotency_key="abcd-1234", job_id=7
+        )
+
+    def test_format_contract(self):
+        # PRD §3.2 본문에 명시된 `pr=<N>;key=<idempotency_key>;job=<job_id>` 패턴.
+        v = build_action_value_v2(pr_number=42, idempotency_key="K", job_id=1)
+        assert v == "pr=42;key=K;job=1"
+
+    def test_empty_key_rejected(self):
+        with pytest.raises(ValueError):
+            build_action_value_v2(pr_number=22, idempotency_key="", job_id=1)
+
+    @pytest.mark.parametrize("key", ["a;b", "a=b"])
+    def test_separator_in_key_rejected(self, key: str):
+        with pytest.raises(ValueError):
+            build_action_value_v2(pr_number=22, idempotency_key=key, job_id=1)
+
+
+class TestParseInvalid:
+    @pytest.mark.parametrize(
+        "value", [None, "", "no-equals", "pr=22;key=abc", "pr=notint;key=abc;job=1"]
+    )
+    def test_invalid_returns_none(self, value):
+        assert parse_action_value_v2(value) is None
+
+    def test_partial_field_returns_none(self):
+        assert parse_action_value_v2("pr=22") is None
+
+
+class TestMergeConfirmUsesV2:
+    def test_buttons_carry_pr_number(self):
+        blocks = build_merge_confirm_blocks(
+            pr_number=22, idempotency_key="abcd-1234", job_id=7
+        )
+        actions = [b for b in blocks if b.get("type") == "actions"]
+        assert len(actions) == 1
+        for el in actions[0]["elements"]:
+            payload = parse_action_value_v2(el["value"])
+            assert payload is not None
+            assert payload.pr_number == 22
+            assert payload.job_id == 7

--- a/ai/tests/dev_relay/test_agent_integration.py
+++ b/ai/tests/dev_relay/test_agent_integration.py
@@ -1,0 +1,221 @@
+"""에이전트 통합 mock 통합 테스트.
+
+PRD `dev-relay-agent-integration.md` §8.1.
+
+본 파일은 Slack/SDK/`gh` 외부 호출을 mock 으로 대체한 채 picker → reviewer →
+merge 한 사이클을 1회 완주 검증한다 (AC-INT-1 / AC-INT-2 / AC-INT-6).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from ai.dev_relay.agent_runner import AgentRunner
+from ai.dev_relay.failures import FailureClassification
+from ai.dev_relay.merger import MergeOutcome, perform_merge, validate_approval
+from ai.dev_relay.queue import STATUS_DONE, JobQueue
+from ai.dev_relay.reviewer import ReviewDetailCache, ReviewResult
+from ai.dev_relay.worker import JobPicker
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "queue.db"
+
+
+@pytest.fixture
+def queue(db_path: Path) -> JobQueue:
+    return JobQueue(db_path)
+
+
+def _wait_until(predicate, *, timeout: float = 3.0, interval: float = 0.05) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+    raise AssertionError("timeout waiting for condition")
+
+
+class TestReviewerThenMergeRoundTrip:
+    """AC-INT-1 + AC-INT-2 + AC-INT-6 통합 시나리오."""
+
+    def test_review_pr_then_approve_merge(self, queue: JobQueue):
+        runner = AgentRunner()
+        try:
+            audit_records: list[dict] = []
+            cache = ReviewDetailCache()
+            expected_approvals: dict = {}
+
+            # 1) picker handler — reviewer mock 호출 + 결과 캐시 + audit.
+            def review_handler(job):
+                pr_number = int(job.command.rsplit(" ", 1)[-1])
+                audit_records.append({"kind": "reviewer_started", "job_id": job.id})
+                result = ReviewResult(
+                    summary=f"PR {pr_number} 깔끔합니다",
+                    findings=["비고 없음"],
+                    detail="자세한 본문 텍스트",
+                )
+                cache.put(job.id, result.detail)
+                expected_approvals[job.id] = type("ctx", (), {})()  # placeholder
+                expected_approvals[job.id].idempotency_key = job.idempotency_key
+                expected_approvals[job.id].job_id = job.id
+                expected_approvals[job.id].pr_number = pr_number
+                expected_approvals[job.id].user_id = job.user_id
+                audit_records.append(
+                    {
+                        "kind": "reviewer_done",
+                        "job_id": job.id,
+                        "finding_count": 1,
+                    }
+                )
+                return f"reviewer_done pr={pr_number}"
+
+            picker = JobPicker(
+                queue=queue,
+                runner=runner,
+                handler=review_handler,
+                poll_interval_s=0.05,
+            )
+            picker.start()
+            try:
+                # 2) review pr 22 큐 적재 → picker 처리 대기.
+                job, created = queue.enqueue(
+                    idempotency_key="abcd-1234",
+                    user_id="U0AE7A54NHL",
+                    command="review pr 22",
+                )
+                assert created is True
+                _wait_until(lambda: queue.get(job.id).status == STATUS_DONE)
+                assert any(
+                    r["kind"] == "reviewer_started" and r["job_id"] == job.id
+                    for r in audit_records
+                )
+                assert any(
+                    r["kind"] == "reviewer_done" and r["job_id"] == job.id
+                    for r in audit_records
+                )
+                assert cache.get(job.id) == "자세한 본문 텍스트"
+            finally:
+                picker.stop(wait=True, timeout=2.0)
+
+            # 3) `[승인]` 버튼 검증 + merge worker mock 호출.
+            expected = expected_approvals[job.id]
+            approval = validate_approval(
+                pr_number_in_payload=22,
+                idempotency_key_in_payload="abcd-1234",
+                job_id_in_payload=job.id,
+                expected_idempotency_key=expected.idempotency_key,
+                expected_job_id=expected.job_id,
+                user_id="U0AE7A54NHL",
+                allowed_user_ids=frozenset({"U0AE7A54NHL"}),
+                action_id="approve_merge",
+            )
+            captured: list[int] = []
+
+            def fake_worker(pr: int) -> MergeOutcome:
+                captured.append(pr)
+                return MergeOutcome(success=True, sha="abc1234", detail="squashed")
+
+            outcome = perform_merge(approval=approval, worker=fake_worker)
+            assert captured == [22]
+            assert outcome.success is True
+            assert outcome.sha == "abc1234"
+
+            # 4) audit kind 6종 (정상 흐름) 중 4개가 등장해야 한다.
+            audit_records.append({"kind": "merge_started", "job_id": job.id})
+            audit_records.append(
+                {"kind": "merge_done", "job_id": job.id, "sha": outcome.sha}
+            )
+            kinds = {r["kind"] for r in audit_records}
+            assert {"reviewer_started", "reviewer_done", "merge_started", "merge_done"} <= kinds
+        finally:
+            runner.shutdown(wait=True, timeout=2.0)
+
+
+class TestApprovalRejectsMismatchedPayload:
+    """AC-INT-7 회귀 일부: 검증 실패 시 `_perform_merge` 미호출."""
+
+    def test_idempotency_mismatch_blocks_call(self):
+        from ai.dev_relay.merger import MergeRejection
+
+        called = False
+
+        def worker(pr):
+            nonlocal called
+            called = True
+            return MergeOutcome(success=True, sha="x", detail="")
+
+        with pytest.raises(MergeRejection):
+            validate_approval(
+                pr_number_in_payload=22,
+                idempotency_key_in_payload="WRONG",
+                job_id_in_payload=7,
+                expected_idempotency_key="EXPECTED",
+                expected_job_id=7,
+                user_id="U0AE7A54NHL",
+                allowed_user_ids=frozenset({"U0AE7A54NHL"}),
+                action_id="approve_merge",
+            )
+
+        assert called is False
+
+
+class TestConcurrencyAcInt3:
+    """AC-INT-3: review 진행 중 두 번째 review 가 pending 으로 적재."""
+
+    def test_second_review_queued_while_first_running(self, queue: JobQueue):
+        runner = AgentRunner()
+        try:
+            gate = threading.Event()
+            release = threading.Event()
+            seen: list[int] = []
+
+            def handler(job):
+                seen.append(job.id)
+                if len(seen) == 1:
+                    gate.set()
+                    release.wait(timeout=3.0)
+                return "ok"
+
+            picker = JobPicker(
+                queue=queue, runner=runner, handler=handler, poll_interval_s=0.05
+            )
+            picker.start()
+            try:
+                a, _ = queue.enqueue(
+                    idempotency_key="ka", user_id="U", command="review pr 1"
+                )
+                b, _ = queue.enqueue(
+                    idempotency_key="kb", user_id="U", command="review pr 2"
+                )
+                assert gate.wait(timeout=2.0)
+                # 첫 작업 RUNNING, 두 번째는 PENDING.
+                assert queue.get(a.id).status == "running"
+                assert queue.get(b.id).status == "pending"
+                release.set()
+                _wait_until(lambda: queue.get(b.id).status == "done")
+            finally:
+                release.set()
+                picker.stop(wait=True, timeout=2.0)
+        finally:
+            runner.shutdown(wait=True, timeout=2.0)
+
+
+class TestFailureClassificationMatrixAcInt5:
+    """AC-INT-5: 5개 분류 + fallback 매핑이 templates 와 정합."""
+
+    def test_each_classification_user_message_clean(self):
+        from ai.coordinator._compliance import find_forbidden_keywords
+        from ai.dev_relay.failures import user_message_for
+
+        for classification in FailureClassification:
+            msg = user_message_for(classification)
+            assert msg, f"{classification} 메시지가 비어 있습니다"
+            assert find_forbidden_keywords(msg) == [], (
+                f"{classification} 메시지에 도메인 키워드: {msg}"
+            )

--- a/ai/tests/dev_relay/test_audit_recovery.py
+++ b/ai/tests/dev_relay/test_audit_recovery.py
@@ -1,0 +1,89 @@
+"""audit.jsonl 기반 머지 carve-out 식별 단위 테스트.
+
+PRD `dev-relay-agent-integration.md` §3.1.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ai.dev_relay.audit_recovery import find_merge_in_flight_job_ids
+
+
+def _write_audit(path: Path, lines: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for record in lines:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+class TestFindMergeInFlightJobIds:
+    def test_missing_file_returns_empty(self, tmp_path: Path):
+        assert find_merge_in_flight_job_ids(tmp_path / "no.jsonl") == frozenset()
+
+    def test_started_without_terminal_is_in_flight(self, tmp_path: Path):
+        path = tmp_path / "audit.jsonl"
+        _write_audit(
+            path,
+            [
+                {"ts": "x", "kind": "merge_started", "job_id": 7, "pr": 22},
+            ],
+        )
+        assert find_merge_in_flight_job_ids(path) == frozenset({7})
+
+    def test_started_then_done_not_in_flight(self, tmp_path: Path):
+        path = tmp_path / "audit.jsonl"
+        _write_audit(
+            path,
+            [
+                {"ts": "x", "kind": "merge_started", "job_id": 7, "pr": 22},
+                {"ts": "y", "kind": "merge_done", "job_id": 7, "pr": 22, "sha": "abc"},
+            ],
+        )
+        assert find_merge_in_flight_job_ids(path) == frozenset()
+
+    def test_started_then_failed_not_in_flight(self, tmp_path: Path):
+        path = tmp_path / "audit.jsonl"
+        _write_audit(
+            path,
+            [
+                {"ts": "x", "kind": "merge_started", "job_id": 7, "pr": 22},
+                {"ts": "y", "kind": "merge_failed", "job_id": 7, "pr": 22},
+            ],
+        )
+        assert find_merge_in_flight_job_ids(path) == frozenset()
+
+    def test_multiple_jobs_mixed(self, tmp_path: Path):
+        path = tmp_path / "audit.jsonl"
+        _write_audit(
+            path,
+            [
+                {"ts": "x", "kind": "merge_started", "job_id": 1, "pr": 11},
+                {"ts": "x", "kind": "merge_started", "job_id": 2, "pr": 12},
+                {"ts": "x", "kind": "merge_done", "job_id": 1, "pr": 11, "sha": "a"},
+                {"ts": "x", "kind": "merge_started", "job_id": 3, "pr": 13},
+            ],
+        )
+        assert find_merge_in_flight_job_ids(path) == frozenset({2, 3})
+
+    def test_corrupt_lines_skipped(self, tmp_path: Path):
+        path = tmp_path / "audit.jsonl"
+        path.write_text(
+            '{"ts": "x", "kind": "merge_started", "job_id": 7, "pr": 22}\n'
+            "this is not json\n"
+            '{"ts": "y", "kind": "merge_done", "job_id": 7, "pr": 22}\n',
+            encoding="utf-8",
+        )
+        assert find_merge_in_flight_job_ids(path) == frozenset()
+
+    def test_unrelated_kinds_ignored(self, tmp_path: Path):
+        path = tmp_path / "audit.jsonl"
+        _write_audit(
+            path,
+            [
+                {"ts": "x", "kind": "command_received", "job_id": 1},
+                {"ts": "x", "kind": "reviewer_started", "job_id": 1},
+                {"ts": "x", "kind": "reviewer_done", "job_id": 1},
+            ],
+        )
+        assert find_merge_in_flight_job_ids(path) == frozenset()

--- a/ai/tests/dev_relay/test_compliance.py
+++ b/ai/tests/dev_relay/test_compliance.py
@@ -27,6 +27,9 @@ from ai.dev_relay import slack_renderer
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PRD_PATH = REPO_ROOT / "docs" / "prd" / "slack-dev-relay.md"
 PRD_NL_PATH = REPO_ROOT / "docs" / "prd" / "dev-relay-natural-language.md"
+PRD_AGENT_INTEGRATION_PATH = (
+    REPO_ROOT / "docs" / "prd" / "dev-relay-agent-integration.md"
+)
 DEV_RELAY_DIR = REPO_ROOT / "ai" / "dev_relay"
 
 
@@ -67,6 +70,15 @@ _STATIC_TEMPLATES = (
     ("TEMPLATE_RATE_LIMIT", slack_renderer.TEMPLATE_RATE_LIMIT),
     ("TEMPLATE_UNKNOWN_COMMAND", slack_renderer.TEMPLATE_UNKNOWN_COMMAND),
     ("TEMPLATE_DESTRUCTIVE_BLOCKED", slack_renderer.TEMPLATE_DESTRUCTIVE_BLOCKED),
+    # PRD `dev-relay-agent-integration.md` 신규 템플릿.
+    ("TEMPLATE_MERGE_CARVE_OUT_NOTICE", slack_renderer.TEMPLATE_MERGE_CARVE_OUT_NOTICE),
+    ("TEMPLATE_REVIEW_DETAIL_LOOKUP_FAILED", slack_renderer.TEMPLATE_REVIEW_DETAIL_LOOKUP_FAILED),
+    ("TEMPLATE_FAIL_DESTRUCTIVE_BLOCKED", slack_renderer.TEMPLATE_FAIL_DESTRUCTIVE_BLOCKED),
+    ("TEMPLATE_FAIL_SDK_TIMEOUT", slack_renderer.TEMPLATE_FAIL_SDK_TIMEOUT),
+    ("TEMPLATE_FAIL_GITHUB_UNAUTHORIZED", slack_renderer.TEMPLATE_FAIL_GITHUB_UNAUTHORIZED),
+    ("TEMPLATE_FAIL_GITHUB_UNPROCESSABLE", slack_renderer.TEMPLATE_FAIL_GITHUB_UNPROCESSABLE),
+    ("TEMPLATE_FAIL_COMPLIANCE_BLOCKED", slack_renderer.TEMPLATE_FAIL_COMPLIANCE_BLOCKED),
+    ("TEMPLATE_FAIL_UNKNOWN", slack_renderer.TEMPLATE_FAIL_UNKNOWN),
 )
 
 
@@ -202,6 +214,16 @@ def test_prd_natural_language_body_outside_code_is_clean():
     matched = find_forbidden_keywords(body)
     assert matched == [], (
         f"자연어 분기 PRD 본문에 도메인 키워드가 노출되어 있습니다: {matched}"
+    )
+
+
+def test_prd_agent_integration_body_outside_code_is_clean():
+    """에이전트 통합 PRD 산문 검사 (AC-INT-8)."""
+    text = PRD_AGENT_INTEGRATION_PATH.read_text(encoding="utf-8")
+    body = _strip_code_blocks(text)
+    matched = find_forbidden_keywords(body)
+    assert matched == [], (
+        f"에이전트 통합 PRD 본문에 도메인 키워드가 노출되어 있습니다: {matched}"
     )
 
 

--- a/ai/tests/dev_relay/test_failures.py
+++ b/ai/tests/dev_relay/test_failures.py
@@ -1,0 +1,87 @@
+"""실패 분류 매핑 단위 테스트 (PRD `dev-relay-agent-integration.md` AC-INT-5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ai.dev_relay.agent_runner import DestructiveOperationBlocked
+from ai.dev_relay.failures import (
+    FailureClassification,
+    classify_exception,
+    classify_github_status,
+    report,
+    user_message_for,
+)
+from ai.dev_relay.slack_renderer import (
+    TEMPLATE_FAIL_COMPLIANCE_BLOCKED,
+    TEMPLATE_FAIL_DESTRUCTIVE_BLOCKED,
+    TEMPLATE_FAIL_GITHUB_UNAUTHORIZED,
+    TEMPLATE_FAIL_GITHUB_UNPROCESSABLE,
+    TEMPLATE_FAIL_SDK_TIMEOUT,
+    TEMPLATE_FAIL_UNKNOWN,
+)
+
+
+class TestUserMessageMapping:
+    """5개 분류 + fallback 모두 정적 템플릿과 정확히 매핑되는지."""
+
+    @pytest.mark.parametrize(
+        "classification,expected_template",
+        [
+            (FailureClassification.DESTRUCTIVE_BLOCKED, TEMPLATE_FAIL_DESTRUCTIVE_BLOCKED),
+            (FailureClassification.SDK_TIMEOUT, TEMPLATE_FAIL_SDK_TIMEOUT),
+            (FailureClassification.GITHUB_UNAUTHORIZED, TEMPLATE_FAIL_GITHUB_UNAUTHORIZED),
+            (FailureClassification.GITHUB_UNPROCESSABLE, TEMPLATE_FAIL_GITHUB_UNPROCESSABLE),
+            (FailureClassification.COMPLIANCE_BLOCKED, TEMPLATE_FAIL_COMPLIANCE_BLOCKED),
+            (FailureClassification.UNKNOWN_ERROR, TEMPLATE_FAIL_UNKNOWN),
+        ],
+    )
+    def test_each_classification_maps_to_template(
+        self, classification: FailureClassification, expected_template: str
+    ):
+        assert user_message_for(classification) == expected_template
+
+
+class TestClassifyGithubStatus:
+    @pytest.mark.parametrize("code", [401, 403])
+    def test_auth_codes(self, code: int):
+        assert classify_github_status(code) is FailureClassification.GITHUB_UNAUTHORIZED
+
+    def test_unprocessable(self):
+        assert classify_github_status(422) is FailureClassification.GITHUB_UNPROCESSABLE
+
+    @pytest.mark.parametrize("code", [200, 500, 502, 999])
+    def test_other_codes_fallback(self, code: int):
+        assert classify_github_status(code) is FailureClassification.UNKNOWN_ERROR
+
+
+class TestClassifyException:
+    def test_destructive_blocked(self):
+        exc = DestructiveOperationBlocked("blocked")
+        assert classify_exception(exc) is FailureClassification.DESTRUCTIVE_BLOCKED
+
+    def test_timeout(self):
+        exc = TimeoutError("waited too long")
+        assert classify_exception(exc) is FailureClassification.SDK_TIMEOUT
+
+    def test_unknown_fallback(self):
+        exc = ValueError("nope")
+        assert classify_exception(exc) is FailureClassification.UNKNOWN_ERROR
+
+    def test_custom_timeout_marker(self):
+        class MyTimeout(Exception):
+            pass
+
+        exc = MyTimeout("dom timeout")
+        assert (
+            classify_exception(exc, timeout_marker_types=(MyTimeout,))
+            is FailureClassification.SDK_TIMEOUT
+        )
+
+
+class TestReport:
+    def test_report_packages_classification_and_message(self):
+        rep = report(FailureClassification.GITHUB_UNAUTHORIZED, detail="gh stderr 401")
+        assert rep.classification is FailureClassification.GITHUB_UNAUTHORIZED
+        assert rep.user_message == TEMPLATE_FAIL_GITHUB_UNAUTHORIZED
+        assert "401" in rep.detail

--- a/ai/tests/dev_relay/test_merger.py
+++ b/ai/tests/dev_relay/test_merger.py
@@ -1,0 +1,185 @@
+"""`_perform_merge` 검증 + payload 단위 테스트.
+
+PRD `dev-relay-agent-integration.md` §3.3 / AC-INT-2 / AC-INT-7.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ai.dev_relay.failures import FailureClassification
+from ai.dev_relay.merger import (
+    MERGE_STRATEGY,
+    ApprovalContext,
+    MergeOutcome,
+    MergeRejection,
+    classify_merge_stderr,
+    extract_sha,
+    perform_merge,
+    validate_approval,
+)
+
+
+_ALLOWED = frozenset({"U0AE7A54NHL"})
+
+
+class TestValidateApproval:
+    def _base_kwargs(self) -> dict:
+        return {
+            "pr_number_in_payload": 22,
+            "idempotency_key_in_payload": "abcd-1234",
+            "job_id_in_payload": 7,
+            "expected_idempotency_key": "abcd-1234",
+            "expected_job_id": 7,
+            "user_id": "U0AE7A54NHL",
+            "allowed_user_ids": _ALLOWED,
+            "action_id": "approve_merge",
+        }
+
+    def test_happy_path(self):
+        ctx = validate_approval(**self._base_kwargs())
+        assert ctx.pr_number == 22
+        assert ctx.idempotency_key == "abcd-1234"
+        assert ctx.job_id == 7
+        assert ctx.user_id == "U0AE7A54NHL"
+
+    def test_wrong_action_id_rejected(self):
+        kwargs = self._base_kwargs() | {"action_id": "merge_review"}
+        with pytest.raises(MergeRejection):
+            validate_approval(**kwargs)
+
+    def test_user_not_in_allow_list(self):
+        kwargs = self._base_kwargs() | {"user_id": "Uintruder99"}
+        with pytest.raises(MergeRejection):
+            validate_approval(**kwargs)
+
+    @pytest.mark.parametrize("bad", [None, 0, -1])
+    def test_invalid_pr_number(self, bad):
+        kwargs = self._base_kwargs() | {"pr_number_in_payload": bad}
+        with pytest.raises(MergeRejection):
+            validate_approval(**kwargs)
+
+    def test_missing_idempotency_key(self):
+        kwargs = self._base_kwargs() | {"idempotency_key_in_payload": ""}
+        with pytest.raises(MergeRejection):
+            validate_approval(**kwargs)
+
+    def test_idempotency_key_mismatch(self):
+        kwargs = self._base_kwargs() | {"expected_idempotency_key": "OTHER"}
+        with pytest.raises(MergeRejection):
+            validate_approval(**kwargs)
+
+    def test_job_id_mismatch(self):
+        kwargs = self._base_kwargs() | {"expected_job_id": 999}
+        with pytest.raises(MergeRejection):
+            validate_approval(**kwargs)
+
+    def test_no_expected_relaxed(self):
+        # expected 가 None 이면 페이로드 자체만 검증. (예: 캐시 유실 후 fallback)
+        kwargs = self._base_kwargs() | {
+            "expected_idempotency_key": None,
+            "expected_job_id": None,
+        }
+        ctx = validate_approval(**kwargs)
+        assert ctx.pr_number == 22
+
+
+class TestPerformMerge:
+    def test_dispatches_to_worker_with_pr_number(self):
+        approval = ApprovalContext(
+            pr_number=42,
+            idempotency_key="abcd-1234",
+            job_id=11,
+            user_id="U0AE7A54NHL",
+        )
+        captured: list[int] = []
+
+        def worker(pr: int) -> MergeOutcome:
+            captured.append(pr)
+            return MergeOutcome(success=True, sha="deadbeef1234567", detail="ok")
+
+        outcome = perform_merge(approval=approval, worker=worker)
+        assert captured == [42]
+        assert outcome.success is True
+        assert outcome.sha == "deadbeef1234567"
+
+    def test_strategy_is_squash(self):
+        # PRD §10 — squash 고정.
+        assert MERGE_STRATEGY == "squash"
+
+
+class TestClassifyMergeStderr:
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "gh: HTTP 401: Bad credentials",
+            "permission denied",
+            "403 Forbidden",
+            "authentication failed",
+        ],
+    )
+    def test_unauthorized(self, stderr: str):
+        assert (
+            classify_merge_stderr(stderr)
+            is FailureClassification.GITHUB_UNAUTHORIZED
+        )
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "422 Unprocessable Entity",
+            "Pull request is not mergeable",
+            "checks failed",
+            "merge conflict",
+        ],
+    )
+    def test_unprocessable(self, stderr: str):
+        assert (
+            classify_merge_stderr(stderr)
+            is FailureClassification.GITHUB_UNPROCESSABLE
+        )
+
+    def test_unknown_fallback(self):
+        assert (
+            classify_merge_stderr("some random network error")
+            is FailureClassification.UNKNOWN_ERROR
+        )
+
+    def test_empty_is_unknown(self):
+        assert classify_merge_stderr("") is FailureClassification.UNKNOWN_ERROR
+        assert classify_merge_stderr(None) is FailureClassification.UNKNOWN_ERROR
+
+
+class TestExtractSha:
+    def test_extracts_short_sha(self):
+        out = "Merged PR #22 as squash; commit deadbeef1 on main"
+        assert extract_sha(out) == "deadbeef1"
+
+    def test_extracts_long_sha(self):
+        out = "Squashed and merged: 1234567890abcdef1234567890abcdef12345678"
+        assert extract_sha(out) == "1234567890abcdef1234567890abcdef12345678"
+
+    def test_no_sha_returns_none(self):
+        assert extract_sha("All good!") is None
+        assert extract_sha("") is None
+        assert extract_sha(None) is None
+
+
+class TestDispatcherDoesNotBlockGhMerge:
+    """AC-INT-7 회귀: dispatcher 의 destructive 가드는 `gh pr merge` 를 차단하지 않음."""
+
+    def test_dispatcher_allows_gh_pr_merge(self):
+        from ai.dev_relay.dispatcher import is_destructive
+
+        # `gh pr merge 22 --squash --delete-branch` 가 destructive 분류에 떨어지지
+        # 않아야 한다 (의도적 destructive op 이지만 사용자 명시 승인 흐름).
+        assert is_destructive("gh pr merge 22 --squash --delete-branch") is False
+
+    def test_dispatcher_still_blocks_known_destructive(self):
+        from ai.dev_relay.dispatcher import is_destructive
+
+        # 회귀: 기존 차단 대상이 여전히 차단되는지.
+        assert is_destructive("git reset --hard HEAD~5") is True
+        assert is_destructive("git push --force origin main") is True
+        assert is_destructive("git branch -d feature") is True
+        assert is_destructive("git clean -fd") is True

--- a/ai/tests/dev_relay/test_queue.py
+++ b/ai/tests/dev_relay/test_queue.py
@@ -134,10 +134,11 @@ class TestRecoverRunningAsFailed:
             command="review pr 8",
         )
         # job_b 는 pending 상태로 둔다.
-        recovered = queue.recover_running_as_failed()
-        assert len(recovered) == 1
-        assert recovered[0].id == job_a.id
-        assert recovered[0].status == STATUS_FAILED
+        failed, unknown = queue.recover_running_as_failed()
+        assert len(failed) == 1
+        assert failed[0].id == job_a.id
+        assert failed[0].status == STATUS_FAILED
+        assert unknown == []
         # pending job 은 그대로.
         assert queue.count_by_status(STATUS_PENDING) == 1
         assert queue.count_by_status(STATUS_RUNNING) == 0
@@ -154,9 +155,9 @@ class TestRecoverRunningAsFailed:
 
         # 재시작.
         second = JobQueue(db_path)
-        recovered = second.recover_running_as_failed()
-        assert len(recovered) == 1
-        assert recovered[0].id == job.id
+        failed, _unknown = second.recover_running_as_failed()
+        assert len(failed) == 1
+        assert failed[0].id == job.id
         # 같은 멱등성 키 재수신 시 새 row 가 만들어지지 않는다.
         again, created = second.enqueue(
             idempotency_key="restart-key",

--- a/ai/tests/dev_relay/test_reviewer.py
+++ b/ai/tests/dev_relay/test_reviewer.py
@@ -1,0 +1,126 @@
+"""reviewer 결과 캐시·렌더링 단위 테스트.
+
+PRD `dev-relay-agent-integration.md` §3.2.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ai.coordinator._compliance import find_forbidden_keywords
+from ai.dev_relay.reviewer import (
+    MAX_FINDINGS_DISPLAYED,
+    ReviewDetailCache,
+    ReviewResult,
+    truncate_findings,
+)
+from ai.dev_relay.slack_renderer import (
+    build_review_result_blocks,
+    parse_action_value_v2,
+)
+
+
+class TestReviewDetailCache:
+    def test_put_and_get(self):
+        cache = ReviewDetailCache()
+        cache.put(7, "발견 사항 본문")
+        assert cache.get(7) == "발견 사항 본문"
+
+    def test_cache_miss_returns_none(self):
+        cache = ReviewDetailCache()
+        assert cache.get(99) is None
+
+    def test_lru_eviction(self):
+        cache = ReviewDetailCache(max_entries=2)
+        cache.put(1, "a")
+        cache.put(2, "b")
+        cache.put(3, "c")
+        # 1 이 evict 되어 None.
+        assert cache.get(1) is None
+        assert cache.get(2) == "b"
+        assert cache.get(3) == "c"
+
+    def test_invalid_max(self):
+        with pytest.raises(ValueError):
+            ReviewDetailCache(max_entries=0)
+
+
+class TestTruncateFindings:
+    def test_short_passthrough(self):
+        assert truncate_findings(["a", "b"]) == ["a", "b"]
+
+    def test_truncated(self):
+        items = [f"item-{i}" for i in range(5)]
+        assert truncate_findings(items) == items[:MAX_FINDINGS_DISPLAYED]
+
+    def test_empty(self):
+        assert truncate_findings([]) == []
+
+
+class TestReviewResultBlocksWithV2Payload:
+    """PRD 위험 §1: `[머지 검토]` 페이로드에 PR 번호가 포함되어야 한다."""
+
+    def test_button_value_contains_pr_number(self):
+        blocks = build_review_result_blocks(
+            pr_number=22,
+            summary="요약 본문",
+            findings=["발견 1"],
+            idempotency_key="abcd-1234",
+            job_id=7,
+        )
+        # actions block 에 두 버튼이 있어야 한다.
+        actions = [b for b in blocks if b.get("type") == "actions"]
+        assert len(actions) == 1
+        elements = actions[0]["elements"]
+        action_ids = [e["action_id"] for e in elements]
+        assert "merge_review" in action_ids
+        assert "view_details" in action_ids
+
+        # 모든 버튼 value 가 v2 포맷이고 pr_number 가 22.
+        for el in elements:
+            payload = parse_action_value_v2(el["value"])
+            assert payload is not None
+            assert payload.pr_number == 22
+            assert payload.idempotency_key == "abcd-1234"
+            assert payload.job_id == 7
+
+    def test_no_findings_falls_back_to_message(self):
+        blocks = build_review_result_blocks(
+            pr_number=5,
+            summary="간단 요약",
+            findings=None,
+            idempotency_key="key",
+            job_id=1,
+        )
+        # 본문에 "특이사항 없음" 이 포함된다.
+        joined = " ".join(
+            b.get("text", {}).get("text", "") if isinstance(b.get("text"), dict) else ""
+            for b in blocks
+        )
+        assert "특이사항 없음" in joined
+
+    def test_dirty_summary_replaced_with_fallback(self):
+        # 도메인 키워드가 들어가면 원본이 발사 텍스트에 남지 않는다.
+        import json
+
+        blocks = build_review_result_blocks(
+            pr_number=22,
+            summary="this contains signal keyword",
+            findings=None,
+            idempotency_key="key",
+            job_id=1,
+        )
+        joined = json.dumps(blocks, ensure_ascii=False)
+        assert find_forbidden_keywords(joined) == []
+
+
+class TestReviewResultDataclass:
+    def test_construction(self):
+        result = ReviewResult(
+            summary="요약",
+            findings=["a", "b", "c", "d"],
+            detail="자세한 본문",
+        )
+        assert result.summary == "요약"
+        assert len(result.findings) == 4
+        assert result.detail == "자세한 본문"

--- a/ai/tests/dev_relay/test_worker.py
+++ b/ai/tests/dev_relay/test_worker.py
@@ -1,0 +1,179 @@
+"""백그라운드 picker 단위·통합 테스트.
+
+PRD `dev-relay-agent-integration.md` §3.1 / AC-INT-3 / AC-INT-4.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from ai.dev_relay.agent_runner import AgentRunner
+from ai.dev_relay.queue import (
+    STATUS_DONE,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_RUNNING,
+    Job,
+    JobQueue,
+)
+from ai.dev_relay.worker import JobPicker
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "queue.db"
+
+
+@pytest.fixture
+def queue(db_path: Path) -> JobQueue:
+    return JobQueue(db_path)
+
+
+@pytest.fixture
+def runner() -> AgentRunner:
+    r = AgentRunner()
+    yield r
+    r.shutdown(wait=True, timeout=2.0)
+
+
+def _wait_until(predicate, *, timeout: float = 3.0, interval: float = 0.05) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+    raise AssertionError("timeout waiting for condition")
+
+
+class TestClaimNextPending:
+    def test_oldest_first(self, queue: JobQueue):
+        a, _ = queue.enqueue(idempotency_key="a", user_id="U", command="review pr 1")
+        # 분리된 created_at 시각을 위해 약간 sleep.
+        time.sleep(0.02)
+        b, _ = queue.enqueue(idempotency_key="b", user_id="U", command="review pr 2")
+        first = queue.claim_next_pending()
+        assert first is not None
+        assert first.id == a.id
+        assert first.status == STATUS_RUNNING
+        second = queue.claim_next_pending()
+        assert second is not None
+        assert second.id == b.id
+
+    def test_returns_none_when_empty(self, queue: JobQueue):
+        assert queue.claim_next_pending() is None
+
+    def test_running_jobs_are_not_reclaimed(self, queue: JobQueue):
+        a, _ = queue.enqueue(idempotency_key="a", user_id="U", command="review pr 1")
+        first = queue.claim_next_pending()
+        assert first is not None and first.id == a.id
+        # 두 번째 호출 — 같은 job 을 다시 잡으면 안 된다.
+        assert queue.claim_next_pending() is None
+
+
+class TestJobPickerLifecycle:
+    def test_picker_processes_pending_job(self, queue: JobQueue, runner: AgentRunner):
+        processed: list[int] = []
+
+        def handler(job: Job) -> str | None:
+            processed.append(job.id)
+            return "ok"
+
+        picker = JobPicker(
+            queue=queue, runner=runner, handler=handler, poll_interval_s=0.05
+        )
+        picker.start()
+        try:
+            job, _ = queue.enqueue(
+                idempotency_key="key-1", user_id="U", command="review pr 1"
+            )
+            _wait_until(lambda: queue.get(job.id).status == STATUS_DONE, timeout=3.0)
+            assert processed == [job.id]
+        finally:
+            picker.stop(wait=True, timeout=2.0)
+
+    def test_handler_exception_marks_failed(
+        self, queue: JobQueue, runner: AgentRunner
+    ):
+        def handler(job: Job) -> str | None:
+            raise RuntimeError("boom")
+
+        picker = JobPicker(
+            queue=queue, runner=runner, handler=handler, poll_interval_s=0.05
+        )
+        picker.start()
+        try:
+            job, _ = queue.enqueue(
+                idempotency_key="key-2", user_id="U", command="review pr 2"
+            )
+            _wait_until(
+                lambda: queue.get(job.id).status == STATUS_FAILED, timeout=3.0
+            )
+        finally:
+            picker.stop(wait=True, timeout=2.0)
+
+    def test_concurrency_second_job_waits(
+        self, queue: JobQueue, runner: AgentRunner
+    ):
+        """AC-INT-3: 첫 job 이 처리 중인 동안 두 번째 job 은 pending 으로 대기."""
+        gate = threading.Event()
+        release = threading.Event()
+        first_seen: list[int] = []
+
+        def handler(job: Job) -> str | None:
+            first_seen.append(job.id)
+            if len(first_seen) == 1:
+                # 첫 job 은 release 신호 받을 때까지 hold.
+                gate.set()
+                release.wait(timeout=3.0)
+            return "ok"
+
+        picker = JobPicker(
+            queue=queue, runner=runner, handler=handler, poll_interval_s=0.05
+        )
+        picker.start()
+        try:
+            job_a, _ = queue.enqueue(
+                idempotency_key="ka", user_id="U", command="review pr 1"
+            )
+            job_b, _ = queue.enqueue(
+                idempotency_key="kb", user_id="U", command="review pr 2"
+            )
+            # 첫 job 이 핸들러에 진입하면 gate 가 set 된다.
+            assert gate.wait(timeout=2.0)
+            # 첫 job 이 RUNNING, 두 번째는 PENDING 이어야 한다.
+            assert queue.get(job_a.id).status == STATUS_RUNNING
+            assert queue.get(job_b.id).status == STATUS_PENDING
+            # 첫 job 해제 → 두 번째도 처리되어야.
+            release.set()
+            _wait_until(lambda: queue.get(job_a.id).status == STATUS_DONE)
+            _wait_until(lambda: queue.get(job_b.id).status == STATUS_DONE)
+        finally:
+            release.set()
+            picker.stop(wait=True, timeout=2.0)
+
+
+class TestRecoveryWithMergeCarveOut:
+    """PRD §3.1 머지 carve-out — `merge_started` 후 종결 라인 없는 job 은 unknown."""
+
+    def test_merge_in_flight_marked_unknown(self, queue: JobQueue):
+        merge_job, _ = queue.enqueue(
+            idempotency_key="m1", user_id="U", command="merge pr 22"
+        )
+        review_job, _ = queue.enqueue(
+            idempotency_key="r1", user_id="U", command="review pr 23"
+        )
+        queue.mark_running(merge_job.id)
+        queue.mark_running(review_job.id)
+
+        failed, unknown = queue.recover_running_as_failed(
+            merge_in_flight_job_ids=frozenset({merge_job.id})
+        )
+        assert [j.id for j in failed] == [review_job.id]
+        assert [j.id for j in unknown] == [merge_job.id]
+        # status 검증.
+        assert queue.get(merge_job.id).status == "unknown"
+        assert queue.get(review_job.id).status == STATUS_FAILED

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -417,3 +417,42 @@
   - PRD `dev-relay-agent-integration` 사용자 검토 후 별도 PR (다음 세션 첫 트랙).
   - Issue #28 본문 strikethrough (사용자 동의 후, 외부 가시 액션).
   - shell metachar 정책 완화 — 다음 세션 추천 1순위.
+
+### 2026-05-06 — feat(dev-relay): 에이전트 통합 — reviewer 결과·실 머지·동시성 큐 적재 (#43)
+
+- **slug**: `dev-relay-agent-integration` · **author**: @HY0118
+- **PR**: https://github.com/deeptrading-lab/trading-signal-engine/pull/43
+- **요약**: feat(dev-relay): 에이전트 통합 — reviewer 결과·실 머지·동시성 큐 적재
+- **현재 상태**: QA 통과 · 리뷰·머지 대기 (이 항목은 QA 통과 시점에 자동 기록됨)
+- **PR 본문 발췌**:
+  > ## Summary
+  > 
+  > 상위 PRD `slack-dev-relay.md` deferred 3건(AC-4 reviewer 결과 + Block Kit 버튼, AC-5 2단계 실 머지, AC-14 동시성 큐 적재) 을 reproducible 하게 통합한다. 본 PRD: docs/prd/dev-relay-agent-integration.md (#42).
+  > 
+  > ### 트리거 / 참고
+  > - 트리거 Issue: #28
+  > - 상위 PRD: docs/prd/slack-dev-relay.md
+  > - 본 PRD: docs/prd/dev-relay-agent-integration.md
+  > - 선행 PR: #25 (slack-dev-relay), #37 (AgentRunner shutdown)
+  > 
+  > ### 구현 결정 (PRD §10 표 그대로)
+  > - **Worker 루프**: 데몬 시작 시 백그라운드 thread 1개 (`JobPicker`). `JobQueue.pending` 을 1초 폴링 (`DEFAULT_POLL_INTERVAL_S`). oldest-first 1건 dequeue → `pending → running` atomic 전이 (`claim_next_pending`).
+  > - **reviewer 호출**: `AgentRunner.run_callable` 경유. `nl_sdk_runtime` 와 별도 진입점 (`_build_reviewer`). 결과는 `ReviewResult(summary, findings, detail)` — `[머지 검토]` `[상세 보기]` 버튼 발사 + `ReviewDetailCache(LRU)` 에 본문 저장. `[상세 보기]` 캐시 유실 시 `TEMPLATE_REVIEW_DETAIL_LOOKUP_FAILED` 안내 + audit `reviewer_detail_lookup_failed`.
+  > - **머지 호출**: `_perform_merge` (merger 모듈) — `AgentRunner` 우회. `gh pr merge <N> --squash --delete-branch` 고정 (PRD §10). `validate_approval` 이 화이트리스트 user_id + action_id + payload 의 idempotency_key·job_id 일치를 통과한 경우에만 호출.
+  > - **Block Kit 페이로드 v2**: `pr=<N>;key=<idempotency_key>;job=<job_id>` 신규 포맷. `[머지 검토]` `[승인]` `[취소]` `[상세 보기]` 모두 본 포맷. legacy `build_action_value`/`parse_action_value` 는 호환성 유지용으로 남김.
+  > - **destructive 가드 회귀**: `is_destructive` 가 \`gh pr merge\` 를 차단하지 않음을 회귀 테스트로 명시 (`test_merger.py::TestDispatcherDoesNotBlockGhMerge`). 기존 `git reset --hard`, `force push`, `branch -d`, `clean -fd` 차단은 그대로.
+  > - **실패 분류 5개** (`failures.py`): `destructive_blocked` / `sdk_timeout` / `github_unauthorized` / `github_unprocessable` / `compliance_blocked` + `unknown_error` fallback. 각 분류별 사용자 노출 메시지는 PRD §3.5 표 그대로 정적 템플릿 (`TEMPLATE_FAIL_*`).
+  > - **신규 audit kind 7개**: `reviewer_started`, `reviewer_done`, `reviewer_failed`, `reviewer_detail_lookup_failed`, `merge_started`, `merge_done`, `merge_failed`. 기존 `command_received`/`job_started`/`job_done` 라이프사이클과 협업.
+  > - **재시작 머지 carve-out**: `audit_recovery.find_merge_in_flight_job_ids` 가 `merge_started` 후 종결 라인 없는 job_id 를 식별. `JobQueue.recover_running_as_failed(merge_in_flight_job_ids=...)` 가 carve-out job 은 `unknown` 으로 남기고 사용자 안내 (`TEMPLATE_MERGE_CARVE_OUT_NOTICE`).
+  > - **컴플라이언스**: 신규 메시지·버튼 라벨·audit kind 명·신규 PRD 본문·신규 모듈 모두 `ai/coordinator/_compliance.py` `FORBIDDEN_KEYWORDS` 통과. `test_compliance.py` 정적 검사가 본 PRD 산출물도 커버.
+  > 
+  > ### 신규 모듈 (재사용 인프라 재구현 금지 원칙 준수)
+  > - `ai/dev_relay/worker.py` — `JobPicker`, `JobHandler` 시그니처. `AgentRunner` 그대로 사용.
+  > - `ai/dev_relay/reviewer.py` — `ReviewResult`, `ReviewDetailCache`, `truncate_findings`. SDK 호출 자체는 caller-injected.
+  > - `ai/dev_relay/merger.py` — `validate_approval`, `perform_merge`, `classify_merge_stderr`, `extract_sha`. 외부 프로세스 호출도 caller-injected.
+  > - `ai/dev_relay/failures.py` — `FailureClassification`, `classify_exception`, `classify_github_status`, `user_message_for`.
+  > - `ai/dev_relay/audit_recovery.py` — `find_merge_in_flight_job_ids`.
+  > - `ai/dev_relay/queue.py` 추가: `claim_next_pending`, `mark_unknown`, `recover_running_as_failed` 시그니처 확장 (failed/unknown 분리).
+  > - `ai/dev_relay/slack_renderer.py` 추가: `build_action_value_v2`/`parse_action_value_v2`/`ActionPayloadV2`, 7개 신규 정적 템플릿.
+  > 
+- **다음 작업 후보**: _PR 본문에 별도 섹션 없음. 본문 참고하여 판단._


### PR DESCRIPTION
## Summary

상위 PRD `slack-dev-relay.md` deferred 3건(AC-4 reviewer 결과 + Block Kit 버튼, AC-5 2단계 실 머지, AC-14 동시성 큐 적재) 을 reproducible 하게 통합한다. 본 PRD: docs/prd/dev-relay-agent-integration.md (#42).

### 트리거 / 참고
- 트리거 Issue: #28
- 상위 PRD: docs/prd/slack-dev-relay.md
- 본 PRD: docs/prd/dev-relay-agent-integration.md
- 선행 PR: #25 (slack-dev-relay), #37 (AgentRunner shutdown)

### 구현 결정 (PRD §10 표 그대로)
- **Worker 루프**: 데몬 시작 시 백그라운드 thread 1개 (`JobPicker`). `JobQueue.pending` 을 1초 폴링 (`DEFAULT_POLL_INTERVAL_S`). oldest-first 1건 dequeue → `pending → running` atomic 전이 (`claim_next_pending`).
- **reviewer 호출**: `AgentRunner.run_callable` 경유. `nl_sdk_runtime` 와 별도 진입점 (`_build_reviewer`). 결과는 `ReviewResult(summary, findings, detail)` — `[머지 검토]` `[상세 보기]` 버튼 발사 + `ReviewDetailCache(LRU)` 에 본문 저장. `[상세 보기]` 캐시 유실 시 `TEMPLATE_REVIEW_DETAIL_LOOKUP_FAILED` 안내 + audit `reviewer_detail_lookup_failed`.
- **머지 호출**: `_perform_merge` (merger 모듈) — `AgentRunner` 우회. `gh pr merge <N> --squash --delete-branch` 고정 (PRD §10). `validate_approval` 이 화이트리스트 user_id + action_id + payload 의 idempotency_key·job_id 일치를 통과한 경우에만 호출.
- **Block Kit 페이로드 v2**: `pr=<N>;key=<idempotency_key>;job=<job_id>` 신규 포맷. `[머지 검토]` `[승인]` `[취소]` `[상세 보기]` 모두 본 포맷. legacy `build_action_value`/`parse_action_value` 는 호환성 유지용으로 남김.
- **destructive 가드 회귀**: `is_destructive` 가 \`gh pr merge\` 를 차단하지 않음을 회귀 테스트로 명시 (`test_merger.py::TestDispatcherDoesNotBlockGhMerge`). 기존 `git reset --hard`, `force push`, `branch -d`, `clean -fd` 차단은 그대로.
- **실패 분류 5개** (`failures.py`): `destructive_blocked` / `sdk_timeout` / `github_unauthorized` / `github_unprocessable` / `compliance_blocked` + `unknown_error` fallback. 각 분류별 사용자 노출 메시지는 PRD §3.5 표 그대로 정적 템플릿 (`TEMPLATE_FAIL_*`).
- **신규 audit kind 7개**: `reviewer_started`, `reviewer_done`, `reviewer_failed`, `reviewer_detail_lookup_failed`, `merge_started`, `merge_done`, `merge_failed`. 기존 `command_received`/`job_started`/`job_done` 라이프사이클과 협업.
- **재시작 머지 carve-out**: `audit_recovery.find_merge_in_flight_job_ids` 가 `merge_started` 후 종결 라인 없는 job_id 를 식별. `JobQueue.recover_running_as_failed(merge_in_flight_job_ids=...)` 가 carve-out job 은 `unknown` 으로 남기고 사용자 안내 (`TEMPLATE_MERGE_CARVE_OUT_NOTICE`).
- **컴플라이언스**: 신규 메시지·버튼 라벨·audit kind 명·신규 PRD 본문·신규 모듈 모두 `ai/coordinator/_compliance.py` `FORBIDDEN_KEYWORDS` 통과. `test_compliance.py` 정적 검사가 본 PRD 산출물도 커버.

### 신규 모듈 (재사용 인프라 재구현 금지 원칙 준수)
- `ai/dev_relay/worker.py` — `JobPicker`, `JobHandler` 시그니처. `AgentRunner` 그대로 사용.
- `ai/dev_relay/reviewer.py` — `ReviewResult`, `ReviewDetailCache`, `truncate_findings`. SDK 호출 자체는 caller-injected.
- `ai/dev_relay/merger.py` — `validate_approval`, `perform_merge`, `classify_merge_stderr`, `extract_sha`. 외부 프로세스 호출도 caller-injected.
- `ai/dev_relay/failures.py` — `FailureClassification`, `classify_exception`, `classify_github_status`, `user_message_for`.
- `ai/dev_relay/audit_recovery.py` — `find_merge_in_flight_job_ids`.
- `ai/dev_relay/queue.py` 추가: `claim_next_pending`, `mark_unknown`, `recover_running_as_failed` 시그니처 확장 (failed/unknown 분리).
- `ai/dev_relay/slack_renderer.py` 추가: `build_action_value_v2`/`parse_action_value_v2`/`ActionPayloadV2`, 7개 신규 정적 템플릿.

### 테스트 커버리지
- 신규 단위 테스트: `test_worker.py`, `test_reviewer.py`, `test_merger.py`, `test_failures.py`, `test_audit_recovery.py`, `test_action_value_v2.py`.
- 신규 통합 (mock) 테스트: `test_agent_integration.py` — picker → reviewer mock → 결과 캐시 → 검증 → merge worker mock → outcome → audit 7 kind 한 사이클 완주.
- 회귀: 기존 339 PASS → 본 PR 후 613 PASS (모든 기존 테스트 0 fail 유지). 컴플라이언스 정적 검사가 신규 PRD·신규 템플릿·신규 모듈 모두 커버.

### 수용 기준 체크리스트 (PRD §5)
- [x] AC-INT-1: reviewer 결과 + Block Kit 버튼 (요약·발견 사항·`[머지 검토]` `[상세 보기]`).
- [x] AC-INT-2: `[승인]` → 실 머지 (`_perform_merge`).
- [x] AC-INT-3: 동시성 두 번째 명령 큐 적재 (`test_worker.py::TestJobPickerLifecycle::test_concurrency_second_job_waits` + `test_agent_integration.py::TestConcurrencyAcInt3`).
- [x] AC-INT-4: Worker 루프 가용성 (`test_worker.py::TestJobPickerLifecycle::test_picker_processes_pending_job` + shutdown 통합).
- [x] AC-INT-5: 실패 분류 5개 + fallback 매핑 (`test_failures.py::TestUserMessageMapping`, `test_agent_integration.py::TestFailureClassificationMatrixAcInt5`).
- [x] AC-INT-6: audit 신규 kind 기록 (`test_agent_integration.py::TestReviewerThenMergeRoundTrip`).
- [x] AC-INT-7: destructive 가드 회귀 — `gh pr merge` 미차단 명시 + 기존 차단 대상 회귀 (`test_merger.py::TestDispatcherDoesNotBlockGhMerge`).
- [x] AC-INT-8: 컴플라이언스 회귀 — `test_compliance.py` 가 신규 템플릿·신규 모듈·본 PRD 본문 모두 정적 스캔.

### 수동 검증 가이드 (PRD §8.2)
부록 A 셋업이 완료된 환경(.env.local + Slack App + Claude SDK 인증 + `gh auth status` 통과)에서 모바일 Slack 앱 1 사이클:
1. DM 에 `review pr <N>` 입력 → 같은 스레드에서 큐 적재 안내 → reviewer 결과 메시지 (요약 2~3 문장 + 발견 사항 ≤3건 + `[머지 검토]` `[상세 보기]` 버튼).
2. `[상세 보기]` 클릭 → 같은 스레드 본문 발사.
3. `[머지 검토]` 클릭 → 같은 스레드 confirm 다이얼로그 (`[승인]` `[취소]`).
4. `[승인]` 클릭 → `gh pr merge <N> --squash --delete-branch` 실행 → 같은 스레드 머지 결과 메시지 (성공 SHA + 전략 또는 §3.5 분류 라벨).
5. 결과 메시지·버튼 라벨·실패 분류 라벨 모두 도메인 키워드 미포함 (육안 확인).

### Devops 가드 안내
- 본 PR 머지는 사용자 승인 후 별도 단계 (PR 본문 작성 + `impl-ready` 라벨까지가 본 단계 책임).
- 머지 전략: squash + 브랜치 정리 (PRD §10).

## Test plan
- [x] `python -m pytest ai/tests -q` — 613 passed
- [x] 신규 단위 + 통합 mock 테스트 6개 파일 추가 (총 +106 테스트)
- [x] 컴플라이언스 정적 검사가 신규 PRD·신규 템플릿·신규 dev_relay 모듈 모두 커버
- [ ] 사용자 수동 1 사이클 검증 (부록 A 셋업 후 PRD §8.2 수행)