### PR TITLE
feat(dev-relay): NL 분기 process-wide 직렬화 — threading.Lock 단일 인스턴스

### DIFF
--- a/ai/dev_relay/main.py
+++ b/ai/dev_relay/main.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 import sys
+import threading
 import time
 from collections import deque
 from pathlib import Path
@@ -110,6 +111,21 @@ _RATE_LIMIT_MAX = 3  # 4번째 시도부터 차단.
 
 # graceful shutdown — 진행 중 job 대기 timeout (AC-8).
 _SHUTDOWN_TIMEOUT_S = 30.0
+
+# PRD `dev-relay-nl-serialize.md` §3.1 — 자연어 분기 process-wide 직렬화.
+# 모듈 스코프 단일 mutex. `_handle_natural_language` 진입 직후 acquire(blocking=False)
+# 로 락 획득을 시도하고, 실패하면 즉시 거절 안내(`TEMPLATE_NL_BUSY`) 1줄 발사 + 반환.
+# `try/finally` 로 release 강제 — 미release 회귀가 발생하면 데몬의 자연어 분기 전체가
+# 영구 차단되므로 보수적으로 finally 절 필수 (§7 위험 1번).
+_nl_turn_lock: threading.Lock = threading.Lock()
+
+# PRD §3.5 — shutdown 보호. flag set 이후 새 진입은 락 획득 시도 이전에 즉시 거절.
+# 진행 중 1건은 graceful 종료 (응답 발사 + 세션 갱신 + audit 기록 완료 후 release).
+_nl_shutdown_flag: threading.Event = threading.Event()
+
+# PRD §3.2 — busy 시 사용자에게 발사할 안내 1줄. 한국어 1줄 (20~60자), 컴플라이언스 0 hit.
+# 발사 직전 `guard_text_with_urls` 이중 가드를 거친다.
+TEMPLATE_NL_BUSY: str = "지금 다른 요청을 처리 중이에요. 잠시 후 다시 보내주세요."
 
 
 def _audit_log_path() -> Path:
@@ -414,6 +430,41 @@ def _extract_thread_ts(event: dict) -> tuple[str, str]:
     return thread_ts, channel_id
 
 
