### PR TITLE
chore(dev-relay): NL shutdown flag wire — PR #48 reviewer P2 후속

### DIFF
--- a/ai/dev_relay/main.py
+++ b/ai/dev_relay/main.py
@@ -449,6 +449,8 @@ def _emit_nl_busy_notice(
     safe = guard_text_with_urls(TEMPLATE_NL_BUSY)
     if find_forbidden_keywords(safe):
         # 다중 layer 안전망 — 정적 검사로 0 hit 을 보장하지만 회귀 방어.
+        # 정책: 가드 위반 시 사용자 무발사 (audit 만 기록) — 컴플라이언스 우선,
+        # 외부 노출 사고 차단이 사용자 안내 손실보다 우선한다 (PR #48 reviewer P2-1).
         logger.error("compliance: blocked busy notice", extra={"reason": reason})
     else:
         try:
@@ -993,6 +995,31 @@ def _install_interrupt_handlers(logger: logging.Logger) -> None:
         pass
 
 
+def shutdown_dev_relay(
+    runner: AgentRunner,
+    *,
+    timeout: float | None = _SHUTDOWN_TIMEOUT_S,
+    logger: logging.Logger | None = None,
+) -> None:
+    """데몬 shutdown 진입점 — NL flag set + AgentRunner.shutdown 위임.
+
+    PRD `dev-relay-nl-serialize.md` §3.5 + PR #48 reviewer P2-2 후속.
+
+    호출 순서:
+    1. `_nl_shutdown_flag.set()` — 신규 NL 진입 거절 (락 acquire 시도 이전).
+       진행 중 1건은 `try/finally` 로 graceful 종료.
+    2. `runner.shutdown(wait=True, timeout=timeout)` — worker 큐 graceful 종료.
+
+    flag set 은 idempotent (`threading.Event.set` 자체가 이미 set 상태면 no-op)
+    이라 다중 호출 안전. 본 함수는 `run()` 의 finally 절에서 호출되며 직접 호출도
+    가능 (`AgentRunner.shutdown` 시그니처는 그대로 유지 — 외부 호출 측 회귀 0).
+    """
+    _nl_shutdown_flag.set()
+    if logger is not None:
+        logger.info("NL 분기 shutdown flag set — 신규 진입 거절 시작.")
+    runner.shutdown(wait=True, timeout=timeout)
+
+
 def _build_nl_runtime(logger: logging.Logger) -> dict[str, Any] | None:
     """SDK 자연어 분기 runtime 을 구성한다.
 
@@ -1393,7 +1420,8 @@ def run() -> int:
         except Exception:  # noqa: BLE001
             pass
         try:
-            runner.shutdown(wait=True, timeout=_SHUTDOWN_TIMEOUT_S)
+            # PR #48 reviewer P2-2 후속 — NL flag set + AgentRunner.shutdown 통합.
+            shutdown_dev_relay(runner, timeout=_SHUTDOWN_TIMEOUT_S, logger=logger)
         except Exception:  # noqa: BLE001
             pass
         logger.info("Dev Manager 데몬을 정리했습니다.")

--- a/ai/tests/dev_relay/test_shutdown_dev_relay.py
+++ b/ai/tests/dev_relay/test_shutdown_dev_relay.py
@@ -1,0 +1,93 @@
+"""`shutdown_dev_relay` 헬퍼 단위 테스트.
+
+PR #48 reviewer P2-2 후속 — `_nl_shutdown_flag.set()` 호출 측 통합 검증.
+
+검증 항목:
+- 호출 시 `_nl_shutdown_flag` 가 set 된다.
+- `AgentRunner.shutdown` 이 동일 호출에서 위임된다.
+- 다중 호출 시 idempotent (Event.set 은 이미 set 상태면 no-op).
+- flag set 의 사용자 측 효과 (새 NL 진입 거절) 는 기존 AC-NLS-9 (a) 가 보장 —
+  본 테스트는 wire-up 만 검증한다.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ai.dev_relay import main as main_mod
+from ai.dev_relay.agent_runner import AgentRunner
+from ai.dev_relay.main import shutdown_dev_relay
+
+
+def _fresh_runner() -> AgentRunner:
+    return AgentRunner(max_workers=1)
+
+
+class TestShutdownDevRelayWiring:
+    def setup_method(self) -> None:
+        # 이전 테스트가 set 한 상태로 남겼을 수 있으므로 매 케이스 시작 시 초기화.
+        main_mod._nl_shutdown_flag.clear()
+
+    def teardown_method(self) -> None:
+        main_mod._nl_shutdown_flag.clear()
+
+    def test_sets_nl_shutdown_flag(self) -> None:
+        """헬퍼 호출 시 NL flag 가 set 된다."""
+        runner = _fresh_runner()
+        assert not main_mod._nl_shutdown_flag.is_set()
+
+        shutdown_dev_relay(runner, timeout=1.0)
+
+        assert main_mod._nl_shutdown_flag.is_set()
+
+    def test_delegates_to_runner_shutdown(self) -> None:
+        """`AgentRunner.shutdown` 이 같은 호출에서 위임된다 — runner 가 closed 상태로 전이."""
+        runner = _fresh_runner()
+
+        shutdown_dev_relay(runner, timeout=1.0)
+
+        # 두 번째 task 제출이 RuntimeError 로 거절돼야 한다 (closed 상태 검증).
+        try:
+            runner.run_callable.__self__  # 안전한 attr 접근 — 아래에서 직접 검증.
+        except Exception:
+            pass
+
+        # closed 후 제출은 RuntimeError.
+        from ai.dev_relay.agent_runner import AgentTask
+        task = AgentTask(job_id=1, command="echo")
+        raised = False
+        try:
+            runner.run_callable(task, lambda: "x")
+        except RuntimeError:
+            raised = True
+        assert raised, "runner.shutdown 이 위임되지 않음 — closed 상태 미전이"
+
+    def test_idempotent_double_call(self) -> None:
+        """헬퍼 다중 호출 시 예외 없이 정상 처리 (Event.set 은 idempotent,
+        AgentRunner.shutdown 도 closed 재호출 시 early return)."""
+        runner = _fresh_runner()
+
+        shutdown_dev_relay(runner, timeout=1.0)
+        # 두 번째 호출이 raise 하면 fail.
+        shutdown_dev_relay(runner, timeout=1.0)
+
+        assert main_mod._nl_shutdown_flag.is_set()
+
+    def test_logger_optional(self) -> None:
+        """logger=None 호출도 정상 동작."""
+        runner = _fresh_runner()
+
+        shutdown_dev_relay(runner, timeout=1.0, logger=None)
+
+        assert main_mod._nl_shutdown_flag.is_set()
+
+    def test_logger_info_message_emitted(self, caplog) -> None:
+        """logger 제공 시 INFO 한 줄이 남는다."""
+        runner = _fresh_runner()
+        logger = logging.getLogger("ai.dev_relay.test_shutdown_helper")
+
+        caplog.set_level(logging.INFO, logger=logger.name)
+        shutdown_dev_relay(runner, timeout=1.0, logger=logger)
+
+        msgs = [rec.getMessage() for rec in caplog.records if rec.name == logger.name]
+        assert any("shutdown flag set" in m for m in msgs)

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -536,3 +536,44 @@
 - **다음 작업 후보** (PR 본문 기반, 절대적 지시 아님):
   - 머지 후 1~2주 `nl_busy_rejected` 발생 빈도 모니터링 (PRD §6.3 / SESSION_NOTES follow-up 7번).
   - 빈도가 높으면 옵션 A (`JobQueue` 통합) 또는 옵션 B (thread_ts 별 lock map) 재설계 — 후속 PRD.
+
+### 2026-05-12 — chore(dev-relay): NL shutdown flag wire — PR #48 reviewer P2 후속 (#49)
+
+- **slug**: `dev-relay-nl-shutdown-wire` · **author**: @HY0118
+- **PR**: https://github.com/deeptrading-lab/trading-signal-engine/pull/49
+- **요약**: chore(dev-relay): NL shutdown flag wire — PR #48 reviewer P2 후속
+- **현재 상태**: QA 통과 · 리뷰·머지 대기 (이 항목은 QA 통과 시점에 자동 기록됨)
+- **PR 본문 발췌**:
+  > ## 배경
+  > 
+  > PR #48 (`dev-relay-nl-serialize` impl, commit `40efb0c`) 머지 직후 reviewer 가 남긴 P2 후속 메모 2건을 본 chore PR 로 처리. 자가 self-review 한계는 비범위 (별도 운영자 트랙).
+  > 
+  > reviewer 코멘트 원문:
+  > - **P2-1**: `_emit_nl_busy_notice` 가드 위반 fallback 시 audit 만 기록되고 사용자 무발사 — 의도된 안전망 (외부 노출 사고 우선 차단). 운영 모니터링에서 `compliance: blocked busy notice` 에러 로그 빈도 추적 권장.
+  > - **P2-2**: `_nl_shutdown_flag.set()` 호출 측 미통합 — `AgentRunner.shutdown` 와 묶는 후속 PR 필요.
+  > 
+  > ## 변경 사항
+  > 
+  > ### P2-2 본체 — NL shutdown wire (옵션 b 채택)
+  > 
+  > `ai/dev_relay/main.py` 에 통합 헬퍼 추가:
+  > 
+  > ```python
+  > def shutdown_dev_relay(runner, *, timeout, logger=None):
+  >     _nl_shutdown_flag.set()
+  >     if logger is not None:
+  >         logger.info("NL 분기 shutdown flag set — 신규 진입 거절 시작.")
+  >     runner.shutdown(wait=True, timeout=timeout)
+  > ```
+  > 
+  > `run()` 의 `finally` 절에서 기존 `runner.shutdown(...)` 직접 호출을 본 헬퍼로 단일화. 외부 시그니처 (`AgentRunner.shutdown`) 는 그대로 유지 — 회귀 0.
+  > 
+  > **옵션 비교**:
+  > - (a) `AgentRunner.shutdown` 내부에서 `_nl_shutdown_flag.set()` — 모듈 전역 의존 도입, 책임 분리 위반 → 거절
+  > - (b) 통합 헬퍼 `shutdown_dev_relay` (채택) — AgentRunner 책임 분리 유지 + NL flag set + 후속 정리를 같은 모듈에서 묶음
+  > - (c) OS SIGTERM/SIGINT 핸들러에서 둘 다 호출 — lifecycle 분기점이 늘어남, 직접 호출 경로 미커버 → 거절
+  > 
+  > ### P2-1 — 가드 위반 fallback 정책 명문화
+- **다음 작업 후보** (PR 본문 기반, 절대적 지시 아님):
+  - (없음 — 본 PR 머지 후 PR #48 reviewer P2-1·P2-2 종결)
+  - 별도 트랙은 SESSION_NOTES 2026-05-13 entry follow-up 표 참조 (A-3/A-4/A-5/B-1/B-2/C-1/C-2/C-3)

--- a/docs/SESSION_NOTES.md
+++ b/docs/SESSION_NOTES.md
@@ -197,3 +197,43 @@
 - PR #43 의 reviewer P2 코멘트 3건은 follow-up 표 5번으로 이월 — 본 세션 처리 안 함.
 - PR #46 의 NL 분기 동시성 구현은 다음 세션 1번 트랙 — `feat/dev-relay-nl-serialize` 브랜치 미생성 상태.
 - 1~2주 운영 데이터 수집 prerequisite 가 걸린 트랙 2건 (6번, 7번) — 즉시 진입 불가.
+
+---
+
+## 2026-05-13 — NL 직렬화 impl 머지 + reviewer P2 후속 chore
+
+**요약**: 직전 세션 follow-up 표 1번(`dev-relay-nl-serialize` 구현) 종결 — PR #48 머지. PR #48 reviewer 가 남긴 P2-1·P2-2 후속 메모 2건을 본 세션에서 chore PR 로 처리. NL 분기는 이제 데몬 shutdown 시 새 진입 거절 + 진행 중 1건 graceful 종료가 wire 된 상태.
+
+### 처리한 일
+
+- **PR [#48](https://github.com/deeptrading-lab/trading-signal-engine/pull/48)** — `dev-relay-nl-serialize` 구현 (옵션 C: process-wide `threading.Lock` 단일 인스턴스). impl commit `40efb0c`. QA AC 9/9 PASS, reviewer P0=0 P1=0 P2=3 (P2-1 가드 위반 fallback 명문화 / P2-2 `_nl_shutdown_flag.set()` 호출 측 미통합 / P2-3 self-review 한계 — 비범위).
+- **본 PR (chore)** — `dev-relay-nl-shutdown-wire`. reviewer P2-1 + P2-2 후속.
+  - P2-1: `_emit_nl_busy_notice` 가드 위반 fallback 의도를 한 줄 코멘트로 명문화 (정책: 사용자 무발사 = 컴플라이언스 우선).
+  - P2-2: `shutdown_dev_relay(runner, *, timeout, logger)` 헬퍼 신설 → NL flag set + `AgentRunner.shutdown` 위임. `run()` finally 절에서 호출. 단위 테스트 5건 추가.
+- **SESSION_NOTES 동봉** — 본 항목 (정책 준수, 별도 PR 금지).
+
+### 결정·합의 사항
+
+- **NL shutdown wire 설계 = 옵션 (b)**: `dev_relay/main.py` 에 통합 헬퍼 `shutdown_dev_relay(runner, *, timeout, logger)` 추가. 근거 — (1) `AgentRunner` 외부 시그니처 불변 (회귀 0), (2) NL flag 가 `main.py` 모듈 스코프라 같은 모듈 안에서 wire 가 가장 자연스러움, (3) 후속 정리 (예: handler.close / picker.stop) 와 묶을 위치가 분명. 옵션 (a) `AgentRunner.shutdown` 내부 호출은 모듈 전역 의존이 들어가 책임 분리 위반 — 거절. 옵션 (c) OS SIGTERM/SIGINT 핸들러 통합은 lifecycle 분기점이 늘어남 — 거절.
+- **PR #48 reviewer 가 `--approve` 대신 `--comment` 사용**: GitHub 가 동일 사용자 자가-승인 API 를 차단해 발생. AGENTS.md L235 정책 부연 허용 범위 내. 후속 트랙: 별도 운영자 / cmux 패널로 reviewer 분리 검토 (follow-up 표 B-2).
+- **단독 SESSION_NOTES PR 금지** 정책 준수: 본 entry 는 본 chore PR 브랜치에 동봉.
+
+### 다음 세션 시작 포인트 (follow-up 표 — 갱신)
+
+직전 표 1번(`dev-relay-nl-serialize` impl) 종결. 본 chore PR 머지 후 reviewer P2-1·P2-2 도 종결. P2-3 (self-review 한계) 는 B-2 트랙으로 일반화.
+
+| 우선 | 항목 | 슬러그/이슈 | 비고 |
+|---|---|---|---|
+| A-3 | audit `user_id` 추적 누락 fix | 직전 세션 P2 (reviewer C-2 후속) | 즉시 가능. chore 또는 작은 PRD |
+| A-4 | PR #43 reviewer P2 코멘트 3건 | [#43 review comment](https://github.com/deeptrading-lab/trading-signal-engine/pull/43#issuecomment-4389053077) | 즉시 가능. (a) `validate_approval(expected=None)` fallback, (b) `_build_reviewer` NotImplementedError fallback, (c) `_post_blocks_to_thread` blocks 가드 미적용 |
+| A-5 | 사용자 검증 이슈 4건 회귀 테스트화 | 직전 세션 P3 (reviewer 권고) | 즉시 가능 |
+| B-1 | Phase 2 PRD `dev-relay-write-tools` | 직전 세션 P2 | PRD 필요 — write 도구 + 머지 confirm |
+| B-2 | reviewer 운영자 분리 (정책 결정) | PR #48 reviewer P2-3 일반화 | GitHub 자가-승인 차단 회피 — 별도 cmux 패널/운영자 권장 정책화 |
+| C-1 | shell metachar `;`/`>`/`<`/`&` 추가 허용 검토 | `dev-relay-shell-chain-allow` (가칭) | PR #45 머지(2026-05-07) 후 ~2026-05-21 데이터 prerequisite |
+| C-2 | NL 분기 옵션 A/B 재설계 검토 | `dev-relay-nl-serialize-v2` (가칭) | PR #48 머지(2026-05-13) 후 ~2026-05-27 `nl_busy_rejected` 빈도 데이터 prerequisite |
+| C-3 | Issue #28 §3 운영 모니터링 | quota / audit 로테이션 / launchd plist | 일상 운영 1~2주 데이터 prerequisite — 충족 시 항목별 분기 |
+
+### 미결·블록
+
+- 본 chore PR 의 SESSION_NOTES append 는 정책 준수 (단독 PR 금지) — 본 브랜치에 동봉.
+- A-그룹 3건은 다음 세션 즉시 진입 가능. B-그룹 2건은 PRD 또는 정책 결정 필요. C-그룹 3건은 운영 데이터 수집 prerequisite.

--- a/docs/qa/dev-relay-nl-shutdown-wire.md
+++ b/docs/qa/dev-relay-nl-shutdown-wire.md
@@ -1,0 +1,110 @@
+# QA: dev-relay-nl-shutdown-wire (chore)
+
+> 작성자: QA (자동 검증)
+> 작성일: 2026-05-13
+> 입력: chore — PRD 없음. PR #48 reviewer P2-1 / P2-2 후속.
+> 검증 대상 PR: [#49](https://github.com/deeptrading-lab/trading-signal-engine/pull/49) (`feature/dev-relay-nl-shutdown-wire`)
+> 변경 규모: +162 / -1, 3 files, 1 commit (`1d59691`)
+> 회귀 (dev_relay 전체): `python -m pytest ai/tests/dev_relay/ -q` → **494 passed (2.43s, 0 failed)**
+> 회귀 (컴플라이언스): `python -m pytest ai/tests/dev_relay/test_compliance.py -v` → **52 passed (0.02s, 0 hit)**
+> 회귀 (PR #48 NL serialize): `python -m pytest ai/tests/dev_relay/test_handle_command_nl_serialize.py -v` → **9 passed (1.30s, 0 failed)**
+
+---
+
+## 0. 요약
+
+- chore PR 이므로 PRD AC 매핑 대신 PR #48 reviewer 가 남긴 P2 메모 2건을 검증 항목으로 변환했다.
+- **신규 테스트 5/5 PASS** (`test_shutdown_dev_relay.py`) — `shutdown_dev_relay` 헬퍼의 4 가지 동작 (flag set / runner 위임 / idempotent / logger optional + INFO emit) 모두 통과.
+- **회귀 0건** — `ai/tests/dev_relay/` 494 전건 PASS, 컴플라이언스 52 PASS (`main.py` 신규 코드 포함 0 hit).
+- **PR #48 의 NL serialize 9건 0 fail** — shutdown flag set 후 새 진입 거절 (AC-NLS-9 (b)) 회귀 보존.
+- **SESSION_NOTES** — 2026-05-13 entry 가 정상 append 됨 (직전 2026-05-07 entry 구조 동일, 다음 세션 follow-up 표 A-3~C-3 으로 갱신).
+- **최종 판정**: `qa-passed`.
+
+---
+
+## 1. 검증 항목 매핑 (reviewer P2 → 테스트)
+
+### 핵심 (P2-2 — `_nl_shutdown_flag.set()` 호출 측 통합)
+
+| # | 검증 항목 | 재현 | 기대 | 실제 | 결과 |
+|---|---|---|---|---|---|
+| 1 | `shutdown_dev_relay()` 호출 후 `_nl_shutdown_flag.is_set()` == True | `test_shutdown_dev_relay.py::test_sets_nl_shutdown_flag` — 헬퍼 호출 전후 flag 상태 비교 | 호출 전 `False`, 호출 후 `True` | flag 가 정확히 set | PASS |
+| 2 | `AgentRunner.shutdown(timeout=...)` 위임 정상 | `test_delegates_to_runner_shutdown` — 헬퍼 호출 후 runner 에 새 task 제출 시 RuntimeError | runner 가 closed 상태로 전이, `run_callable` 두 번째 제출 거절 | RuntimeError 발생 (closed 검증) | PASS |
+| 3 | shutdown 호출 후 새 NL 진입 즉시 거절 (PR #48 AC-NLS-9 (b) 회귀) | `test_handle_command_nl_serialize.py::TestNLSerializeShutdown::test_shutdown_flag_rejects_new_entry` | flag set 상태에서 새 NL 진입 시 `TEMPLATE_NL_BUSY` 발사 + `nl_busy_rejected` audit | 정상 거절 + audit 기록 | PASS |
+| 4 | `run()` finally 절에서 헬퍼 호출 — 데몬 정상 종료 흐름 회귀 0 | `ai/dev_relay/main.py:1422-1426` 정적 검증 + 전체 회귀 | finally 절이 `shutdown_dev_relay(runner, timeout=_SHUTDOWN_TIMEOUT_S, logger=logger)` 를 호출 | 호출 라인 존재 확인. 본 모듈은 외부 연결로 단위 테스트 대상이 아니지만 (모듈 docstring 명시), `_SHUTDOWN_TIMEOUT_S=30.0` 그대로 사용 + `_nl_shutdown_flag` 모듈 스코프 단일 인스턴스 wire 확인. dev_relay 회귀 494 PASS. | PASS |
+
+### 부수 (P2-1 — 코멘트 보강)
+
+| # | 검증 항목 | 재현 | 기대 | 실제 | 결과 |
+|---|---|---|---|---|---|
+| 5 | `_emit_nl_busy_notice` fallback path 동작 변경 없음 — 가드 위반 시 audit 만 기록 + 사용자 무발사 (PR #48 동작 회귀) | `test_handle_command_nl_serialize.py::TestNLSerializeAudit::test_busy_audit_record_fields_exact` + `main.py:449-467` 정적 검증 | 가드 위반 시 `say()` 호출 안 함, `nl_busy_rejected` audit 1줄만 기록 | 동작 동일. PR #48 의 코드 흐름 변경 없이 인라인 코멘트만 보강 (`main.py:451-453`) | PASS |
+| 6 | docstring/코멘트 컴플라이언스 0 hit | `test_compliance.py::test_dev_relay_source_clean[main.py]` | `find_forbidden_keywords(main.py)` 가 빈 리스트 반환 | PASS — main.py 평문 0 hit (P2-1 신규 코멘트 포함) | PASS |
+
+### 정책 (D-1 — SESSION_NOTES 동봉)
+
+| # | 검증 항목 | 재현 | 기대 | 실제 | 결과 |
+|---|---|---|---|---|---|
+| 7 | `docs/SESSION_NOTES.md` 2026-05-13 entry 추가 + 직전 entry(2026-05-07) 형식 따르는지, follow-up 표 갱신됐는지 | `docs/SESSION_NOTES.md:203-239` 정독 | 5 섹션 (요약/처리한 일/결정·합의 사항/다음 세션 시작 포인트/미결·블록) + follow-up 표 갱신 (A/B/C 그룹) | 5 섹션 완비. follow-up 표가 직전 1~8번 일부 종결분 반영해 A-3~C-3 으로 갱신 (1번 = PR #48 종결, 5번 P2-1/P2-2 = 본 PR 종결). 정책 (단독 PR 금지) 명시. | PASS |
+| 8 | SESSION_NOTES 본문 컴플라이언스 0 hit (정적 스캐너 통과) | `test_compliance.py` 가 SESSION_NOTES 를 dev_relay source 스캔 대상에서 제외하므로, 외부 노출 산출물 기준 미회귀 — 본 PR 의 신규 entry 가 도입한 키워드 0건 (`signal`/`trading` 등 기존 entry 에 이미 포함된 URL·repo 명만 등장, 신규 표현 0건) | 신규 entry 가 베이스라인 keyword set 외의 도메인 키워드를 추가하지 않음 | 베이스라인 일치 — 본 entry 의 도메인 키워드는 슬러그명 `dev-relay-nl-shutdown-wire` / `dev-relay-nl-serialize` (PRD 슬러그) 등 코드/repo 식별자 한정 | PASS |
+
+### 회귀
+
+| # | 검증 항목 | 명령 | 결과 | 판정 |
+|---|---|---|---|---|
+| 9 | `ai/tests/dev_relay/` 전체 0 fail | `python -m pytest ai/tests/dev_relay/ -q` | **494 passed in 2.43s** | PASS |
+| 10 | `test_compliance.py` 0 hit | `python -m pytest ai/tests/dev_relay/test_compliance.py -v` | **52 passed in 0.02s** | PASS |
+| 11 | PR #48 의 `test_handle_command_nl_serialize.py` 9건 0 fail | `python -m pytest ai/tests/dev_relay/test_handle_command_nl_serialize.py -v` | **9 passed in 1.30s** | PASS |
+
+---
+
+## 2. 실행 로그 (요약)
+
+### 신규 테스트
+
+```
+ai/tests/dev_relay/test_shutdown_dev_relay.py::TestShutdownDevRelayWiring::test_sets_nl_shutdown_flag PASSED
+ai/tests/dev_relay/test_shutdown_dev_relay.py::TestShutdownDevRelayWiring::test_delegates_to_runner_shutdown PASSED
+ai/tests/dev_relay/test_shutdown_dev_relay.py::TestShutdownDevRelayWiring::test_idempotent_double_call PASSED
+ai/tests/dev_relay/test_shutdown_dev_relay.py::TestShutdownDevRelayWiring::test_logger_optional PASSED
+ai/tests/dev_relay/test_shutdown_dev_relay.py::TestShutdownDevRelayWiring::test_logger_info_message_emitted PASSED
+============================== 5 passed in 0.02s ===============================
+```
+
+### 전체 회귀
+
+```
+ai/tests/dev_relay/ → 494 passed in 2.43s
+```
+
+### 컴플라이언스
+
+```
+ai/tests/dev_relay/test_compliance.py → 52 passed in 0.02s
+(test_dev_relay_source_clean[main.py] PASS 포함)
+```
+
+### PR #48 NL serialize 회귀 (`shutdown_flag_rejects_new_entry` 포함)
+
+```
+ai/tests/dev_relay/test_handle_command_nl_serialize.py → 9 passed in 1.30s
+```
+
+---
+
+## 3. 에지 케이스 검증
+
+본 chore PR 은 외부 의존(거래소·뉴스 피드·네트워크) 흐름을 건드리지 않으므로 표준 에지 케이스는 비범위. 본 PR 한정 에지 케이스만 검증:
+
+| 케이스 | 검증 방법 | 결과 |
+|---|---|---|
+| `shutdown_dev_relay` 다중 호출 (한 데몬에 SIGINT → finally 진입 후 사용자가 SIGTERM 추가 전송 시나리오) | `test_idempotent_double_call` — 같은 runner 로 헬퍼 2회 호출 | PASS — `Event.set` 이 idempotent (이미 set 상태면 no-op), `AgentRunner.shutdown` 도 closed 재호출 시 early return |
+| `logger=None` 호출 (`run()` 외부에서 직접 호출 시) | `test_logger_optional` | PASS — INFO 라인 생략 + 정상 wire 동작 |
+| 진행 중 NL turn 1건 graceful 종료 (flag set 이전 락 획득한 turn) | `test_handle_command_nl_serialize.py::TestNLSerializeShutdown::test_in_flight_turn_completes_gracefully` (PR #48 회귀 보존) | PASS — `try/finally` 가 락 release 강제 |
+
+---
+
+## 4. 판정
+
+- 핵심 4/4, 부수 2/2, 정책 2/2, 회귀 3/3 — 총 **11/11 PASS**.
+- 실패 0건.
+- **최종**: `qa-passed`.


### PR DESCRIPTION
## 배경

PR #48 (`dev-relay-nl-serialize` impl, commit `40efb0c`) 머지 직후 reviewer 가 남긴 P2 후속 메모 2건을 본 chore PR 로 처리. 자가 self-review 한계는 비범위 (별도 운영자 트랙).

reviewer 코멘트 원문:
- **P2-1**: `_emit_nl_busy_notice` 가드 위반 fallback 시 audit 만 기록되고 사용자 무발사 — 의도된 안전망 (외부 노출 사고 우선 차단). 운영 모니터링에서 `compliance: blocked busy notice` 에러 로그 빈도 추적 권장.
- **P2-2**: `_nl_shutdown_flag.set()` 호출 측 미통합 — `AgentRunner.shutdown` 와 묶는 후속 PR 필요.

## 변경 사항

### P2-2 본체 — NL shutdown wire (옵션 b 채택)

`ai/dev_relay/main.py` 에 통합 헬퍼 추가:

```python
def shutdown_dev_relay(runner, *, timeout, logger=None):
    _nl_shutdown_flag.set()
    if logger is not None:
        logger.info("NL 분기 shutdown flag set — 신규 진입 거절 시작.")
    runner.shutdown(wait=True, timeout=timeout)
```

`run()` 의 `finally` 절에서 기존 `runner.shutdown(...)` 직접 호출을 본 헬퍼로 단일화. 외부 시그니처 (`AgentRunner.shutdown`) 는 그대로 유지 — 회귀 0.

**옵션 비교**:
- (a) `AgentRunner.shutdown` 내부에서 `_nl_shutdown_flag.set()` — 모듈 전역 의존 도입, 책임 분리 위반 → 거절
- (b) 통합 헬퍼 `shutdown_dev_relay` (채택) — AgentRunner 책임 분리 유지 + NL flag set + 후속 정리를 같은 모듈에서 묶음
- (c) OS SIGTERM/SIGINT 핸들러에서 둘 다 호출 — lifecycle 분기점이 늘어남, 직접 호출 경로 미커버 → 거절

### P2-1 — 가드 위반 fallback 정책 명문화

`_emit_nl_busy_notice` 의 `if find_forbidden_keywords(safe):` 블록에 한 줄 코멘트 추가:

```python
# 정책: 가드 위반 시 사용자 무발사 (audit 만 기록) — 컴플라이언스 우선,
# 외부 노출 사고 차단이 사용자 안내 손실보다 우선한다 (PR #48 reviewer P2-1).
```

기존 docstring 의 "외부 노출 사고 절대 금지" 명시를 보강하는 위치만 짧게 표시.

### 테스트 (5건 추가)

`ai/tests/dev_relay/test_shutdown_dev_relay.py`:
- `test_sets_nl_shutdown_flag` — 헬퍼 호출 시 NL flag 가 set 된다.
- `test_delegates_to_runner_shutdown` — `AgentRunner.shutdown` 위임 검증 (closed 후 제출 RuntimeError).
- `test_idempotent_double_call` — 다중 호출 idempotent.
- `test_logger_optional` — logger=None 경로.
- `test_logger_info_message_emitted` — logger 제공 시 INFO 한 줄.

새 진입 거절 사용자 측 효과는 기존 AC-NLS-9 (a) 가 보장 (`test_handle_command_nl_serialize.py` 회귀 — 추가 안 함).

### SESSION_NOTES 동봉

`docs/SESSION_NOTES.md` 2026-05-13 entry append — PR #48 머지 완료 + 본 chore + follow-up 표 갱신.

## 변경 파일

- `ai/dev_relay/main.py` — `shutdown_dev_relay` 추가, `run()` finally 절 교체, `_emit_nl_busy_notice` 코멘트 보강
- `ai/tests/dev_relay/test_shutdown_dev_relay.py` — 신규 (테스트 5건)
- `docs/SESSION_NOTES.md` — 2026-05-13 entry append

3 files / +162 / -1

## 테스트 결과

- `pytest tests/dev_relay/ -x -q` — **494 passed** (회귀 0 fail)
- `pytest tests/dev_relay/test_shutdown_dev_relay.py -v` — **5/5 PASS**
- `pytest tests/dev_relay/test_compliance.py -v` — **52/52 PASS**

## 수용 기준 (chore — PRD 없음, reviewer P2 후속 메모 매핑)

- [x] P2-2: 데몬 shutdown 시 `_nl_shutdown_flag.set()` 호출 측이 wire 됨
- [x] `AgentRunner.shutdown` 외부 시그니처 불변
- [x] 직접 호출 경로도 커버 (OS 시그널 핸들러 의존 안 함)
- [x] 진행 중 1건 graceful 종료 (기존 try/finally 보장, 회귀 0)
- [x] 새 진입 거절 (기존 AC-NLS-9 (a) 보장)
- [x] P2-1: fallback 의도 한 줄 명문화
- [x] 테스트 회귀 0 fail
- [x] 컴플라이언스 0 hit (코드·테스트·코멘트·식별자)
- [x] 신규 의존성 0

## 다음 작업

- (없음 — 본 PR 머지 후 PR #48 reviewer P2-1·P2-2 종결)
- 별도 트랙은 SESSION_NOTES 2026-05-13 entry follow-up 표 참조 (A-3/A-4/A-5/B-1/B-2/C-1/C-2/C-3)