### PR TITLE
chore(dev-relay): audit record 에 user_id_masked 누락 fix

### DIFF
--- a/ai/dev_relay/main.py
+++ b/ai/dev_relay/main.py
@@ -295,6 +295,7 @@ def _handle_command(
                 "ts": _now_kst(),
                 "kind": "destructive_blocked",
                 "user": masked,
+                "user_id_masked": masked,
             }
         )
         safe_say(say, TEMPLATE_DESTRUCTIVE_BLOCKED, logger, context="destructive")
@@ -360,6 +361,7 @@ def _handle_command(
             "ts": _now_kst(),
             "kind": "command_received",
             "user": masked,
+            "user_id_masked": masked,
             "cmd": parsed.normalized,
             "key": idempotency_key,
             "job_id": job.id,
@@ -558,6 +560,7 @@ def _handle_natural_language(
                         "thread_ts": thread_ts,
                         "session_id": session.session_id,
                         "model": session.model_used,
+                        "user_id_masked": masked,
                     }
                 )
             else:
@@ -574,6 +577,7 @@ def _handle_natural_language(
                             "thread_ts": thread_ts,
                             "session_id": session.session_id,
                             "turn": session.turn_count,
+                            "user_id_masked": masked,
                         }
                     )
 
@@ -722,6 +726,7 @@ def build_app(
                 "ts": _now_kst(),
                 "kind": "button_action",
                 "user": mask_user_id(user_id),
+                "user_id_masked": mask_user_id(user_id),
                 "action": "cancel_merge",
             }
         )
@@ -742,6 +747,7 @@ def build_app(
                 "ts": _now_kst(),
                 "kind": "button_action",
                 "user": mask_user_id(user_id),
+                "user_id_masked": mask_user_id(user_id),
                 "action": "approve_merge",
             }
         )
@@ -796,6 +802,7 @@ def build_app(
                     "job_id": payload.job_id,
                     "pr": payload.pr_number,
                     "classification": FailureClassification.UNKNOWN_ERROR.value,
+                    "user_id_masked": mask_user_id(user_id),
                 }
             )
             safe_say(
@@ -812,6 +819,7 @@ def build_app(
                 "kind": "merge_started",
                 "job_id": approval.job_id,
                 "pr": approval.pr_number,
+                "user_id_masked": mask_user_id(user_id),
             }
         )
         try:
@@ -826,6 +834,7 @@ def build_app(
                     "job_id": approval.job_id,
                     "pr": approval.pr_number,
                     "classification": classification.value,
+                    "user_id_masked": mask_user_id(user_id),
                 }
             )
             safe_say(
@@ -845,6 +854,7 @@ def build_app(
                     "pr": approval.pr_number,
                     "sha": outcome.sha or "",
                     "strategy": MERGE_STRATEGY,
+                    "user_id_masked": mask_user_id(user_id),
                 }
             )
             safe_say(
@@ -868,6 +878,7 @@ def build_app(
                     "job_id": approval.job_id,
                     "pr": approval.pr_number,
                     "classification": classification.value,
+                    "user_id_masked": mask_user_id(user_id),
                 }
             )
             safe_say(
@@ -892,6 +903,7 @@ def build_app(
                 "ts": _now_kst(),
                 "kind": "button_action",
                 "user": mask_user_id(user_id),
+                "user_id_masked": mask_user_id(user_id),
                 "action": "merge_review",
             }
         )
@@ -943,6 +955,7 @@ def build_app(
                     "kind": "reviewer_detail_lookup_failed",
                     "job_id": payload.job_id,
                     "pr": payload.pr_number,
+                    "user_id_masked": mask_user_id(user_id),
                 }
             )
             safe_say(
@@ -1109,6 +1122,7 @@ def _build_review_job_handler(
                 "kind": "reviewer_started",
                 "job_id": job.id,
                 "pr": pr_number,
+                "user_id_masked": mask_user_id(job.user_id),
             }
         )
 
@@ -1121,6 +1135,7 @@ def _build_review_job_handler(
                     "job_id": job.id,
                     "pr": pr_number,
                     "classification": classification.value,
+                    "user_id_masked": mask_user_id(job.user_id),
                 }
             )
             _post_to_thread(
@@ -1145,6 +1160,7 @@ def _build_review_job_handler(
                     "job_id": job.id,
                     "pr": pr_number,
                     "classification": classification.value,
+                    "user_id_masked": mask_user_id(job.user_id),
                 }
             )
             _post_to_thread(
@@ -1165,6 +1181,7 @@ def _build_review_job_handler(
                     "job_id": job.id,
                     "pr": pr_number,
                     "classification": classification.value,
+                    "user_id_masked": mask_user_id(job.user_id),
                 }
             )
             _post_to_thread(
@@ -1185,6 +1202,7 @@ def _build_review_job_handler(
                     "job_id": job.id,
                     "pr": pr_number,
                     "classification": classification.value,
+                    "user_id_masked": mask_user_id(job.user_id),
                 }
             )
             _post_to_thread(
@@ -1207,6 +1225,7 @@ def _build_review_job_handler(
                 "pr": pr_number,
                 "duration_s": duration_s,
                 "finding_count": len(findings),
+                "user_id_masked": mask_user_id(job.user_id),
             }
         )
 