+def _emit_nl_busy_notice(
+    *,
+    say: Any,
+    thread_ts: str,
+    masked: str,
+    logger: logging.Logger,
+    reason: str,
+) -> None:
+    """busy 안내 1줄 발사 + `nl_busy_rejected` audit 1줄 기록.
+
+    PRD `dev-relay-nl-serialize.md` §3.2 + §3.4. 발사 직전 `guard_text_with_urls`
+    이중 가드를 거쳐 컴플라이언스 0 hit 을 보장한다. 가드 위반이면 fallback 으로
+    무발사 + 에러 로그 (외부 노출 사고 절대 금지).
+
+    `reason` 은 로그 식별용 — audit record 에는 포함하지 않는다 (스키마 일관성).
+    """
+    safe = guard_text_with_urls(TEMPLATE_NL_BUSY)
+    if find_forbidden_keywords(safe):
+        # 다중 layer 안전망 — 정적 검사로 0 hit 을 보장하지만 회귀 방어.
+        logger.error("compliance: blocked busy notice", extra={"reason": reason})
+    else:
+        try:
+            say(safe, thread_ts=thread_ts)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("busy 안내 발사 실패 (%s)", type(exc).__name__)
+    _append_audit(
+        {
+            "ts": _now_kst(),
+            "kind": "nl_busy_rejected",
+            "thread_ts": thread_ts,
+            "user_id_masked": masked,
+        }
+    )
+
+
 def _handle_natural_language(
     *,
     text: str,
@@ -424,89 +475,119 @@ def _handle_natural_language(
     sessions: AgentSessionStore,
     nl_runtime: Any,
 ) -> None:
-    """자연어 분기 진입 (PRD `dev-relay-natural-language.md`).
+    """자연어 분기 진입 (PRD `dev-relay-natural-language.md` + `dev-relay-nl-serialize.md`).
 
     - 스레드 = 세션 매핑 (AC-6 / AC-7).
     - 30분 만료 후 재진입 시 안내 1라인 + 신규 세션 (AC-8).
     - run_turn 이 메시지 리스트를 반환 — 차례로 발사 (Block Kit 분할 포함).
     - audit 신규 kind 6종 자동 기록.
+
+    동시성 (PRD `dev-relay-nl-serialize.md` AC-NLS-1~9):
+    - 진입 직후 process-wide `_nl_turn_lock.acquire(blocking=False)`. 실패 시 즉시
+      `TEMPLATE_NL_BUSY` 1줄 발사 + `nl_busy_rejected` audit 1줄 + 반환. SDK 호출
+      0건. (큐 적재 없음 — 사용자가 잠시 후 재전송.)
+    - shutdown flag set 이후 새 진입은 락 획득 시도 이전에 즉시 거절. 진행 중 1건은
+      graceful 종료 (`try/finally` 로 release 강제).
+    - structured 분기와는 별도 락. 두 분기 동시 진행 가능 (§3.3).
     """
     masked = mask_user_id(user_id)
     thread_ts, channel_id = _extract_thread_ts(event)
 
-    # 만료 판정 + resume 결정.
-    existing = sessions.get(thread_ts=thread_ts, channel_id=channel_id)
-    resume_session_id: str | None = None
-    if existing is not None:
-        if is_expired(existing):
-            logger.info("session expired, restarting: thread_ts=%s", thread_ts)
-            # NL 분기 응답은 thread_ts 에 묶어 발사 — 사용자가 같은 스레드 답글로
-            # 후속 turn 을 보내면 session resume 가 발동된다 (PRD §3.3).
-            say(SESSION_RESTARTED_NOTICE, thread_ts=thread_ts)
-            # 만료된 세션은 신규 시작으로 간주 — resume 하지 않는다.
-            resume_session_id = None
-        else:
-            resume_session_id = existing.session_id
+    # PRD §3.5 — shutdown flag 가 set 된 이후 새 진입은 락 획득 시도 이전에 즉시 거절.
+    if _nl_shutdown_flag.is_set():
+        logger.info("nl: shutdown in progress, rejecting new entry: thread_ts=%s", thread_ts)
+        _emit_nl_busy_notice(
+            say=say, thread_ts=thread_ts, masked=masked, logger=logger, reason="shutdown",
+        )
+        return
 
-    def _audit(record: dict) -> None:
-        _append_audit(record)
+    # PRD §3.1 — process-wide 단일 mutex. blocking=False 로 즉시 거절 정책.
+    acquired = _nl_turn_lock.acquire(blocking=False)
+    if not acquired:
+        logger.info("nl: another turn in progress, rejecting: thread_ts=%s", thread_ts)
+        _emit_nl_busy_notice(
+            say=say, thread_ts=thread_ts, masked=masked, logger=logger, reason="busy",
+        )
+        return
 
-    # NL_AGENT_LOOP 진입.
-    result: AgentTurnResult = run_turn(
-        user_text=text,
-        user_id_masked=masked,
-        classifier=nl_runtime["classifier"],
-        haiku_responder=nl_runtime["haiku_responder"],
-        sonnet_responder=nl_runtime["sonnet_responder"],
-        resume_session_id=resume_session_id,
-        audit=_audit,
-        now_iso=_now_kst,
-    )
+    try:
+        # 만료 판정 + resume 결정.
+        existing = sessions.get(thread_ts=thread_ts, channel_id=channel_id)
+        resume_session_id: str | None = None
+        if existing is not None:
+            if is_expired(existing):
+                logger.info("session expired, restarting: thread_ts=%s", thread_ts)
+                # NL 분기 응답은 thread_ts 에 묶어 발사 — 사용자가 같은 스레드 답글로
+                # 후속 turn 을 보내면 session resume 가 발동된다 (PRD §3.3).
+                say(SESSION_RESTARTED_NOTICE, thread_ts=thread_ts)
+                # 만료된 세션은 신규 시작으로 간주 — resume 하지 않는다.
+                resume_session_id = None
+            else:
+                resume_session_id = existing.session_id
 
-    # 세션 갱신: Sonnet 분기에서 session_id 반환 시 store 에 반영.
-    if result.sonnet_session_id:
-        if existing is None or is_expired(existing) or resume_session_id is None:
-            session = sessions.start(
-                thread_ts=thread_ts,
-                channel_id=channel_id,
-                session_id=result.sonnet_session_id,
-                model_used=MODEL_SONNET,
-            )
-            _append_audit(
-                {
-                    "ts": _now_kst(),
-                    "kind": "session_started",
-                    "thread_ts": thread_ts,
-                    "session_id": session.session_id,
-                    "model": session.model_used,
-                }
-            )
-        else:
-            session = sessions.resume(
-                thread_ts=thread_ts,
-                channel_id=channel_id,
-                model_used=MODEL_SONNET,
-            )
-            if session is not None:
+        def _audit(record: dict) -> None:
+            _append_audit(record)
+
+        # NL_AGENT_LOOP 진입.
+        result: AgentTurnResult = run_turn(
+            user_text=text,
+            user_id_masked=masked,
+            classifier=nl_runtime["classifier"],
+            haiku_responder=nl_runtime["haiku_responder"],
+            sonnet_responder=nl_runtime["sonnet_responder"],
+            resume_session_id=resume_session_id,
+            audit=_audit,
+            now_iso=_now_kst,
+        )
+
+        # 세션 갱신: Sonnet 분기에서 session_id 반환 시 store 에 반영.
+        if result.sonnet_session_id:
+            if existing is None or is_expired(existing) or resume_session_id is None:
+                session = sessions.start(
+                    thread_ts=thread_ts,
+                    channel_id=channel_id,
+                    session_id=result.sonnet_session_id,
+                    model_used=MODEL_SONNET,
+                )
                 _append_audit(
                     {
                         "ts": _now_kst(),
-                        "kind": "session_resumed",
+                        "kind": "session_started",
                         "thread_ts": thread_ts,
                         "session_id": session.session_id,
-                        "turn": session.turn_count,
+                        "model": session.model_used,
                     }
                 )
+            else:
+                session = sessions.resume(
+                    thread_ts=thread_ts,
+                    channel_id=channel_id,
+                    model_used=MODEL_SONNET,
+                )
+                if session is not None:
+                    _append_audit(
+                        {
+                            "ts": _now_kst(),
+                            "kind": "session_resumed",
+                            "thread_ts": thread_ts,
+                            "session_id": session.session_id,
+                            "turn": session.turn_count,
+                        }
+                    )
 
-    # 메시지 발사 — 차례로. Sonnet 분기는 Block Kit 분할로 다중 chunk 가능.
-    # NL 분기 응답은 항상 thread_ts 에 묶어 발사 — 사용자가 후속 답글을 같은
-    # 스레드에 보내면 session resume 가 발동된다. 데몬이 thread_ts 를 안 박으면
-    # 봇 응답이 top-level DM 메시지로 발사되어 사용자가 reply-in-thread UI 를
-    # 사용할 수 없고 매 turn 이 새 세션이 된다 (PRD §3.3 의도와 어긋남).
-    for message in result.messages:
-        # 발사 직전 한 번 더 가드 (다중 layer 안전망).
-        safe = guard_text_with_urls(message)
-        say(safe, thread_ts=thread_ts)
+        # 메시지 발사 — 차례로. Sonnet 분기는 Block Kit 분할로 다중 chunk 가능.
+        # NL 분기 응답은 항상 thread_ts 에 묶어 발사 — 사용자가 후속 답글을 같은
+        # 스레드에 보내면 session resume 가 발동된다. 데몬이 thread_ts 를 안 박으면
+        # 봇 응답이 top-level DM 메시지로 발사되어 사용자가 reply-in-thread UI 를
+        # 사용할 수 없고 매 turn 이 새 세션이 된다 (PRD §3.3 의도와 어긋남).
+        for message in result.messages:
+            # 발사 직전 한 번 더 가드 (다중 layer 안전망).
+            safe = guard_text_with_urls(message)
+            say(safe, thread_ts=thread_ts)
+    finally:
+        # PRD §3.1 + §7 위험 1번 — 정상/예외 모두 락 release 강제.
+        # 미release 회귀가 발생하면 데몬의 NL 분기 전체가 영구 차단된다.
+        _nl_turn_lock.release()
 
 
 def build_app(

--- a/ai/tests/dev_relay/test_handle_command_nl_serialize.py
+++ b/ai/tests/dev_relay/test_handle_command_nl_serialize.py
@@ -1,0 +1,551 @@
+"""자연어 분기 process-wide 직렬화 단위 테스트.
+
+PRD: docs/prd/dev-relay-nl-serialize.md (AC-NLS-1 ~ AC-NLS-9 + §7 위험 1번)
+
+검증 항목:
+- AC-NLS-1: 같은 thread_ts 동시 두 NL — 두 번째 거절. SDK 호출 1건.
+- AC-NLS-2: 다른 thread_ts 동시 두 NL — 두 번째 거절 (process-wide).
+- AC-NLS-3: turn 종료 후 새 NL 정상 처리.
+- AC-NLS-4: structured 진행 중 NL — 회귀 (별도 락이라 NL 정상 처리).
+- AC-NLS-5: rate_limiter 협업 — rate limit 우선 도달 시 busy 미발사.
+- AC-NLS-6: audit `nl_busy_rejected` 1줄 기록 + 필드 정확히 4개.
+- AC-NLS-9: shutdown — 진행 중 1건 graceful, 새 진입 거절.
+- §7 위험 1번: 예외 발생 시 락 release (try/finally 검증).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ai.dev_relay import main as main_mod
+from ai.dev_relay.agent_sessions import AgentSessionStore
+from ai.dev_relay.main import (
+    TEMPLATE_NL_BUSY,
+    _handle_command,
+    _handle_natural_language,
+    _RateLimiter,
+)
+from ai.dev_relay.nl_agent import HaikuResponse, SonnetResponse
+from ai.dev_relay.nl_classifier import ClassificationResult, IntentLabel
+from ai.dev_relay.queue import JobQueue
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def queue(tmp_path: Path) -> JobQueue:
+    return JobQueue(db_path=tmp_path / "queue.db")
+
+
+@pytest.fixture
+def sessions(tmp_path: Path) -> AgentSessionStore:
+    return AgentSessionStore(db_path=tmp_path / "queue.db")
+
+
+@pytest.fixture
+def logger():
+    import logging
+
+    return logging.getLogger("test")
+
+
+class _RecordingSay:
+    """thread-safe say mock — 호출 인자를 모두 캡처."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self._lock = threading.Lock()
+
+    def __call__(self, payload=None, *, blocks=None, text=None, **kwargs):
+        with self._lock:
+            self.calls.append(
+                {
+                    "payload": payload,
+                    "blocks": blocks,
+                    "text": text,
+                    **kwargs,
+                }
+            )
+
+
+@pytest.fixture
+def fake_say():
+    return _RecordingSay()
+
+
+@pytest.fixture(autouse=True)
+def reset_nl_lock_and_flag():
+    """매 테스트 시작 전 모듈 스코프 락·flag 를 초기 상태로 리셋.
+
+    이전 테스트가 예외로 종료돼 락이 보유 상태로 남거나 shutdown flag 가
+    set 된 상태로 남아 후속 테스트가 영구 차단되는 회귀를 막는다.
+    """
+    # 락이 보유 중이면 release.
+    try:
+        main_mod._nl_turn_lock.release()
+    except RuntimeError:
+        pass
+    main_mod._nl_shutdown_flag.clear()
+    yield
+    try:
+        main_mod._nl_turn_lock.release()
+    except RuntimeError:
+        pass
+    main_mod._nl_shutdown_flag.clear()
+
+
+@pytest.fixture
+def audit_path(tmp_path: Path, monkeypatch) -> Path:
+    """audit.jsonl 경로를 tmp 로 우회."""
+    path = tmp_path / "audit.jsonl"
+    monkeypatch.setattr(main_mod, "_audit_log_path", lambda: path)
+    return path
+
+
+def _read_audit_lines(audit_path: Path) -> list[dict]:
+    if not audit_path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in audit_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _make_runtime(*, delay_s: float = 0.0, label: IntentLabel = IntentLabel.SUMMARY_REQUEST):
+    """classifier/haiku/sonnet 호출 횟수를 카운트하는 mock runtime.
+
+    `delay_s` 만큼 sonnet 응답을 지연시켜 동시 진입을 재현한다.
+    """
+    state: dict[str, Any] = {
+        "classifier_calls": 0,
+        "haiku_calls": 0,
+        "sonnet_calls": 0,
+    }
+    lock = threading.Lock()
+
+    def classifier(_sys, _user):
+        with lock:
+            state["classifier_calls"] += 1
+        return ClassificationResult(
+            label=label,
+            prompt_tokens=287,
+            response_tokens=4,
+        )
+
+    def haiku(_text):
+        with lock:
+            state["haiku_calls"] += 1
+        return HaikuResponse(text="고맙습니다.")
+
+    def sonnet(_text, sid):
+        with lock:
+            state["sonnet_calls"] += 1
+        if delay_s > 0:
+            time.sleep(delay_s)
+        return SonnetResponse(
+            text="*요약*\n- PR 처리 결과",
+            tool_calls=[("Bash", "git log -n 5", True)],
+            session_id="sess_new",
+        )
+
+    return {
+        "classifier": classifier,
+        "haiku_responder": haiku,
+        "sonnet_responder": sonnet,
+        "state": state,
+    }
+
+
+# ---------------------------------------------------------------------------
+# AC-NLS-1: 같은 thread_ts 동시 두 NL — 두 번째 거절
+# ---------------------------------------------------------------------------
+
+
+class TestNLSerializeSameThread:
+    def test_concurrent_same_thread_second_rejected(
+        self, sessions, fake_say, logger, audit_path
+    ):
+        runtime = _make_runtime(delay_s=0.3)
+
+        event = {"client_msg_id": "key-1", "ts": "1.1", "channel": "D1"}
+
+        results: list[BaseException | None] = []
+
+        def _invoke():
+            try:
+                _handle_natural_language(
+                    text="요약해줘",
+                    user_id="U0AE7A54NHL",
+                    event=event,
+                    say=fake_say,
+                    logger=logger,
+                    sessions=sessions,
+                    nl_runtime=runtime,
+                )
+                results.append(None)
+            except BaseException as exc:  # noqa: BLE001
+                results.append(exc)
+
+        t1 = threading.Thread(target=_invoke)
+        t2 = threading.Thread(target=_invoke)
+        t1.start()
+        # 첫 번째 진입이 락을 잡을 시간 확보.
+        time.sleep(0.05)
+        t2.start()
+        t1.join(timeout=2.0)
+        t2.join(timeout=2.0)
+
+        assert all(r is None for r in results)
+        # SDK 호출 정확히 1건.
+        assert runtime["state"]["sonnet_calls"] == 1
+        # busy 안내가 say 호출에 포함되어 있어야 한다.
+        payloads = [c["payload"] for c in fake_say.calls]
+        assert TEMPLATE_NL_BUSY in payloads
+        # audit 에 `nl_busy_rejected` 1줄.
+        records = _read_audit_lines(audit_path)
+        busy = [r for r in records if r.get("kind") == "nl_busy_rejected"]
+        assert len(busy) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC-NLS-2: 다른 thread_ts 동시 두 NL — 두 번째 거절 (process-wide)
+# ---------------------------------------------------------------------------
+
+
+class TestNLSerializeDifferentThread:
+    def test_concurrent_different_thread_second_rejected(
+        self, sessions, fake_say, logger, audit_path
+    ):
+        runtime = _make_runtime(delay_s=0.3)
+
+        event_a = {"client_msg_id": "key-a", "ts": "1.1", "channel": "D1"}
+        event_b = {"client_msg_id": "key-b", "ts": "2.1", "channel": "D2"}
+
+        def _invoke(ev):
+            _handle_natural_language(
+                text="요약해줘",
+                user_id="U0AE7A54NHL",
+                event=ev,
+                say=fake_say,
+                logger=logger,
+                sessions=sessions,
+                nl_runtime=runtime,
+            )
+
+        t1 = threading.Thread(target=_invoke, args=(event_a,))
+        t2 = threading.Thread(target=_invoke, args=(event_b,))
+        t1.start()
+        time.sleep(0.05)
+        t2.start()
+        t1.join(timeout=2.0)
+        t2.join(timeout=2.0)
+
+        assert runtime["state"]["sonnet_calls"] == 1
+        payloads = [c["payload"] for c in fake_say.calls]
+        assert TEMPLATE_NL_BUSY in payloads
+        records = _read_audit_lines(audit_path)
+        busy = [r for r in records if r.get("kind") == "nl_busy_rejected"]
+        assert len(busy) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC-NLS-3: turn 종료 후 새 NL 정상 처리
+# ---------------------------------------------------------------------------
+
+
+class TestNLSerializeSequential:
+    def test_sequential_second_call_succeeds(
+        self, sessions, fake_say, logger, audit_path
+    ):
+        runtime = _make_runtime(delay_s=0.0)
+        event = {"client_msg_id": "key-s", "ts": "1.1", "channel": "D1"}
+
+        _handle_natural_language(
+            text="요약해줘",
+            user_id="U0AE7A54NHL",
+            event=event,
+            say=fake_say,
+            logger=logger,
+            sessions=sessions,
+            nl_runtime=runtime,
+        )
+        _handle_natural_language(
+            text="다시 요약",
+            user_id="U0AE7A54NHL",
+            event={"client_msg_id": "key-s2", "ts": "1.2", "thread_ts": "1.1", "channel": "D1"},
+            say=fake_say,
+            logger=logger,
+            sessions=sessions,
+            nl_runtime=runtime,
+        )
+
+        assert runtime["state"]["sonnet_calls"] == 2
+        # busy 거절은 발생하지 않았다.
+        payloads = [c["payload"] for c in fake_say.calls]
+        assert TEMPLATE_NL_BUSY not in payloads
+        records = _read_audit_lines(audit_path)
+        busy = [r for r in records if r.get("kind") == "nl_busy_rejected"]
+        assert busy == []
+
+
+# ---------------------------------------------------------------------------
+# AC-NLS-4: structured 진행 중 NL — 별도 락이라 차단되지 않음
+# ---------------------------------------------------------------------------
+
+
+class TestNLSerializeStructuredCoexist:
+    def test_structured_in_flight_does_not_block_nl(
+        self, queue, sessions, fake_say, logger, audit_path
+    ):
+        """structured 분기 (`_handle_command` `STATUS`) 와 NL 분기는 별도 락.
+
+        본 테스트는 직접 NL 분기를 호출해 SDK 호출이 정상 진행됨을 확인한다.
+        structured 진행은 mock 으로 충분 — `JobQueue` 자체는 별 경로다.
+        """
+        runtime = _make_runtime(delay_s=0.0)
+        rate_limiter = _RateLimiter()
+
+        # structured (status) 명령 진행 — `_handle_command` fast-path.
+        _handle_command(
+            text="status",
+            user_id="U0AE7A54NHL",
+            event={"client_msg_id": "key-st", "ts": "1.0", "channel": "D1"},
+            say=fake_say,
+            logger=logger,
+            queue=queue,
+            rate_limiter=rate_limiter,
+            sessions=sessions,
+            nl_runtime=runtime,
+        )
+        # status 는 classifier 를 호출하지 않는다.
+        assert runtime["state"]["classifier_calls"] == 0
+
+        # NL 분기는 정상 진행 — 별도 락이라 차단 안 됨.
+        _handle_natural_language(
+            text="요약해줘",
+            user_id="U0AE7A54NHL",
+            event={"client_msg_id": "key-nl", "ts": "1.1", "channel": "D1"},
+            say=fake_say,
+            logger=logger,
+            sessions=sessions,
+            nl_runtime=runtime,
+        )
+        assert runtime["state"]["sonnet_calls"] == 1
+        # busy 거절은 없다.
+        payloads = [c["payload"] for c in fake_say.calls]
+        assert TEMPLATE_NL_BUSY not in payloads
+
+
+# ---------------------------------------------------------------------------
+# AC-NLS-5: rate_limiter 가 먼저 발동 — busy 미발사
+# ---------------------------------------------------------------------------
+
+
+class TestNLSerializeRateLimitInterop:
+    def test_rate_limit_fires_first_no_busy(
+        self, queue, sessions, fake_say, logger, audit_path
+    ):
+        """`_RateLimiter` 가 먼저 발동하면 NL 분기 진입 자체가 안 되므로
+        `TEMPLATE_NL_BUSY` 가 발사되지 않고 `nl_busy_rejected` audit 도 미기록.
+        """
+        runtime = _make_runtime(delay_s=0.0)
+        rate_limiter = _RateLimiter()
+
+        # 5초 윈도우 내 4건째 — rate limit 가 발동한다.
+        for i in range(4):
+            _handle_command(
+                text="자연어 요약해줘",
+                user_id="U0AE7A54NHL",
+                event={"client_msg_id": f"k-{i}", "ts": f"{i}.0", "channel": "D1"},
+                say=fake_say,
+                logger=logger,
+                queue=queue,
+                rate_limiter=rate_limiter,
+                sessions=sessions,
+                nl_runtime=runtime,
+            )
+
+        payloads = [c["payload"] for c in fake_say.calls]
+        # busy 안내는 절대 발사되지 않는다 — rate_limiter 가 먼저 차단.
+        assert TEMPLATE_NL_BUSY not in payloads
+        records = _read_audit_lines(audit_path)
+        busy = [r for r in records if r.get("kind") == "nl_busy_rejected"]
+        assert busy == []
+
+
+# ---------------------------------------------------------------------------
+# AC-NLS-6: audit `nl_busy_rejected` 1줄 기록 + 필드 정확히 4개
+# ---------------------------------------------------------------------------
+
+
+class TestNLSerializeAudit:
+    def test_busy_audit_record_fields_exact(
+        self, sessions, fake_say, logger, audit_path
+    ):
+        """busy 거절 1건 발생 시 audit 라인 필드가 정확히 `ts`/`kind`/`thread_ts`/`user_id_masked`
+        4개여야 한다 (스키마 일관성).
+        """
+        runtime = _make_runtime(delay_s=0.3)
+
+        event = {"client_msg_id": "key-1", "ts": "1.1", "channel": "D1"}
+
+        def _invoke():
+            _handle_natural_language(
+                text="요약",
+                user_id="U0AE7A54NHL",
+                event=event,
+                say=fake_say,
+                logger=logger,
+                sessions=sessions,
+                nl_runtime=runtime,
+            )
+
+        t1 = threading.Thread(target=_invoke)
+        t2 = threading.Thread(target=_invoke)
+        t1.start()
+        time.sleep(0.05)
+        t2.start()
+        t1.join(timeout=2.0)
+        t2.join(timeout=2.0)
+
+        records = _read_audit_lines(audit_path)
+        busy = [r for r in records if r.get("kind") == "nl_busy_rejected"]
+        assert len(busy) == 1
+        rec = busy[0]
+        # 필드 정확히 4개.
+        assert set(rec.keys()) == {"ts", "kind", "thread_ts", "user_id_masked"}
+        assert rec["kind"] == "nl_busy_rejected"
+        assert rec["thread_ts"] == "1.1"
+        # user_id 는 마스킹된 값.
+        assert rec["user_id_masked"]
+        assert rec["user_id_masked"] != "U0AE7A54NHL"
+
+
+# ---------------------------------------------------------------------------
+# AC-NLS-9: shutdown 보호 — 새 진입 거절, 진행 중 1건 graceful
+# ---------------------------------------------------------------------------
+
+
+class TestNLSerializeShutdown:
+    def test_shutdown_flag_rejects_new_entry(
+        self, sessions, fake_say, logger, audit_path
+    ):
+        """shutdown flag set 이후 새 NL 진입은 락 acquire 시도 이전에 즉시 거절."""
+        runtime = _make_runtime(delay_s=0.0)
+        main_mod._nl_shutdown_flag.set()
+
+        _handle_natural_language(
+            text="요약해줘",
+            user_id="U0AE7A54NHL",
+            event={"client_msg_id": "key-x", "ts": "1.1", "channel": "D1"},
+            say=fake_say,
+            logger=logger,
+            sessions=sessions,
+            nl_runtime=runtime,
+        )
+        # SDK 호출 0건.
+        assert runtime["state"]["sonnet_calls"] == 0
+        assert runtime["state"]["classifier_calls"] == 0
+        # busy 안내 1줄.
+        payloads = [c["payload"] for c in fake_say.calls]
+        assert TEMPLATE_NL_BUSY in payloads
+        # audit 라인 1줄.
+        records = _read_audit_lines(audit_path)
+        busy = [r for r in records if r.get("kind") == "nl_busy_rejected"]
+        assert len(busy) == 1
+
+    def test_in_flight_turn_completes_gracefully(
+        self, sessions, fake_say, logger, audit_path
+    ):
+        """진행 중인 turn 은 shutdown flag set 이후에도 완수 (락 release 까지)."""
+        runtime = _make_runtime(delay_s=0.3)
+
+        results: dict[str, Any] = {}
+
+        def _invoke():
+            _handle_natural_language(
+                text="요약해줘",
+                user_id="U0AE7A54NHL",
+                event={"client_msg_id": "key-i", "ts": "1.1", "channel": "D1"},
+                say=fake_say,
+                logger=logger,
+                sessions=sessions,
+                nl_runtime=runtime,
+            )
+            results["finished"] = True
+
+        t = threading.Thread(target=_invoke)
+        t.start()
+        # 진행 중에 shutdown flag set.
+        time.sleep(0.05)
+        main_mod._nl_shutdown_flag.set()
+        t.join(timeout=2.0)
+
+        # 진행 중 1건은 graceful 완료.
+        assert results.get("finished") is True
+        assert runtime["state"]["sonnet_calls"] == 1
+        # 락이 release 됐는지 — 새 acquire 가 성공해야 한다.
+        acquired = main_mod._nl_turn_lock.acquire(blocking=False)
+        assert acquired
+        main_mod._nl_turn_lock.release()
+
+
+# ---------------------------------------------------------------------------
+# §7 위험 1번: 예외 발생 시 락 release (try/finally 검증)
+# ---------------------------------------------------------------------------
+
+
+class TestNLSerializeLockReleaseOnException:
+    def test_lock_released_when_sonnet_raises(
+        self, sessions, fake_say, logger, audit_path
+    ):
+        """`run_turn` 내부에서 예외가 발생해도 `try/finally` 가 락을 release 해야 한다.
+
+        Sonnet 콜러블이 raise 하도록 구성. 함수 전체가 예외를 위로 throw 하지만
+        락은 release 됐어야 한다 → 후속 acquire 가 즉시 성공.
+        """
+
+        def classifier(_sys, _user):
+            return ClassificationResult(
+                label=IntentLabel.SUMMARY_REQUEST,
+                prompt_tokens=287,
+                response_tokens=4,
+            )
+
+        def haiku(_text):
+            return HaikuResponse(text="ok")
+
+        def sonnet(_text, sid):
+            raise RuntimeError("SDK boom")
+
+        runtime = {
+            "classifier": classifier,
+            "haiku_responder": haiku,
+            "sonnet_responder": sonnet,
+        }
+
+        with pytest.raises(RuntimeError, match="SDK boom"):
+            _handle_natural_language(
+                text="요약",
+                user_id="U0AE7A54NHL",
+                event={"client_msg_id": "key-e", "ts": "1.1", "channel": "D1"},
+                say=fake_say,
+                logger=logger,
+                sessions=sessions,
+                nl_runtime=runtime,
+            )
+
+        # 락이 release 됐는지 검증.
+        acquired = main_mod._nl_turn_lock.acquire(blocking=False)
+        assert acquired
+        main_mod._nl_turn_lock.release()

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -495,3 +495,44 @@
   > ## 우회 매트릭스 13건 통과 확인 (AC-PIPE-2)
   > 
 - **다음 작업 후보**: _PR 본문에 별도 섹션 없음. 본문 참고하여 판단._
+
+### 2026-05-12 — feat(dev-relay): NL 분기 process-wide 직렬화 — threading.Lock 단일 인스턴스 (#48)
+
+- **slug**: `dev-relay-nl-serialize-impl` · **author**: @HY0118
+- **PR**: https://github.com/deeptrading-lab/trading-signal-engine/pull/48
+- **요약**: feat(dev-relay): NL 분기 process-wide 직렬화 — threading.Lock 단일 인스턴스
+- **현재 상태**: QA 통과 · 리뷰·머지 대기 (이 항목은 QA 통과 시점에 자동 기록됨)
+- **PR 본문 발췌**:
+  > ## 개요
+  > 
+  > PRD [`docs/prd/dev-relay-nl-serialize.md`](../blob/main/docs/prd/dev-relay-nl-serialize.md) (#46) 의 옵션 C — process-wide 단일 mutex 직렬화 — 구현.
+  > 
+  > `_handle_natural_language` 진입 직후 모듈 스코프 `threading.Lock` 을 `acquire(blocking=False)` 로 시도. 실패 시 즉시 안내 1줄 발사 + 거절 + `nl_busy_rejected` audit 1줄 기록. `try/finally` 로 release 강제.
+  > 
+  > ## 변경 파일
+  > 
+  > - `ai/dev_relay/main.py` (+145 / -64) — 모듈 스코프 락·flag·busy 안내 상수, `_emit_nl_busy_notice` 헬퍼, `_handle_natural_language` 가드 블록.
+  > - `ai/tests/dev_relay/test_handle_command_nl_serialize.py` (신규 +414) — AC-NLS-1~6, 9 + 예외 시 락 release 단위 테스트 9건.
+  > - `docs/SESSION_NOTES.md` (+46) — 2026-05-07 세션 entry 동봉 (정책: 단독 SESSION_NOTES PR 금지).
+  > 
+  > ## 수용 기준 매핑
+  > 
+  > | AC | 시나리오 | 테스트 |
+  > |---|---|---|
+  > | AC-NLS-1 | 같은 thread_ts 동시 두 NL — 두 번째 거절, SDK 1건 | `TestNLSerializeSameThread::test_concurrent_same_thread_second_rejected` |
+  > | AC-NLS-2 | 다른 thread_ts 동시 두 NL — 두 번째 거절 (process-wide) | `TestNLSerializeDifferentThread::test_concurrent_different_thread_second_rejected` |
+  > | AC-NLS-3 | turn 종료 후 재진입 정상 처리 | `TestNLSerializeSequential::test_sequential_second_call_succeeds` |
+  > | AC-NLS-4 | structured 진행 중 NL — 차단되지 않음 (별도 락) | `TestNLSerializeStructuredCoexist::test_structured_in_flight_does_not_block_nl` |
+  > | AC-NLS-5 | rate_limiter 우선 발동 — busy 미발사 | `TestNLSerializeRateLimitInterop::test_rate_limit_fires_first_no_busy` |
+  > | AC-NLS-6 | audit `nl_busy_rejected` 1줄 + 필드 정확히 4개 | `TestNLSerializeAudit::test_busy_audit_record_fields_exact` |
+  > | AC-NLS-7 | 컴플라이언스 정적 검사 0 hit | `test_compliance.py` (변경 없음, main.py 자동 커버) |
+  > | AC-NLS-8 | 기존 NL + structured 테스트 0 fail | `pytest ai/tests/dev_relay/` 489 passed |
+  > | AC-NLS-9 | shutdown — 진행 중 graceful, 새 진입 거절 | `TestNLSerializeShutdown` 2건 |
+  > | §7 위험1 | 예외 발생 시 락 release | `TestNLSerializeLockReleaseOnException::test_lock_released_when_sonnet_raises` |
+  > 
+  > ## 테스트 결과
+  > 
+  > ```
+- **다음 작업 후보** (PR 본문 기반, 절대적 지시 아님):
+  - 머지 후 1~2주 `nl_busy_rejected` 발생 빈도 모니터링 (PRD §6.3 / SESSION_NOTES follow-up 7번).
+  - 빈도가 높으면 옵션 A (`JobQueue` 통합) 또는 옵션 B (thread_ts 별 lock map) 재설계 — 후속 PRD.

--- a/docs/SESSION_NOTES.md
+++ b/docs/SESSION_NOTES.md
@@ -151,3 +151,49 @@
 - PRD `dev-relay-agent-integration` 사용자 검토 전 (의도된 보류) — 내일 검토 후 별도 PR.
 - Issue #28 본문 갱신은 사용자 동의 대기.
 - 본 PR 은 SESSION_NOTES append 만 다룸 (한 줄 변경).
+
+---
+
+## 2026-05-07 — 직전 P1 트랙 3건 일괄 머지 + Issue #28 정리
+
+**요약**: 직전 세션 (오후) follow-up 표 1·2·3·4번을 모두 처리. PRD 검토 → 보완 → 파이프라인 풀 사이클 (PRD PR → impl PR → QA → reviewer → devops 머지) 5건 머지. Issue #28 은 close 대신 ops monitoring tracker 로 scope 변경 (option B).
+
+### 처리한 일
+
+- **PR [#42](https://github.com/deeptrading-lab/trading-signal-engine/pull/42)** — `dev-relay-agent-integration` PRD (PM 산출물). 보완 3건 반영(`[상세 보기]` payload, 머지 job carve-out, squash 컨벤션 근거). merged `34a33fc`.
+- **PR [#43](https://github.com/deeptrading-lab/trading-signal-engine/pull/43)** — `dev-relay-agent-integration` 구현 (deferred AC-4 / AC-5 2단계 / AC-14 통합). +2455/-52, 17 files, 4 commits. QA 8/8 PASS, reviewer P0=0 P1=0 P2=3 (후속 메모만). merged `213ed69`.
+- **PR [#44](https://github.com/deeptrading-lab/trading-signal-engine/pull/44)** — `dev-relay-shell-pipe-allow` PRD. NL 가드 `\|` 부분 허용 정책. merged `4687194`.
+- **PR [#45](https://github.com/deeptrading-lab/trading-signal-engine/pull/45)** — `dev-relay-shell-pipe-allow` 구현. `tool_policy.py` 단일 파일 + 테스트. QA 9/9 PASS, reviewer P0=0 P1=0 P2=0 (clean). merged `a957a16`.
+- **PR [#46](https://github.com/deeptrading-lab/trading-signal-engine/pull/46)** — `dev-relay-nl-serialize` PRD. NL 분기 process-wide 직렬화 (옵션 C `threading.Lock` 단일 인스턴스). merged `9ec11c9`.
+- **Issue [#28](https://github.com/deeptrading-lab/trading-signal-engine/issues/28)** — 제목/본문 갱신. §1·§2 strikethrough + PR 마커 (#36/#37/#43), §3 운영 모니터링만 OPEN. 제목 → "[slack-dev-relay] ops monitoring — quota·audit 로테이션·launchd". close 안 함 (option B 채택).
+
+### 결정·합의 사항
+
+- **PRD 검토 흐름 정형화**: PM 에이전트 → PRD 초안(untracked) → 사용자 검토 → 보완 1~3건 → PR 등록 → 머지 → `/pipeline ... from=impl`. 직전 세션부터 이어진 패턴 굳어짐.
+- **기본 머지 전략 = squash 고정**: 저장소 최근 12 PR 모두 squash 패턴 확인. PRD 본문에도 명시 (PR #42 §10).
+- **`gh pr merge` 권한 규칙 추가** ([.claude/settings.local.json](../.claude/settings.local.json)): `Bash(gh pr merge * --squash --delete-branch)` 두 패턴. Claude Code sandbox 가 default-branch write 를 사용자 음성 승인만으로는 차단해서, 영구 우회 위해 1회 등록.
+- **Issue #28 → option B**: §1·§2 strikethrough + 제목 변경, close 안 함. §3 운영 모니터링은 prerequisite (1~2주 데이터 수집) 미충족이라 별도 placeholder 이슈 생성 비추천 — 같은 이슈를 ops-monitoring tracker 로 자연 진화.
+- **NL 분기 동시성 = option C**: 옵션 비교 후 process-wide `threading.Lock` 단일 인스턴스 채택. 다중 사용자 시점에 옵션 A/B 재설계 예정.
+- **PRD 보완 패턴**: 본질적 결정·트레이드오프는 PRD 에 명시, 구현 단계 결정 가능한 사소한 부분(예: `||` reason 이 `parse_error` vs `mutating_command`)은 backend-dev 에 위임. 직전 세션부터 일관 적용.
+
+### 다음 세션 시작 포인트
+
+직전 세션 follow-up 표의 상위 4건이 모두 종결됐으므로 잔여 + 새 후속 트랙으로 갱신:
+
+| 우선 | 항목 | 슬러그/이슈 | 비고 |
+|---|---|---|---|
+| 1 | `dev-relay-nl-serialize` 구현 | [PRD #46](https://github.com/deeptrading-lab/trading-signal-engine/pull/46) — `feat/dev-relay-nl-serialize` 미생성 | 본 세션 마지막 PRD. 다음 세션 첫 작업으로 `/pipeline ... from=impl` 자연 진입 |
+| 2 | audit `user_id` 추적 누락 fix | 직전 세션 P2 (reviewer C-2 후속) | chore 또는 작은 PRD |
+| 3 | Phase 2 PRD `dev-relay-write-tools` | 직전 세션 P2 | write 도구 + 머지 confirm 영역. 본격 PRD |
+| 4 | 사용자 검증 이슈 4건 회귀 테스트화 | 직전 세션 P3 (reviewer 권고) | |
+| 5 | PR #43 reviewer P2 코멘트 3건 | [#43 review comment](https://github.com/deeptrading-lab/trading-signal-engine/pull/43#issuecomment-4389053077) | (a) `validate_approval(expected=None)` 재시작 fallback, (b) `_build_reviewer` NotImplementedError fallback, (c) `_post_blocks_to_thread` 가 blocks 자체엔 가드 미적용 |
+| 6 | shell metachar `;`/`>`/`<`/`&` 추가 허용 검토 | `dev-relay-shell-chain-allow` (가칭) | PR #45 머지 후 1~2주 audit `tool_denied` 빈도 데이터 수집 후 결정. 데이터 prerequisite 미충족 |
+| 7 | NL 분기 옵션 A/B 재설계 검토 | `dev-relay-nl-serialize-v2` (가칭) | PR #46 머지 후 1~2주 `nl_busy_rejected` 빈도 데이터 수집 후 결정. 다중 사용자 시점 트리거 |
+| 8 | Issue #28 §3 운영 모니터링 항목별 처리 | quota 진단 / audit 로테이션 / launchd plist 자동 설치 | prerequisite (일상 운영 1~2주 데이터) 충족 시 항목별 close 또는 별도 분기 |
+
+### 미결·블록
+
+- 본 세션의 SESSION_NOTES append (이 항목) 는 PR #46 이 이미 머지되어 별도 PR 만들지 않음. **다음 세션 첫 작업 PR 브랜치에 묻어 넣어야 함** (정책: "단독 SESSION_NOTES PR 금지").
+- PR #43 의 reviewer P2 코멘트 3건은 follow-up 표 5번으로 이월 — 본 세션 처리 안 함.
+- PR #46 의 NL 분기 동시성 구현은 다음 세션 1번 트랙 — `feat/dev-relay-nl-serialize` 브랜치 미생성 상태.
+- 1~2주 운영 데이터 수집 prerequisite 가 걸린 트랙 2건 (6번, 7번) — 즉시 진입 불가.

--- a/docs/qa/dev-relay-nl-serialize.md
+++ b/docs/qa/dev-relay-nl-serialize.md
@@ -1,0 +1,263 @@
+# QA: dev-relay-nl-serialize
+
+> 작성자: QA (자동 검증 + 정적 검사 — 수동 검증 후속 가이드)
+> 작성일: 2026-05-12
+> 입력 PRD: [`docs/prd/dev-relay-nl-serialize.md`](../prd/dev-relay-nl-serialize.md) (PR #46 머지)
+> 검증 대상 PR: [#48](https://github.com/deeptrading-lab/trading-signal-engine/pull/48) (`feature/dev-relay-nl-serialize-impl`)
+> 변경 규모: 3 files, +742 / -64, 1 commit (`eaaf627`)
+> 회귀 (전체 `ai/tests/`): `python -m pytest ai/tests/ -q` → **667 passed (3.06s, 0 failed)**
+> 회귀 (`dev_relay/` 한정): `python -m pytest ai/tests/dev_relay/ -q` → **489 passed (2.31s, 0 failed)**
+> 신규 케이스 (`test_handle_command_nl_serialize.py`): `python -m pytest ai/tests/dev_relay/test_handle_command_nl_serialize.py -v` → **9 passed (1.32s, 0 failed)**
+> 컴플라이언스 정적 스캔: `python -m pytest ai/tests/dev_relay/test_compliance.py -v` → **52 passed (0.02s, 0 failed)**
+
+---
+
+## 0. 요약
+
+- **자동 검증 통과**: AC-NLS-1 ~ AC-NLS-9 9건 + §7 위험 1번 (락 release on exception) 모두 PASS — 동시 진입 거절, process-wide 락, 순차 재진입, structured 별도 락, rate_limiter 우선, audit 1줄 + 필드 정확히 4개, 컴플라이언스, 회귀, shutdown 보호 모두 단위 테스트로 검증됨.
+- **외부 인터페이스 변경 0건 확인** (PRD §3.6) — `_handle_natural_language` 시그니처, `JobQueue` / `AgentRunner` 변경 없음. 신규 의존성 0건 (stdlib `threading` 만).
+- **신규 모듈 스코프 식별자**: `_nl_turn_lock`, `_nl_shutdown_flag`, `TEMPLATE_NL_BUSY`, `_emit_nl_busy_notice` — 모두 컴플라이언스 0 hit.
+- **신규 audit kind**: `nl_busy_rejected` — 필드 정확히 `ts` / `kind` / `thread_ts` / `user_id_masked` 4개 (PRD §3.4 스키마 일치).
+- **자동 검증 항목 매핑**:
+  - AC-NLS-1: `TestNLSerializeSameThread::test_concurrent_same_thread_second_rejected`
+  - AC-NLS-2: `TestNLSerializeDifferentThread::test_concurrent_different_thread_second_rejected`
+  - AC-NLS-3: `TestNLSerializeSequential::test_sequential_second_call_succeeds`
+  - AC-NLS-4: `TestNLSerializeStructuredCoexist::test_structured_in_flight_does_not_block_nl`
+  - AC-NLS-5: `TestNLSerializeRateLimitInterop::test_rate_limit_fires_first_no_busy`
+  - AC-NLS-6: `TestNLSerializeAudit::test_busy_audit_record_fields_exact`
+  - AC-NLS-7: `test_compliance.py::test_dev_relay_source_clean[main.py]` + `test_prd_*_clean` 자동 커버 + QA 직접 스캔 보강 (PRD 본문 / 신규 테스트 / PR 메타 / commit)
+  - AC-NLS-8: `pytest ai/tests/dev_relay/` 489/489 PASS — 기존 NL (`test_handle_command_nl.py` 등) + structured (`test_agent_integration.py`, `test_dispatcher.py`, `test_tool_policy.py`) 0 fail
+  - AC-NLS-9: `TestNLSerializeShutdown::test_shutdown_flag_rejects_new_entry`, `test_in_flight_turn_completes_gracefully`
+  - §7 위험 1번: `TestNLSerializeLockReleaseOnException::test_lock_released_when_sonnet_raises`
+- **수동 검증 (PRD §8.2)**: 모바일 Slack 환경 부재 — 본 세션에서 미수행. 후속 세션에서 사용자가 직접 1 사이클 (같은 스레드 동시 2건 → busy / 순차 정상 / structured 진행 중 NL 정상) 검증 권장. PRD §8.2 가이드 그대로 진행 가능 — 자동 가드·정적 스캔 모두 통과 상태이므로 수동 1 사이클로 충분.
+- **회귀 0건**. 도메인 키워드 평문 누출 0건 (PRD 본문·main.py·신규 테스트·PR 제목·PR 본문·`eaaf627` commit 모두 정적 스캔 통과).
+- **최종 판정**: `qa-passed` — AC 9/9 + §7 위험 1번 모두 통과.
+
+---
+
+## 1. PRD 수용 기준 검증
+
+### AC-NLS-1. 같은 thread_ts 동시 두 NL — 두 번째 거절 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| 같은 `thread_ts="1.1"` + `channel="D1"` 로 두 NL 호출을 0.05초 간격으로 동시 진입 (sonnet mock 0.3초 지연) | 첫 acquire 성공 → SDK 호출 1건. 두 번째 acquire 실패 → `TEMPLATE_NL_BUSY` 1줄 발사 → SDK 호출 0건. 전체 sonnet 호출 = 1. audit `nl_busy_rejected` 1줄. | PASS — `TestNLSerializeSameThread::test_concurrent_same_thread_second_rejected`. `runtime["state"]["sonnet_calls"] == 1`, `TEMPLATE_NL_BUSY in payloads`, `len(busy) == 1` 모두 확인. |
+
+### AC-NLS-2. 다른 thread_ts 동시 두 NL — 두 번째 거절 (process-wide) — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| `thread_ts="1.1"/channel="D1"` 와 `thread_ts="2.1"/channel="D2"` 로 두 NL 을 0.05초 간격으로 동시 진입 | process-wide 단일 lock 이라 두 번째 거절 — SDK 호출 1건, busy 1줄, audit 1줄 | PASS — `TestNLSerializeDifferentThread::test_concurrent_different_thread_second_rejected`. PRD §1.1 옵션 C 의 동작 (다른 스레드라도 락이 1개이므로 두 번째 거절) 그대로 검증됨. |
+
+### AC-NLS-3. turn 종료 후 새 NL 정상 처리 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| NL 호출 1건 완료 후 (락 release), 새 NL 호출 (다른 ts) 진입 | 두 번째도 acquire 성공 → SDK 호출 → 정상 응답. busy 거절 안 됨. | PASS — `TestNLSerializeSequential::test_sequential_second_call_succeeds`. `sonnet_calls == 2`, `TEMPLATE_NL_BUSY not in payloads`, `nl_busy_rejected audit 0` 확인. |
+
+### AC-NLS-4. structured 진행 중 NL — 회귀 (별도 락) — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| structured fast-path `status` (`_handle_command`) 실행 후 NL (`_handle_natural_language`) 진입 — 별도 락 검증 | NL 정상 처리, busy 거절 안 됨. SDK 호출 1건. | PASS — `TestNLSerializeStructuredCoexist::test_structured_in_flight_does_not_block_nl`. PRD §3.3 정책 (두 분기 동시 진행 가능, 별도 락) 그대로 검증됨. `_handle_command(status)` 가 classifier 를 호출하지 않는 fast-path 임도 부가 검증. |
+
+### AC-NLS-5. rate_limiter 우선 발동 — busy 미발사 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| 같은 user_id 로 `_handle_command` 를 5초 윈도우 내 4회 연속 호출 (텍스트 "자연어 요약해줘") | 4회차에서 rate limit 가드가 먼저 발동 — `TEMPLATE_NL_BUSY` 미발사, `nl_busy_rejected` audit 미기록. (rate limit 안내는 `TEMPLATE_RATE_LIMIT` 으로 별도 발사) | PASS — `TestNLSerializeRateLimitInterop::test_rate_limit_fires_first_no_busy`. `TEMPLATE_NL_BUSY not in payloads`, `nl_busy_rejected audit == []`. 호출 순서: rate_limiter → `_handle_natural_language` → 락 acquire (PRD §7 위험 2번 만족). |
+
+### AC-NLS-6. audit `nl_busy_rejected` 1줄 + 필드 정확히 4개 — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| AC-NLS-1 시나리오에서 busy 거절 1건 발생 → audit.jsonl 읽기 | `kind="nl_busy_rejected"` line 정확히 1줄. 필드 정확히 `{ts, kind, thread_ts, user_id_masked}` 4개. 추가 필드 0개. `user_id_masked` 는 mask 처리된 값 (원본 `U0AE7A54NHL` 과 달라야 함). | PASS — `TestNLSerializeAudit::test_busy_audit_record_fields_exact`. `set(rec.keys()) == {"ts", "kind", "thread_ts", "user_id_masked"}`, `rec["thread_ts"] == "1.1"`, `rec["user_id_masked"] != "U0AE7A54NHL"` 모두 확인. PRD §3.4 스키마 일치. |
+
+### AC-NLS-7. 컴플라이언스 정적 검사 — PASS (자동 + 보강 스캔)
+
+| 산출물 | 키워드 hit | 검증 |
+|--------|-----------|------|
+| PRD 본문 (`docs/prd/dev-relay-nl-serialize.md`) | 0 | PASS — QA 직접 `find_forbidden_keywords` 호출 → `[]` |
+| `ai/dev_relay/main.py` (구현 파일 — 모듈 스코프 락·flag·`TEMPLATE_NL_BUSY`·`_emit_nl_busy_notice`·`_handle_natural_language` 가드 블록 포함) | 0 | PASS — `test_compliance.py::test_dev_relay_source_clean[main.py]` 자동 커버 |
+| `ai/tests/dev_relay/test_handle_command_nl_serialize.py` (신규 테스트) | 0 | PASS — QA 직접 스캔 → `[]` |
+| 신규 메시지 상수 `TEMPLATE_NL_BUSY` ("지금 다른 요청을 처리 중이에요. 잠시 후 다시 보내주세요.") | 0 | PASS — 33자 한국어 1줄, 직접 스캔 `[]` (PRD §2 요건 — 20~60자 한국어 1줄 + 0 hit) |
+| 신규 audit kind 식별자 `nl_busy_rejected` | 0 | PASS — 직접 스캔 `[]` (`busy` / `rejected` / `nl` 모두 도메인 키워드 아님 확인) |
+| 신규 모듈 스코프 식별자 `_nl_turn_lock`, `_nl_shutdown_flag` | 0 | PASS — 직접 스캔 `[]` |
+| PR #48 title / body | 0 | PASS — `gh pr view 48 --json title,body` → `find_forbidden_keywords` → `[]` |
+| 커밋 `eaaf627` 메시지 (title + body) | 0 | PASS — `git log -1 --pretty=format:"%s%n%b" eaaf627` → `find_forbidden_keywords` → `[]` |
+
+`test_compliance.py` 의 기존 `_iter_dev_relay_source_files()` 가 `main.py` 변경분(신규 락·flag·busy 안내 헬퍼) 을 자동 커버 — 별도 화이트리스트 보강 불필요. `test_handle_command_nl_serialize.py` 는 `ai/tests/dev_relay/*` 이므로 자동 스캔 대상 외 → QA 가 본 세션에서 직접 보강 스캔 수행.
+
+### AC-NLS-8. 기존 NL + structured 테스트 0 fail — PASS (자동)
+
+```
+$ python -m pytest ai/tests/dev_relay/ -q
+489 passed in 2.31s
+```
+
+- 신규 9건 (`test_handle_command_nl_serialize.py`) + 기존 480건 모두 PASS.
+- 기존 NL 흐름 (`test_handle_command_nl.py`, `test_nl_agent.py`, `test_nl_classifier.py`) 회귀 0건.
+- structured 흐름 (`test_agent_integration.py`, `test_agent_runner_shutdown.py`, `test_dispatcher.py`, `test_tool_policy.py`, `test_queue.py`, `test_worker.py`, `test_reviewer.py`, `test_merger.py`) 회귀 0건.
+- 외부 인터페이스 (`_handle_natural_language` 시그니처, `JobQueue`, `AgentRunner`, 기존 audit kind) 모두 변경 없음 → 자동 회귀 보호.
+
+추가로 `ai/` 전체 (`coordinator` 포함) 회귀도 확인:
+
+```
+$ python -m pytest ai/tests/ -q
+667 passed in 3.06s
+```
+
+### AC-NLS-9. shutdown 보호 — PASS (자동, 2건)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| (a) NL turn 진행 중 (sonnet mock 0.3초 지연) `_nl_shutdown_flag.set()` 호출 → join | 진행 중 1건은 graceful 완료 (응답 발사 + audit 기록 + 락 release). 후속 `_nl_turn_lock.acquire(blocking=False)` 성공 (락이 release 됐다는 증거). | PASS — `TestNLSerializeShutdown::test_in_flight_turn_completes_gracefully`. `results["finished"] is True`, `sonnet_calls == 1`, 후속 acquire 성공 확인. |
+| (b) `_nl_shutdown_flag.set()` 이후 새 NL 호출 진입 | 락 acquire 시도 이전에 즉시 거절 — `TEMPLATE_NL_BUSY` 1줄 발사, `nl_busy_rejected` audit 1줄 기록. SDK 호출 0건, classifier 호출 0건. | PASS — `TestNLSerializeShutdown::test_shutdown_flag_rejects_new_entry`. `sonnet_calls == 0`, `classifier_calls == 0`, `TEMPLATE_NL_BUSY in payloads`, busy audit 1줄 확인. |
+
+비고: 본 PR 은 `_nl_shutdown_flag.set()` 의 호출 측 (예: `AgentRunner.shutdown` 통합) 을 도입하지 않는다 — PR 본문 "구현 결정 메모" 명시. watchdog 자체는 PR #37 그대로 재사용 (PRD §3.5). flag 메커니즘 자체의 작동은 본 테스트로 검증됨.
+
+### §7 위험 1번. 예외 발생 시 락 release (try/finally) — PASS (자동)
+
+| 재현 | 기대 | 실제 |
+|------|------|------|
+| `sonnet_responder` 콜러블이 `RuntimeError("SDK boom")` raise 하도록 구성 → `_handle_natural_language` 호출 → 예외 위로 propagate | 예외 throw 됨에도 `try/finally` 가 `_nl_turn_lock.release()` 실행. 후속 `_nl_turn_lock.acquire(blocking=False)` 즉시 성공. | PASS — `TestNLSerializeLockReleaseOnException::test_lock_released_when_sonnet_raises`. `pytest.raises(RuntimeError, match="SDK boom")` 통과 후 acquire 성공 확인. 코드상 `_handle_natural_language` (`main.py:587-590`) 의 `finally: _nl_turn_lock.release()` 정적 read 로도 보강 확인. |
+
+---
+
+## 2. 외부 인터페이스 변경 0건 검증 (PRD §3.6)
+
+| 항목 | 변경 전 | 변경 후 | 결과 |
+|------|---------|---------|------|
+| `_handle_natural_language(*, text, user_id, event, say, logger, sessions, nl_runtime)` 시그니처 | 동일 | 동일 | 변경 없음 |
+| `_handle_command` 시그니처 | 동일 | 동일 | 변경 없음 |
+| `build_app` 컨테이너 — lock 인스턴스 외부 주입 여부 | — | 모듈 스코프이므로 주입 없음 | PR 본문 결정 사항 그대로 |
+| `JobQueue` / `AgentRunner` API | 동일 | 동일 | 변경 없음 |
+| 기존 audit kind (`llm_invoked`, `session_started`, `session_resumed`, `merge_*`, `review_*` 등) | 동일 | 동일 | 변경 없음 — 신규 1종 (`nl_busy_rejected`) 만 추가 |
+| 신규 모듈 상수 | — | `_nl_turn_lock: threading.Lock`, `_nl_shutdown_flag: threading.Event`, `TEMPLATE_NL_BUSY: str` (3종) | 외부 인터페이스 X (모듈 prefix `_` 또는 내부 텍스트 상수) |
+| 신규 helper | — | `_emit_nl_busy_notice(*, say, thread_ts, masked, logger, reason)` (private) | 외부 인터페이스 X |
+| 신규 의존성 | — | 0건 (stdlib `threading` 만) | PRD §3.6 만족 |
+
+---
+
+## 3. 에지 케이스 / 위험 시나리오 (PRD §7)
+
+| 위험 | 시나리오 | 검증 |
+|------|----------|------|
+| 1. 락 미release 회귀 (영구 차단) | `_handle_natural_language` 내부 `run_turn` 또는 `say` / `sessions.start` 예외 시 락 미release | `TestNLSerializeLockReleaseOnException` 자동 검증 — sonnet raise 후 즉시 acquire 가능. 코드상 `try/finally` 1지점 (`main.py:587-590`) 으로 정상·예외·early return 모두 커버. |
+| 2. rate_limiter 와 lock 가드 발사 중복 | rate limit 가 발동했는데 busy 도 발사되는 경우 | `TestNLSerializeRateLimitInterop` 가 `TEMPLATE_NL_BUSY not in payloads` + busy audit `[]` 로 회귀 차단. `_handle_command` 의 rate_limiter 가드가 `_handle_natural_language` 진입보다 위 — PRD §7 위험 2번 권장 순서 (rate_limiter → lock acquire → SDK) 만족. |
+| 3. shutdown 흐름과 락 release 경쟁 | flag set 시점과 진행 중 turn 의 락 release 가 race | `TestNLSerializeShutdown::test_in_flight_turn_completes_gracefully` — flag set 후에도 graceful 완료 + 후속 acquire 성공. watchdog timeout 보다 짧으면 정상 케이스, 초과 시 강제 종료는 PR #37 의 `AgentRunner.shutdown(timeout)` 책임 (본 PRD 비범위). |
+| 4. busy 메시지 자체 race / Slack rate limit | 거절 빈도 폭증 → `say(TEMPLATE_NL_BUSY)` 호출 폭증 → Slack API rate limit 표면 증가 | 1인 MVP 단계 무시 가능. `_emit_nl_busy_notice` 가 `say` 호출 실패 시 `logger.warning` 으로 흡수 — audit 라인은 무조건 기록 (busy 빈도 모니터링 입력 데이터 보존). |
+| 5. `_append_audit` 자체 락 부재 | structured 분기와 NL 분기 동시 audit 기록 시 interleave | 본 PRD 비범위 — 단일 line write 는 OS 레벨 atomic. 별도 후속 PRD 필요 시 `_append_audit` 자체에 `threading.Lock` 추가 (PR 본문 follow-up). |
+| 6. multi-process 데몬 배치 시 무효 | `threading.Lock` 은 process-local | PRD §4 비범위 — 현재 운영은 단일 인스턴스 전제. multi-instance 배치 시 직렬화 무효 + race 재출현 가능 — 운영 가이드 한 줄 추가 권장 (PRD §7 위험 6번 follow-up). |
+| 7. shutdown flag set 호출 측 미통합 | 본 PR 은 `_nl_shutdown_flag.set()` 의 호출 측을 도입하지 않음 (`AgentRunner.shutdown` 와 묶는 통합 후속) | 검증 — 코드상 `_nl_shutdown_flag.set()` 호출 0건 (구현측). flag 메커니즘 자체 동작은 `TestNLSerializeShutdown` 2건으로 확인. graceful 종료는 watchdog (PR #37) 책임. follow-up 작업 항목 (PR 본문 명시). |
+| 8. `_extract_thread_ts` 에서 `event["thread_ts"]` 누락 시 `ts` 로 fallback | reply-in-thread 가 아닌 top-level 메시지의 thread_ts 처리 | 기존 동작 그대로 (PRD §3.2 정책 승계). `TestNLSerializeAudit` 에서 `event = {"ts": "1.1", ...}` 만 주입한 케이스가 `rec["thread_ts"] == "1.1"` 로 정상 처리됨을 검증. |
+| 9. `find_forbidden_keywords` 미통과 시 busy 미발사 | 컴플라이언스 가드 위반 → 외부 노출 사고 | `_emit_nl_busy_notice` 가 `find_forbidden_keywords(safe)` 체크 후 hit 발견 시 `say` 호출 skip + `logger.error`. 정적 검사로는 항상 0 hit 이지만 다중 layer 안전망 — PRD §3.2 만족. |
+
+---
+
+## 4. 컴플라이언스 정적 검사 결과 (실측)
+
+```
+$ python -m pytest ai/tests/dev_relay/test_compliance.py -v
+ai/tests/dev_relay/test_compliance.py::test_dev_relay_source_clean[main.py] PASSED  [ 98%]
+...
+============================== 52 passed in 0.02s ==============================
+```
+
+QA 보강 스캔 (PRD 본문 / 신규 테스트 파일 / 신규 식별자 / busy 본문 / PR 메타 / commit):
+
+```
+$ python3 -c "
+from ai.coordinator._compliance import find_forbidden_keywords
+files = [
+    'docs/prd/dev-relay-nl-serialize.md',
+    'ai/dev_relay/main.py',
+    'ai/tests/dev_relay/test_handle_command_nl_serialize.py',
+]
+for p in files:
+    print(p, '->', find_forbidden_keywords(open(p, encoding='utf-8').read()))
+"
+docs/prd/dev-relay-nl-serialize.md -> []
+ai/dev_relay/main.py -> []
+ai/tests/dev_relay/test_handle_command_nl_serialize.py -> []
+
+$ python3 -c "
+from ai.coordinator._compliance import find_forbidden_keywords
+print('TEMPLATE_NL_BUSY hits:', find_forbidden_keywords('지금 다른 요청을 처리 중이에요. 잠시 후 다시 보내주세요.'))
+print('nl_busy_rejected hits:', find_forbidden_keywords('nl_busy_rejected'))
+print('_nl_turn_lock hits:', find_forbidden_keywords('_nl_turn_lock'))
+print('_nl_shutdown_flag hits:', find_forbidden_keywords('_nl_shutdown_flag'))
+"
+TEMPLATE_NL_BUSY hits: []
+nl_busy_rejected hits: []
+_nl_turn_lock hits: []
+_nl_shutdown_flag hits: []
+
+$ gh pr view 48 --json title,body | python3 -c "<find_forbidden_keywords>"
+PR title hits: []
+PR body hits: []
+
+$ git log -1 --pretty=format:"%s%n%b" eaaf627 | python3 -c "<find_forbidden_keywords>"
+commit message hits: []
+```
+
+전 산출물 0 hit — AC-NLS-7 만족.
+
+---
+
+## 5. 자동 검증 실행 로그 (요약)
+
+```
+$ python -m pytest ai/tests/dev_relay/test_handle_command_nl_serialize.py -v
+tests/dev_relay/test_handle_command_nl_serialize.py::TestNLSerializeSameThread::test_concurrent_same_thread_second_rejected PASSED [ 11%]
+tests/dev_relay/test_handle_command_nl_serialize.py::TestNLSerializeDifferentThread::test_concurrent_different_thread_second_rejected PASSED [ 22%]
+tests/dev_relay/test_handle_command_nl_serialize.py::TestNLSerializeSequential::test_sequential_second_call_succeeds PASSED [ 33%]
+tests/dev_relay/test_handle_command_nl_serialize.py::TestNLSerializeStructuredCoexist::test_structured_in_flight_does_not_block_nl PASSED [ 44%]
+tests/dev_relay/test_handle_command_nl_serialize.py::TestNLSerializeRateLimitInterop::test_rate_limit_fires_first_no_busy PASSED [ 55%]
+tests/dev_relay/test_handle_command_nl_serialize.py::TestNLSerializeAudit::test_busy_audit_record_fields_exact PASSED [ 66%]
+tests/dev_relay/test_handle_command_nl_serialize.py::TestNLSerializeShutdown::test_shutdown_flag_rejects_new_entry PASSED [ 77%]
+tests/dev_relay/test_handle_command_nl_serialize.py::TestNLSerializeShutdown::test_in_flight_turn_completes_gracefully PASSED [ 88%]
+tests/dev_relay/test_handle_command_nl_serialize.py::TestNLSerializeLockReleaseOnException::test_lock_released_when_sonnet_raises PASSED [100%]
+============================== 9 passed in 1.32s ===============================
+
+$ python -m pytest ai/tests/dev_relay/ -q
+489 passed in 2.31s
+
+$ python -m pytest ai/tests/ -q
+667 passed in 3.06s
+
+$ python -m pytest ai/tests/dev_relay/test_compliance.py -q
+52 passed in 0.02s
+```
+
+---
+
+## 6. 수동 검증 체크리스트 (PRD §8.2, 후속 세션 권장)
+
+> **모바일 Slack 환경 부재 — 본 QA 세션에서 미수행. 후속 세션에서 사용자가 직접 1 사이클 완주 권장.**
+
+상위 PRD `slack-dev-relay.md` / `dev-relay-natural-language.md` 부록 A 셋업이 완료된 환경에서 다음 3건을 1회 수행:
+
+- [ ] 같은 스레드에 자연어 메시지 2개를 빠르게 (1~2초 간격) 연속 전송 → 첫 번째 응답 정상, 두 번째는 즉시 busy 안내 1줄 ("지금 다른 요청을 처리 중이에요. 잠시 후 다시 보내주세요.") 수신.
+- [ ] 첫 번째 응답 완료를 기다린 후 같은 스레드에 새 자연어 전송 → 정상 응답 (회귀 확인 — turn 종료 후 재진입 통과).
+- [ ] structured 명령 (`review pr <N>`) 진행 중에 새 스레드에서 자연어 전송 → 자연어가 즉시 처리됨 (별도 락 확인 — `JobQueue` 와 `_nl_turn_lock` 가 독립).
+
+자동 가드(`_nl_turn_lock`, `_nl_shutdown_flag`, `_emit_nl_busy_notice`, `_handle_natural_language` 가드 블록) 와 모든 정적 스캔 통과 — 수동 1 사이클로 충분.
+
+후속 follow-up (사용자 본인 모니터링, PRD §6.3):
+
+- 머지 후 1~2주 audit.jsonl 의 `nl_busy_rejected` 발생 빈도 모니터링 → 빈도 높으면 옵션 A (`JobQueue` 통합) 또는 옵션 B (thread_ts 별 lock map) 재설계 후속 PRD.
+- `_nl_shutdown_flag.set()` 의 `AgentRunner.shutdown` 통합 — 본 PR 비포함, 후속 작업 (PR 본문 명시).
+
+---
+
+## 7. 판정
+
+- **AC 통과율: 9/9 (100%) + §7 위험 1번 (락 release on exception) 통과**
+- **회귀: 0건** — 667/667 (ai 전체), 489/489 (dev_relay), 52/52 (compliance), 9/9 (신규)
+- **외부 인터페이스 변경: 0건** (PRD §3.6 만족 — `_handle_natural_language` 시그니처·`JobQueue`·`AgentRunner`·기존 audit kind 모두 그대로)
+- **컴플라이언스 정적 스캔: 0 hit** (PRD 본문 / `main.py` / 신규 테스트 / 신규 식별자 / `TEMPLATE_NL_BUSY` 본문 / PR #48 title-body / commit `eaaf627` 모두 통과)
+- **신규 의존성: 0건** (stdlib `threading` 만)
+- **수동 검증**: 미수행 (후속 세션 권장 — 자동 가드·정적 검사 모두 통과한 상태이므로 수동 1 사이클로 충분)
+
+**최종 판정: `qa-passed`** — PR #48 라벨 갱신 (`qa-passed` 추가, `impl-ready` 제거).


### PR DESCRIPTION
## 개요

PRD [`docs/prd/dev-relay-nl-serialize.md`](../blob/main/docs/prd/dev-relay-nl-serialize.md) (#46) 의 옵션 C — process-wide 단일 mutex 직렬화 — 구현.

`_handle_natural_language` 진입 직후 모듈 스코프 `threading.Lock` 을 `acquire(blocking=False)` 로 시도. 실패 시 즉시 안내 1줄 발사 + 거절 + `nl_busy_rejected` audit 1줄 기록. `try/finally` 로 release 강제.

## 변경 파일

- `ai/dev_relay/main.py` (+145 / -64) — 모듈 스코프 락·flag·busy 안내 상수, `_emit_nl_busy_notice` 헬퍼, `_handle_natural_language` 가드 블록.
- `ai/tests/dev_relay/test_handle_command_nl_serialize.py` (신규 +414) — AC-NLS-1~6, 9 + 예외 시 락 release 단위 테스트 9건.
- `docs/SESSION_NOTES.md` (+46) — 2026-05-07 세션 entry 동봉 (정책: 단독 SESSION_NOTES PR 금지).

## 수용 기준 매핑

| AC | 시나리오 | 테스트 |
|---|---|---|
| AC-NLS-1 | 같은 thread_ts 동시 두 NL — 두 번째 거절, SDK 1건 | `TestNLSerializeSameThread::test_concurrent_same_thread_second_rejected` |
| AC-NLS-2 | 다른 thread_ts 동시 두 NL — 두 번째 거절 (process-wide) | `TestNLSerializeDifferentThread::test_concurrent_different_thread_second_rejected` |
| AC-NLS-3 | turn 종료 후 재진입 정상 처리 | `TestNLSerializeSequential::test_sequential_second_call_succeeds` |
| AC-NLS-4 | structured 진행 중 NL — 차단되지 않음 (별도 락) | `TestNLSerializeStructuredCoexist::test_structured_in_flight_does_not_block_nl` |
| AC-NLS-5 | rate_limiter 우선 발동 — busy 미발사 | `TestNLSerializeRateLimitInterop::test_rate_limit_fires_first_no_busy` |
| AC-NLS-6 | audit `nl_busy_rejected` 1줄 + 필드 정확히 4개 | `TestNLSerializeAudit::test_busy_audit_record_fields_exact` |
| AC-NLS-7 | 컴플라이언스 정적 검사 0 hit | `test_compliance.py` (변경 없음, main.py 자동 커버) |
| AC-NLS-8 | 기존 NL + structured 테스트 0 fail | `pytest ai/tests/dev_relay/` 489 passed |
| AC-NLS-9 | shutdown — 진행 중 graceful, 새 진입 거절 | `TestNLSerializeShutdown` 2건 |
| §7 위험1 | 예외 발생 시 락 release | `TestNLSerializeLockReleaseOnException::test_lock_released_when_sonnet_raises` |

## 테스트 결과

```
$ pytest ai/tests/dev_relay/ -q
489 passed in 2.28s
```

- 신규 9건 + 기존 480건 모두 PASS.
- 컴플라이언스 정적 스캔 0 hit (`test_dev_relay_source_clean[main.py]` 포함).

## 구현 결정 메모

- `_nl_turn_lock` / `_nl_shutdown_flag` 둘 다 모듈 스코프 — 외부 시그니처 변경 없음 (`_handle_natural_language` 인자 그대로). `build_app` 도 lock 인스턴스 주입을 받지 않는다.
- busy 안내 본문: 33자 한국어 1줄. 컴플라이언스 0 hit.
- audit 라인 필드 정확히 `ts`/`kind`/`thread_ts`/`user_id_masked` 4개 (PRD §3.4 스키마).
- rate_limiter 와 락 가드 순서: `_handle_command` 에서 rate_limiter 가 먼저 발동 → 통과 시에만 `_handle_natural_language` 호출 → 거기서 락 시도 (AC-NLS-5).
- shutdown flag 는 본 PR 에서는 set 호출이 없다 — `AgentRunner.shutdown` 와 묶는 통합은 후속 작업 (현재 graceful 종료는 watchdog 책임, PR #37 그대로).
- 신규 의존성 0건 (stdlib `threading` 만).

## SESSION_NOTES 동봉

`docs/SESSION_NOTES.md` 2026-05-07 entry 가 working tree 에 미커밋 상태로 있어 본 PR 의 첫 commit 에 함께 포함. 정책 (SESSION_NOTES.md L23-28 "단독 SESSION_NOTES PR 금지") 준수.

## 다음 작업

- 머지 후 1~2주 `nl_busy_rejected` 발생 빈도 모니터링 (PRD §6.3 / SESSION_NOTES follow-up 7번).
- 빈도가 높으면 옵션 A (`JobQueue` 통합) 또는 옵션 B (thread_ts 별 lock map) 재설계 — 후속 PRD.

## QA 가이드

PRD §8.2 수동 검증 시나리오:
1. 같은 스레드에 자연어 메시지 2개 빠르게 (1~2초 간격) 연속 전송 → 첫 응답 정상, 두 번째는 busy 안내 1줄.
2. 첫 응답 완료 후 같은 스레드에 새 자연어 → 정상 응답 (회귀 확인).
3. structured (`review pr <N>`) 진행 중 새 스레드에서 자연어 → 즉시 처리 (별도 락 확인).