--- a/ai/tests/dev_relay/test_audit_user_id_masked.py
+++ b/ai/tests/dev_relay/test_audit_user_id_masked.py
@@ -1,0 +1,319 @@
+"""audit.jsonl 의 `user_id_masked` 필드 누락 회귀 방어 단위 테스트.
+
+PR #25 reviewer Concern 후속 (SESSION_NOTES.md follow-up P2 4 세션 이월) — 사용자별
+audit 추적이 끊기지 않도록 `_append_audit` 호출 25곳 중 사용자 컨텍스트가 있는
+모든 kind 에 `user_id_masked` 필드가 포함됨을 보장한다.
+
+검증 대상 kind (`ai/dev_relay/main.py` 직접 emit):
+- destructive_blocked
+- command_received
+- session_started / session_resumed
+- button_action (cancel_merge / approve_merge / merge_review)
+- merge_started / merge_done / merge_failed
+- reviewer_started / reviewer_done / reviewer_failed
+- reviewer_detail_lookup_failed
+
+(`nl_busy_rejected` 는 이미 `test_handle_command_nl_serialize.py` 가 검증.)
+
+정책: 기존 `"user"` 키는 back-compat 으로 유지하고 `"user_id_masked"` 키를 추가.
+시스템 audit (사용자 컨텍스트 없음) 은 `user_id_masked` 필드 자체 생략 — Option A.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ai.dev_relay import main as main_mod
+from ai.dev_relay.agent_sessions import AgentSessionStore
+from ai.dev_relay.main import _RateLimiter, _handle_command, _handle_natural_language
+from ai.dev_relay.nl_agent import HaikuResponse, SonnetResponse
+from ai.dev_relay.nl_classifier import ClassificationResult, IntentLabel
+from ai.dev_relay.queue import JobQueue
+
+
+# ---------------------------------------------------------------------------
+# 픽스처
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def queue_(tmp_path: Path) -> JobQueue:
+    return JobQueue(db_path=tmp_path / "queue.db")
+
+
+@pytest.fixture
+def sessions(tmp_path: Path) -> AgentSessionStore:
+    return AgentSessionStore(db_path=tmp_path / "queue.db")
+
+
+@pytest.fixture
+def logger():
+    import logging
+
+    return logging.getLogger("test_audit_user_id_masked")
+
+
+@pytest.fixture
+def fake_say():
+    sent: list[Any] = []
+
+    def _say(payload=None, *, blocks=None, text=None, **kwargs):
+        if blocks is not None or text is not None:
+            sent.append({"text": text, "blocks": blocks, **kwargs})
+        else:
+            sent.append(payload)
+
+    _say.sent = sent  # type: ignore[attr-defined]
+    return _say
+
+
+@pytest.fixture
+def audit_path(tmp_path: Path, monkeypatch) -> Path:
+    path = tmp_path / "audit.jsonl"
+    monkeypatch.setattr(main_mod, "_audit_log_path", lambda: path)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _reset_nl_state():
+    """NL 락·shutdown flag 를 테스트 전후 깨끗하게 한다."""
+    try:
+        main_mod._nl_turn_lock.release()
+    except RuntimeError:
+        pass
+    main_mod._nl_shutdown_flag.clear()
+    yield
+    try:
+        main_mod._nl_turn_lock.release()
+    except RuntimeError:
+        pass
+    main_mod._nl_shutdown_flag.clear()
+
+
+def _read(audit_path: Path) -> list[dict]:
+    if not audit_path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in audit_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _by_kind(records: list[dict], kind: str) -> list[dict]:
+    return [r for r in records if r.get("kind") == kind]
+
+
+# ---------------------------------------------------------------------------
+# dispatcher 경유 — destructive_blocked / command_received
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherAuditUserIdMasked:
+    def test_destructive_blocked_has_user_id_masked(
+        self, queue_, sessions, fake_say, logger, audit_path
+    ):
+        _handle_command(
+            text="git reset --hard HEAD~5",
+            user_id="U0AE7A54NHL",
+            event={"client_msg_id": "key-d", "ts": "1.1", "channel": "D1"},
+            say=fake_say,
+            logger=logger,
+            queue=queue_,
+            rate_limiter=_RateLimiter(),
+        )
+        recs = _by_kind(_read(audit_path), "destructive_blocked")
+        assert len(recs) == 1
+        assert recs[0]["user_id_masked"]
+        assert recs[0]["user_id_masked"] != "U0AE7A54NHL"
+
+    def test_command_received_has_user_id_masked(
+        self, queue_, sessions, fake_say, logger, audit_path
+    ):
+        _handle_command(
+            text="review pr 22",
+            user_id="U0AE7A54NHL",
+            event={"client_msg_id": "key-r", "ts": "1.1", "channel": "D1"},
+            say=fake_say,
+            logger=logger,
+            queue=queue_,
+            rate_limiter=_RateLimiter(),
+        )
+        recs = _by_kind(_read(audit_path), "command_received")
+        assert len(recs) == 1
+        assert recs[0]["user_id_masked"]
+        assert recs[0]["user_id_masked"] != "U0AE7A54NHL"
+
+
+# ---------------------------------------------------------------------------
+# 자연어 분기 — session_started / session_resumed
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_runtime(label: IntentLabel = IntentLabel.SUMMARY_REQUEST):
+    state: dict[str, Any] = {"sonnet_calls": 0}
+
+    def classifier(_sys, _user):
+        return ClassificationResult(label=label, prompt_tokens=10, response_tokens=1)
+
+    def haiku(_text):
+        return HaikuResponse(text="고맙습니다.")
+
+    def sonnet(_text, sid):
+        state["sonnet_calls"] += 1
+        state["last_resume_session_id"] = sid
+        return SonnetResponse(
+            text="*요약*\n- ok",
+            tool_calls=[],
+            session_id="sess_new",
+        )
+
+    return {
+        "classifier": classifier,
+        "haiku_responder": haiku,
+        "sonnet_responder": sonnet,
+        "state": state,
+    }
+
+
+class TestNLSessionAuditUserIdMasked:
+    def test_session_started_has_user_id_masked(
+        self, sessions, fake_say, logger, audit_path
+    ):
+        _handle_natural_language(
+            text="요약해줘",
+            user_id="U0AE7A54NHL",
+            event={"client_msg_id": "k1", "ts": "1.1", "channel": "D1"},
+            say=fake_say,
+            logger=logger,
+            sessions=sessions,
+            nl_runtime=_make_fake_runtime(),
+        )
+        recs = _by_kind(_read(audit_path), "session_started")
+        assert len(recs) == 1
+        assert recs[0]["user_id_masked"]
+        assert recs[0]["user_id_masked"] != "U0AE7A54NHL"
+
+    def test_session_resumed_has_user_id_masked(
+        self, sessions, fake_say, logger, audit_path
+    ):
+        from ai.dev_relay.agent_sessions import MODEL_SONNET
+
+        # 직전 turn 의 세션 row 를 사전 적재.
+        sessions.start(
+            thread_ts="1.1",
+            channel_id="D1",
+            session_id="sess_existing",
+            model_used=MODEL_SONNET,
+        )
+        _handle_natural_language(
+            text="PR #25 자세히",
+            user_id="U0AE7A54NHL",
+            event={
+                "client_msg_id": "k2",
+                "ts": "1.2",
+                "thread_ts": "1.1",
+                "channel": "D1",
+            },
+            say=fake_say,
+            logger=logger,
+            sessions=sessions,
+            nl_runtime=_make_fake_runtime(IntentLabel.REPORT_REQUEST),
+        )
+        recs = _by_kind(_read(audit_path), "session_resumed")
+        assert len(recs) == 1
+        assert recs[0]["user_id_masked"]
+        assert recs[0]["user_id_masked"] != "U0AE7A54NHL"
+
+
+# ---------------------------------------------------------------------------
+# button_action / merge_* / reviewer_* — _append_audit 직접 검증
+#
+# 통합 시나리오 재현 비용이 크므로 _append_audit 직접 호출로 schema 회귀만 방어한다.
+# 실 흐름은 test_agent_integration.py / test_handle_command_nl.py 가 별도로 검증.
+# ---------------------------------------------------------------------------
+
+
+class TestAuditSchemaRegression:
+    """각 kind 가 `user_id_masked` 필드를 포함하는지 schema 회귀 방어."""
+
+    def test_all_target_kinds_carry_user_id_masked_when_emitted_from_main(
+        self, audit_path, monkeypatch
+    ):
+        """`ai/dev_relay/main.py` 내부에서 실제 emit 되는 모든 record 의 정적 스키마.
+
+        Source 를 직접 grep 해 `_append_audit({...})` 블록에 `user_id_masked` 키가
+        존재함을 확인한다. 호출 흐름 재현 없이도 schema 누락 회귀를 잡는다.
+        """
+        import re
+
+        src = Path(main_mod.__file__).read_text(encoding="utf-8")
+        # `_append_audit(` 로 시작해 다음 닫는 `)` 까지의 블록을 모두 추출.
+        # nested dict 1단계만 처리 (record 가 평면 dict 라는 코드 컨벤션 의존).
+        blocks: list[str] = []
+        idx = 0
+        while True:
+            start = src.find("_append_audit(", idx)
+            if start == -1:
+                break
+            depth = 0
+            i = start
+            while i < len(src):
+                ch = src[i]
+                if ch == "(":
+                    depth += 1
+                elif ch == ")":
+                    depth -= 1
+                    if depth == 0:
+                        blocks.append(src[start : i + 1])
+                        idx = i + 1
+                        break
+                i += 1
+            else:
+                break
+
+        # `record` 변수 경유 (line 531, 1046 의 pass-through) 는 본 검사에서 제외.
+        # 검증 대상은 inline dict literal 만.
+        inline_blocks = [b for b in blocks if "{" in b]
+
+        # 각 inline block 의 kind 라벨 추출.
+        kind_re = re.compile(r'"kind":\s*"([a-z_]+)"')
+        target_kinds = {
+            "destructive_blocked",
+            "command_received",
+            "session_started",
+            "session_resumed",
+            "button_action",
+            "merge_started",
+            "merge_done",
+            "merge_failed",
+            "reviewer_started",
+            "reviewer_done",
+            "reviewer_failed",
+            "reviewer_detail_lookup_failed",
+            "nl_busy_rejected",
+        }
+        seen: dict[str, int] = {}
+        missing: list[tuple[str, str]] = []
+        for block in inline_blocks:
+            match = kind_re.search(block)
+            if not match:
+                continue
+            kind = match.group(1)
+            seen[kind] = seen.get(kind, 0) + 1
+            if kind in target_kinds and "user_id_masked" not in block:
+                # 블록 첫 줄만 잘라서 식별용 단서로 노출.
+                first_line = block.splitlines()[0]
+                missing.append((kind, first_line))
+
+        assert not missing, (
+            "다음 audit emit 지점에 `user_id_masked` 누락:\n"
+            + "\n".join(f"  - {k}: {hint}" for k, hint in missing)
+        )
+        # 적어도 대상 kind 가 모두 emit 지점이 존재하는지.
+        for kind in target_kinds:
+            assert kind in seen, f"`{kind}` audit emit 지점이 main.py 에서 사라졌습니다."

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -577,3 +577,42 @@
 - **다음 작업 후보** (PR 본문 기반, 절대적 지시 아님):
   - (없음 — 본 PR 머지 후 PR #48 reviewer P2-1·P2-2 종결)
   - 별도 트랙은 SESSION_NOTES 2026-05-13 entry follow-up 표 참조 (A-3/A-4/A-5/B-1/B-2/C-1/C-2/C-3)
+
+### 2026-05-12 — chore(dev-relay): audit record 에 user_id_masked 누락 fix (#50)
+
+- **slug**: `dev-relay-audit-user-id` · **author**: @HY0118
+- **PR**: https://github.com/deeptrading-lab/trading-signal-engine/pull/50
+- **요약**: chore(dev-relay): audit record 에 user_id_masked 누락 fix
+- **현재 상태**: QA 통과 · 리뷰·머지 대기 (이 항목은 QA 통과 시점에 자동 기록됨)
+- **PR 본문 발췌**:
+  > ## 배경
+  > 
+  > `ai/dev_relay/main.py` 의 `_append_audit` 호출 22 inline 블록 중 일부 audit kind 에 `user_id_masked` 필드가 누락되어 있어 audit 로그에서 사용자별 추적이 끊김. PR #25 reviewer Concern 후속으로 SESSION_NOTES.md follow-up 표 P2 항목에 4 세션 이월된 상태였음.
+  > 
+  > ## 식별 결과 (`_append_audit` inline 호출 분포)
+  > 
+  > | # | 위치 | kind | 사전 상태 |
+  > |---|------|------|-----------|
+  > | 1 | L293 | `destructive_blocked` | `"user"` 만 존재 → **fix** |
+  > | 2 | L359 | `command_received` | `"user"` 만 존재 → **fix** |
+  > | 3 | L460 | `nl_busy_rejected` | `user_id_masked` 이미 존재 (테스트 보장) |
+  > | 4 | L555 | `session_started` | 누락 → **fix** |
+  > | 5 | L571 | `session_resumed` | 누락 → **fix** |
+  > | 6 | L721 | `button_action`/cancel_merge | `"user"` 만 존재 → **fix** |
+  > | 7 | L741 | `button_action`/approve_merge | `"user"` 만 존재 → **fix** |
+  > | 8 | L793 | `merge_failed` (validate) | 누락 → **fix** |
+  > | 9 | L810 | `merge_started` | 누락 → **fix** |
+  > | 10 | L823 | `merge_failed` (exception) | 누락 → **fix** |
+  > | 11 | L841 | `merge_done` | 누락 → **fix** |
+  > | 12 | L865 | `merge_failed` (outcome) | 누락 → **fix** |
+  > | 13 | L891 | `button_action`/merge_review | `"user"` 만 존재 → **fix** |
+  > | 14 | L941 | `reviewer_detail_lookup_failed` | 누락 → **fix** |
+  > | 15 | L1107 | `reviewer_started` | 누락 → **fix** (picker 컨텍스트에 `job.user_id` 사용) |
+  > | 16 | L1118 | `reviewer_failed` (no runtime) | 누락 → **fix** |
+  > | 17 | L1142 | `reviewer_failed` (destructive) | 누락 → **fix** |
+  > | 18 | L1162 | `reviewer_failed` (timeout) | 누락 → **fix** |
+  > | 19 | L1182 | `reviewer_failed` (exception) | 누락 → **fix** |
+  > | 20 | L1203 | `reviewer_done` | 누락 → **fix** |
+  > | pass-through | L531, L1046 | NL agent / SDK hook callback | record 변수 경유 — `nl_agent.py` / `nl_sdk_runtime.py` 소관, 본 PR 범위 외 |
+  > 
+- **다음 작업 후보**: _PR 본문에 별도 섹션 없음. 본문 참고하여 판단._

--- a/docs/qa/dev-relay-audit-user-id.md
+++ b/docs/qa/dev-relay-audit-user-id.md
@@ -1,0 +1,146 @@
+# QA: dev-relay-audit-user-id (chore)
+
+> 작성자: QA (자동 검증)
+> 작성일: 2026-05-13
+> 입력: chore — PRD 없음. PR #25 reviewer Concern C-2 후속 (SESSION_NOTES 2026-05-13 follow-up A-3 그룹).
+> 검증 대상 PR: [#50](https://github.com/deeptrading-lab/trading-signal-engine/pull/50) (`feature/dev-relay-audit-user-id`)
+> 변경 규모: +338 / -0, 2 files, 1 commit (`804f038`)
+> 회귀 (dev_relay 전체): `cd ai && pytest tests/dev_relay/ -q` → **499 passed (2.46s, 0 failed)**
+> 회귀 (ai 전체): `cd ai && pytest tests/ -q` → **677 passed (2.75s, 0 failed)**
+> 회귀 (컴플라이언스): `cd ai && pytest tests/dev_relay/test_compliance.py -v` → **52 passed (0.03s, 0 hit)**
+> 회귀 (PR #48 NL serialize + PR #49 shutdown): **14 passed (1.33s, 0 failed)**
+
+---
+
+## 0. 요약
+
+- chore PR 이라 PRD AC 매핑 대신 reviewer Concern (C-2) 후속 누락 17곳 매핑표를 검증 항목으로 변환.
+- 신규 테스트 **5/5 PASS** (`test_audit_user_id_masked.py`) — 단위 (dispatcher 2건) + 통합 (NL session 2건) + 정적 스캐너 (1건).
+- 정책: **기존 `"user"` 키 back-compat 유지 + `"user_id_masked"` canonical 신규** (다운스트림 0 회귀). 시스템 audit (사용자 컨텍스트 없음) Option A — 본 PR 범위에서 해당 0건.
+- `_append_audit` 정의 1 + inline 호출 **22건** 중, 사용자 컨텍스트 있는 **20곳** 의 record 전부 `user_id_masked` 포함. 변수 경유 2건 (closure pass-through, SDK hook) 은 호출 측에서 record 를 만들고 `user_id_masked` 인자를 전달 — 검증 범위는 main.py 직접 emit 으로 한정.
+- 신규 audit kind 추가 0, 외부 시그니처 변경 0, 신규 의존성 0.
+- **컴플라이언스 0 hit** — `main.py` / 신규 테스트 / 본 QA 리포트 모두 정적 스캐너 통과.
+- **최종 판정**: `qa-passed`.
+
+---
+
+## 1. 검증 항목 매핑 (reviewer Concern C-2 → 테스트)
+
+### 핵심 — `_append_audit` 호출 22 inline 중 사용자 컨텍스트 있는 20곳 (17 fix + 3 기존 OK) 매핑
+
+정적 스캔 (`grep -n "_append_audit" ai/dev_relay/main.py` + 블록 추출) 결과:
+
+| # | 라인 | kind | 기존 `user` 키 | 신규 `user_id_masked` | 결과 |
+|---|---|---|---|---|---|
+| 1 | 293 | `destructive_blocked` | True (기존) | True | OK |
+| 2 | 359 | `command_received` | True (기존) | True | OK |
+| 3 | 462 | `nl_busy_rejected` | False | True (PR #48 기존) | OK |
+| 4 | 556 | `session_started` | False | True (신규 fix) | OK |
+| 5 | 573 | `session_resumed` | False | True (신규 fix) | OK |
+| 6 | 724 | `button_action` (`cancel_merge`) | True (기존) | True (신규 fix) | OK |
+| 7 | 745 | `button_action` (`approve_merge`) | True (기존) | True (신규 fix) | OK |
+| 8 | 798 | `merge_failed` | False | True (신규 fix) | OK |
+| 9 | 816 | `merge_started` | False | True (신규 fix) | OK |
+| 10 | 830 | `merge_failed` | False | True (신규 fix) | OK |
+| 11 | 849 | `merge_done` | False | True (신규 fix) | OK |
+| 12 | 874 | `merge_failed` | False | True (신규 fix) | OK |
+| 13 | 901 | `button_action` (`merge_review`) | True (기존) | True (신규 fix) | OK |
+| 14 | 952 | `reviewer_detail_lookup_failed` | False | True (신규 fix) | OK |
+| 15 | 1119 | `reviewer_started` | False | True (신규 fix) | OK |
+| 16 | 1131 | `reviewer_failed` | False | True (신규 fix) | OK |
+| 17 | 1156 | `reviewer_failed` | False | True (신규 fix) | OK |
+| 18 | 1177 | `reviewer_failed` | False | True (신규 fix) | OK |
+| 19 | 1198 | `reviewer_failed` | False | True (신규 fix) | OK |
+| 20 | 1220 | `reviewer_done` | False | True (신규 fix) | OK |
+| 변수 경유 | 533 | (closure pass-through) | n/a | 호출 측 record 에서 키 보장 | 범위 외 |
+| 변수 경유 | 1059 | (`make_sonnet_responder` audit hook) | n/a | hook 시그니처 `user_id_masked` 인자 | 범위 외 |
+
+**합계 (inline 22)** — 사용자 컨텍스트 있는 record 20곳 모두 `user_id_masked` 키 보유. 변수 경유 2건은 hook factory 측에서 record 가 구성되므로 본 PR 범위 (main.py 직접 emit) 밖.
+
+> 참고: session_* / merge_* / reviewer_* 계열은 **기존 `"user"` 키 자체가 없었던** record. C-2 의 의도가 "기존 record 에 `user` 키만 있고 canonical key 가 없음" 보다 "사용자 컨텍스트 있는 record 에 마스킹된 식별자 자체가 누락" 이었으므로, 이 그룹은 `"user_id_masked"` 만 추가하면 충분 (back-compat 영향 0). 본 PR 정책 부합.
+
+### 핵심 — 자동화 테스트 (신규 5건)
+
+| # | 검증 항목 | 재현 절차 | 기대 | 실제 | 결과 |
+|---|---|---|---|---|---|
+| T1 | `destructive_blocked` audit 에 `user_id_masked` 필드 존재 + 원본 user_id 노출 0 | `_handle_command(text="git reset --hard HEAD~5", user_id="U0AE7A54NHL", ...)` → audit.jsonl read | record `kind="destructive_blocked"`, `user_id_masked` truthy, `!= "U0AE7A54NHL"` | record 1건 발견, 마스킹값 != raw | PASS |
+| T2 | `command_received` audit 에 `user_id_masked` 필드 존재 + 원본 노출 0 | `_handle_command(text="review pr 22", user_id="U0AE7A54NHL", ...)` → audit.jsonl read | 동일 | PASS | PASS |
+| T3 | `session_started` audit 에 `user_id_masked` 필드 존재 (신규 fix) | `_handle_natural_language(text="요약해줘", user_id="U0AE7A54NHL", ...)` + fake_runtime | record `kind="session_started"`, `user_id_masked` truthy, `!= raw` | PASS | PASS |
+| T4 | `session_resumed` audit 에 `user_id_masked` 필드 존재 (신규 fix) | sessions.start() 사전 적재 후 `_handle_natural_language(... thread_ts="1.1" ...)` | record `kind="session_resumed"`, `user_id_masked` truthy, `!= raw` | PASS | PASS |
+| T5 | **정적 스키마 회귀 방어** — `main.py` 의 모든 inline `_append_audit({...})` 블록에서 13개 대상 kind 가 모두 `user_id_masked` 키 포함 | `Path(main_mod.__file__).read_text()` 후 `_append_audit(` 블록 추출 → kind 라벨 grep → 누락 검출 | 13개 target_kinds (`destructive_blocked`, `command_received`, `session_started`, `session_resumed`, `button_action`, `merge_started`, `merge_done`, `merge_failed`, `reviewer_started`, `reviewer_done`, `reviewer_failed`, `reviewer_detail_lookup_failed`, `nl_busy_rejected`) 누락 0 | 누락 0건 | PASS |
+
+### 부수 — 정책 부합
+
+| # | 검증 항목 | 재현 | 기대 | 실제 | 결과 |
+|---|---|---|---|---|---|
+| 6 | 신규 audit kind 추가 0건 | commit diff 정독 + `grep -n '"kind"' ai/dev_relay/main.py` | kind 값 변경 0 | 변경 0건 (record 보강만) | PASS |
+| 7 | 외부 시그니처 변경 0건 (헬퍼 함수 호출 측 회귀 0) | `git show 804f038 -- ai/dev_relay/main.py` | `def _append_audit` / `def _handle_command` / `def _handle_natural_language` / `def shutdown_dev_relay` / `_build_nl_runtime` 등 시그니처 동일 | 시그니처 diff 0 | PASS |
+| 8 | 신규 의존성 0건 | commit diff 의 import 추가 | `ai/dev_relay/main.py` 추가 import 0 | 0 | PASS |
+| 9 | `user_id_masked` 값이 `mask_user_id(user_id)` 결과와 일치 (6자 prefix 마스킹 정책) | `python -c "from ai.dev_relay.main import mask_user_id; print(mask_user_id('U0AE7A54NHL'))"` 및 신규 테스트 assertion (`!= "U0AE7A54NHL"`) | 마스킹된 prefix 형태 (`U0AE7A***`), raw 일치 0 | `U0AE7A***` (6자 prefix + `***`) | PASS |
+| 10 | back-compat — `button_action` / `destructive_blocked` / `command_received` 등 기존 `"user"` 키 보유 record 가 신규 fix 후에도 `"user"` 키 유지 | 정적 스캔 매핑표 (#1, #2, #6, #7, #13) | 양 키 공존 | 공존 확인 (예: L298 `"user": masked` + L299 `"user_id_masked": masked`) | PASS |
+
+### 회귀
+
+| # | 검증 항목 | 명령 | 결과 | 판정 |
+|---|---|---|---|---|
+| 11 | `ai/tests/dev_relay/` 전체 0 fail | `cd ai && pytest tests/dev_relay/ -q` | **499 passed in 2.46s** | PASS |
+| 12 | `ai/tests/` 전체 0 fail | `cd ai && pytest tests/ -q` | **677 passed in 2.75s** | PASS |
+| 13 | `test_compliance.py` 0 hit (main.py / 신규 테스트 컴플라이언스) | `cd ai && pytest tests/dev_relay/test_compliance.py -v` | **52 passed in 0.03s** | PASS |
+| 14 | PR #48 NL serialize 9건 + PR #49 shutdown 5건 회귀 보존 | `cd ai && pytest tests/dev_relay/test_handle_command_nl_serialize.py tests/dev_relay/test_shutdown_dev_relay.py -v` | **14 passed in 1.33s** | PASS |
+| 15 | 신규 `test_audit_user_id_masked.py` 5건 모두 PASS | `cd ai && pytest tests/dev_relay/test_audit_user_id_masked.py -v` | **5 passed in 0.03s** | PASS |
+
+---
+
+## 2. 에지 케이스
+
+본 PR 은 audit record schema 보강이라 외부 I/O (Slack/거래소/네트워크/API rate limit) 영향 0. 다만 audit.jsonl 자체 흐름과 다운스트림 분석기 관점의 에지를 별도 검토:
+
+| # | 에지 케이스 | 재현 | 기대 | 실제 | 결과 |
+|---|---|---|---|---|---|
+| E1 | audit.jsonl 신규 파일 권한 0600 (`_append_audit` 의 PRD §3.8) — 본 PR 이 record schema 만 바꿔도 권한 회귀 0 | `cd ai && pytest tests/dev_relay/test_audit_perm.py -v` | `os.stat(path).st_mode & 0o777 == 0o600` | (`test_audit_perm` 가 dev_relay/ 회귀 499 PASS 안에 포함) | PASS |
+| E2 | 기존 다운스트림 분석기 (PR #25 의 audit_recovery) 가 `"user"` 키만 읽어도 회귀 0 | `cd ai && pytest tests/dev_relay/ -q` 안 audit_recovery 관련 케이스 | back-compat — `"user"` 키 보존된 record (`destructive_blocked` / `command_received` / `button_action`) 정상 파싱 | PASS (499 회귀 중 포함) | PASS |
+| E3 | 변수 경유 audit (closure pass-through L533 / SDK hook L1059) 의 record schema | nl_agent.py / nl_sdk_runtime.py 정적 검토 | nl_agent.py 의 record 는 `"user"` 키 사용 (이미 마스킹된 `user_id_masked` 인자 → record["user"]). 본 PR 범위 밖이므로 canonical key 미적용은 follow-up 으로 분리 | nl_agent.py 의 `"user"` 6곳 모두 `user_id_masked` 인자값 — 마스킹 정책 일관 | OUT-OF-SCOPE (정책 부합) |
+| E4 | mask_user_id 가 짧은 user_id 처리 시 빈 record 방어 | `python -c "from ai.dev_relay.main import mask_user_id; print(repr(mask_user_id('U0')))"` | `'***'` (raw 노출 0) | `'***'` | PASS |
+| E5 | concurrent multi-thread audit append 시 race — record schema 변경이 atomic write 회귀 유발 0 | `_append_audit` 의 `with path.open("a")` 는 OS file append 보장 — schema 변경은 줄 단위 JSON 1건이라 영향 0 | record 1줄 = 1 JSON, 누락·중복 0 | 정적 검토만 (별도 stress test 없음) | OK (검토만) |
+
+---
+
+## 3. 실행 로그 (요약)
+
+```text
+$ git show --stat 804f038 | head -6
+commit 804f038ef17181317d5231d21ee549f0a415cb04
+Date:   Wed May 13 00:34:00 2026 +0900
+    chore(dev-relay): audit record 에 user_id_masked 누락 fix
+ ai/dev_relay/main.py                            |  19 ++
+ ai/tests/dev_relay/test_audit_user_id_masked.py | 319 ++++++++++++++++++++++++
+
+$ cd ai && pytest tests/dev_relay/test_audit_user_id_masked.py -v
+... 5 passed in 0.03s
+
+$ cd ai && pytest tests/dev_relay/ -q
+... 499 passed in 2.46s
+
+$ cd ai && pytest tests/ -q
+... 677 passed in 2.75s
+
+$ cd ai && pytest tests/dev_relay/test_compliance.py -v
+... 52 passed in 0.03s
+
+$ cd ai && pytest tests/dev_relay/test_handle_command_nl_serialize.py \
+                tests/dev_relay/test_shutdown_dev_relay.py -v
+... 14 passed in 1.33s
+```
+
+---
+
+## 4. 판정
+
+- 모든 검증 항목 통과 (15/15) + 신규 테스트 5/5 PASS + 회귀 0건.
+- 정적 스키마 스캐너 (T5) 가 follow-up PR 에서도 누락 회귀를 잡도록 13개 target kind 를 박제 — schema 회귀 방어 자산 확보.
+- **PR 라벨**: `impl-ready` → `qa-passed`.
+
+### Follow-up (본 PR 범위 외, 다음 세션 이월)
+
+- `ai/dev_relay/nl_agent.py` / `nl_sdk_runtime.py` 의 SDK responder 측 audit record 는 `"user"` 키만 사용 (마스킹값 일관) — canonical `"user_id_masked"` 적용은 별도 PR. 본 PR 정책상 main.py 직접 emit 범위로 한정.
+- 신규 audit kind 추가 시 `test_audit_user_id_masked.py::TestAuditSchemaRegression::test_all_target_kinds_carry_user_id_masked_when_emitted_from_main` 의 `target_kinds` 셋도 함께 갱신해야 함 — 컨벤션으로 SESSION_NOTES 메모 권장.


### PR DESCRIPTION
## 배경

`ai/dev_relay/main.py` 의 `_append_audit` 호출 22 inline 블록 중 일부 audit kind 에 `user_id_masked` 필드가 누락되어 있어 audit 로그에서 사용자별 추적이 끊김. PR #25 reviewer Concern 후속으로 SESSION_NOTES.md follow-up 표 P2 항목에 4 세션 이월된 상태였음.

## 식별 결과 (`_append_audit` inline 호출 분포)

| # | 위치 | kind | 사전 상태 |
|---|------|------|-----------|
| 1 | L293 | `destructive_blocked` | `"user"` 만 존재 → **fix** |
| 2 | L359 | `command_received` | `"user"` 만 존재 → **fix** |
| 3 | L460 | `nl_busy_rejected` | `user_id_masked` 이미 존재 (테스트 보장) |
| 4 | L555 | `session_started` | 누락 → **fix** |
| 5 | L571 | `session_resumed` | 누락 → **fix** |
| 6 | L721 | `button_action`/cancel_merge | `"user"` 만 존재 → **fix** |
| 7 | L741 | `button_action`/approve_merge | `"user"` 만 존재 → **fix** |
| 8 | L793 | `merge_failed` (validate) | 누락 → **fix** |
| 9 | L810 | `merge_started` | 누락 → **fix** |
| 10 | L823 | `merge_failed` (exception) | 누락 → **fix** |
| 11 | L841 | `merge_done` | 누락 → **fix** |
| 12 | L865 | `merge_failed` (outcome) | 누락 → **fix** |
| 13 | L891 | `button_action`/merge_review | `"user"` 만 존재 → **fix** |
| 14 | L941 | `reviewer_detail_lookup_failed` | 누락 → **fix** |
| 15 | L1107 | `reviewer_started` | 누락 → **fix** (picker 컨텍스트에 `job.user_id` 사용) |
| 16 | L1118 | `reviewer_failed` (no runtime) | 누락 → **fix** |
| 17 | L1142 | `reviewer_failed` (destructive) | 누락 → **fix** |
| 18 | L1162 | `reviewer_failed` (timeout) | 누락 → **fix** |
| 19 | L1182 | `reviewer_failed` (exception) | 누락 → **fix** |
| 20 | L1203 | `reviewer_done` | 누락 → **fix** |
| pass-through | L531, L1046 | NL agent / SDK hook callback | record 변수 경유 — `nl_agent.py` / `nl_sdk_runtime.py` 소관, 본 PR 범위 외 |

**합계 fix: 17곳** (시스템 자체 audit 으로 분류되어 사용자 컨텍스트가 없는 case 0건 — `main.py` 내 모든 inline `_append_audit` 호출은 사용자 컨텍스트를 가진다.)

## 정책 채택 (시스템 audit Option)

- **Option A 채택** — `user_id_masked` 필드 자체 생략 (현행 일관성).
- 채택 근거: `main.py` 내부에서 직접 emit 되는 inline audit 중 사용자 컨텍스트가 없는 case 가 사실상 없어, 본 PR 의 정책 선택은 명목상의 의미만 가짐. 향후 신규 시스템 audit (예: shutdown / startup) 이 도입될 때 본 PR 의 패턴을 따라 `user_id_masked` 필드를 생략하면 됨.

## 필드 네이밍 정책

- 기존 `"user"` 키는 그대로 유지 (back-compat — 다운스트림 분석 스크립트 회귀 0).
- `"user_id_masked"` 키를 신규로 **추가**해 canonical 필드명으로 일원화. `nl_busy_rejected` 가 이미 사용하던 이름과 통일.
- `mask_user_id(...)` 결과를 두 키에 동일 값으로 채움 — 평문 user_id 노출 0.

## 변경

- `ai/dev_relay/main.py` — 17개 audit 호출에 `user_id_masked` 필드 추가 (+19 lines).
- `ai/tests/dev_relay/test_audit_user_id_masked.py` (신규) — 회귀 방어 테스트 5건:
  - dispatcher 경유 (`destructive_blocked` / `command_received`) 2건.
  - 자연어 분기 (`session_started` / `session_resumed`) 2건.
  - schema 정적 스캔 1건 — `main.py` source 를 직접 파싱해 13 target kind 의 inline `_append_audit` 블록에 `"user_id_masked"` 키가 존재함을 보장 (향후 누락 추가 차단).

audit kind 신규 추가 0건. 외부 시그니처 변경 0건. 신규 의존성 0건.

## 수용 기준 체크리스트

- [x] `_append_audit` 호출 25곳(=22 inline + 3 record 변수 경유) 식별·매핑 완료.
- [x] 사용자 컨텍스트 있는 inline 호출 17곳에 `user_id_masked` 추가.
- [x] 시스템 audit Option A 채택 (해당 case 0건이라 영향 없음).
- [x] 신규 audit kind 추가 0건.
- [x] pytest 전체 회귀 0 fail (677 passed).
- [x] 컴플라이언스 0 hit (`find_forbidden_keywords` 검증).
- [x] 외부 시그니처 변경 0 / import 깨짐 0.
- [x] `SESSION_NOTES.md` 변경 없음 (본 PR 범위 외).

## 테스트 결과

```
$ python -m pytest ai/ -q
677 passed in 2.67s

$ python -m pytest ai/tests/dev_relay/test_audit_user_id_masked.py -v
5 passed in 0.03s
```