### PR TITLE
chore(dev-relay): PR #50/#51 reviewer P2 후속 묶음 — audit canonical + classify + walker

### DIFF
--- a/ai/dev_relay/main.py
+++ b/ai/dev_relay/main.py
@@ -67,6 +67,7 @@ from ai.dev_relay.merger import (
     MergeOutcome,
     MergeRejection,
     MergeWorker,
+    classify_merge_rejection,
     classify_merge_stderr,
     extract_sha,
     perform_merge,
@@ -141,6 +142,13 @@ def _append_audit(record: dict[str, Any]) -> None:
     PRD §3.8 — 신규 파일 생성 시 0600 권한 적용. 이미 존재하는 파일은 사용자가
     명시적으로 권한을 풀어둔 경우를 존중해 그대로 둔다 (강제로 좁히지 않음).
     부모 디렉터리(0700) 는 `JobQueue::_ensure_dir_secure` 가 보장한다.
+
+    canonical 키 정책 (PR #50):
+    - 사용자 컨텍스트가 있는 record 는 `"user_id_masked"` canonical 키를 포함.
+    - 기존 `"user"` 키는 back-compat 으로 병기 (다운스트림 분석 도구 회귀 0).
+    - `"user"` 키 deprecation 시점: **2026-07-13 이후** (PR #50 머지 2026-05-13
+      기준 60일 window). 그 시점에 다운스트림 분석 도구의 `"user_id_masked"`
+      마이그레이션 확인 후 `"user"` 키 제거 PR 별도 진행.
     """
     path = _audit_log_path()
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -717,18 +725,19 @@ def build_app(
     def handle_cancel_merge(ack: Any, body: dict, say: Any) -> None:
         ack()
         user_id = extract_action_user_id(body) or ""
+        masked = mask_user_id(user_id)
         if not is_allowed_sender(user_id, config.allowed_user_ids):
             logger.info(
                 "허용되지 않은 버튼 클릭을 무시했습니다 (user=%s)",
-                mask_user_id(user_id),
+                masked,
             )
             return
         _append_audit(
             {
                 "ts": _now_kst(),
                 "kind": "button_action",
-                "user": mask_user_id(user_id),
-                "user_id_masked": mask_user_id(user_id),
+                "user": masked,
+                "user_id_masked": masked,
                 "action": "cancel_merge",
             }
         )
@@ -738,18 +747,19 @@ def build_app(
     def handle_approve_merge(ack: Any, body: dict, say: Any) -> None:
         ack()
         user_id = extract_action_user_id(body) or ""
+        masked = mask_user_id(user_id)
         if not is_allowed_sender(user_id, config.allowed_user_ids):
             logger.info(
                 "허용되지 않은 버튼 클릭을 무시했습니다 (user=%s)",
-                mask_user_id(user_id),
+                masked,
             )
             return
         _append_audit(
             {
                 "ts": _now_kst(),
                 "kind": "button_action",
-                "user": mask_user_id(user_id),
-                "user_id_masked": mask_user_id(user_id),
+                "user": masked,
+                "user_id_masked": masked,
                 "action": "approve_merge",
             }
         )
@@ -797,6 +807,9 @@ def build_app(
             )
         except MergeRejection as exc:
             logger.warning("approve_merge 검증 실패: %s", exc)
+            # PR #51 후속 F-2 #1: 재시작 거절 / idempotency 불일치 / destructive 거절 등
+            # `MergeRejection` 사유를 세분화해 audit 에 기록. raw stderr 분류와 충돌하지
+            # 않도록 `classification` 키는 그대로 두고 `rejection_reason` 보조 키 신설.
             _append_audit(
                 {
                     "ts": _now_kst(),
@@ -804,7 +817,8 @@ def build_app(
                     "job_id": payload.job_id,
                     "pr": payload.pr_number,
                     "classification": FailureClassification.UNKNOWN_ERROR.value,
-                    "user_id_masked": mask_user_id(user_id),
+                    "rejection_reason": classify_merge_rejection(exc),
+                    "user_id_masked": masked,
                 }
             )
             # PR #43 reviewer P2-1: 재시작 거절 케이스는 사용자 안내를 분기.
@@ -831,7 +845,7 @@ def build_app(
                 "kind": "merge_started",
                 "job_id": approval.job_id,
                 "pr": approval.pr_number,
-                "user_id_masked": mask_user_id(user_id),
+                "user_id_masked": masked,
             }
         )
         try:
@@ -846,7 +860,7 @@ def build_app(
                     "job_id": approval.job_id,
                     "pr": approval.pr_number,
                     "classification": classification.value,
-                    "user_id_masked": mask_user_id(user_id),
+                    "user_id_masked": masked,
                 }
             )
             safe_say(
@@ -866,7 +880,7 @@ def build_app(
                     "pr": approval.pr_number,
                     "sha": outcome.sha or "",
                     "strategy": MERGE_STRATEGY,
-                    "user_id_masked": mask_user_id(user_id),
+                    "user_id_masked": masked,
                 }
             )
             safe_say(
@@ -890,7 +904,7 @@ def build_app(
                     "job_id": approval.job_id,
                     "pr": approval.pr_number,
                     "classification": classification.value,
-                    "user_id_masked": mask_user_id(user_id),
+                    "user_id_masked": masked,
                 }
             )
             safe_say(
@@ -904,18 +918,19 @@ def build_app(
     def handle_merge_review(ack: Any, body: dict, say: Any) -> None:
         ack()
         user_id = extract_action_user_id(body) or ""
+        masked = mask_user_id(user_id)
         if not is_allowed_sender(user_id, config.allowed_user_ids):
             logger.info(
                 "허용되지 않은 버튼 클릭을 무시했습니다 (user=%s)",
-                mask_user_id(user_id),
+                masked,
             )
             return
         _append_audit(
             {
                 "ts": _now_kst(),
                 "kind": "button_action",
-                "user": mask_user_id(user_id),
-                "user_id_masked": mask_user_id(user_id),
+                "user": masked,
+                "user_id_masked": masked,
                 "action": "merge_review",
             }
         )
@@ -1301,23 +1316,66 @@ def _post_to_thread(
         logger.warning("chat_postMessage 실패 (%s)", type(exc).__name__)
 
 
+# Block Kit 에서 사용자 노출 가능한 비-text 키 (PR #51 reviewer P2 #3 후속).
+# `text`/`fields[].text`/`accessory.text.text` 외에 미래 블록 도입 시 누설 위험이
+# 있는 키들을 정적으로 나열. 현재 호출 경로 (`build_review_result_blocks`) 에서는
+# 발생하지 않으나 회귀 안전망으로 미리 보강한다.
+_BLOCK_USER_FACING_NON_TEXT_KEYS: frozenset[str] = frozenset(
+    {
+        "alt_text",      # image 블록 / image element
+        "placeholder",   # plain_text_input / select 의 안내 텍스트 (str 또는 obj)
+        "title",         # image 블록 캡션 (str 또는 plain_text obj)
+        "label",         # input 블록 라벨 (plain_text obj)
+        "hint",          # input 블록 보조 설명 (plain_text obj)
+    }
+)
+
+
 def _collect_block_user_facing_text(blocks: Any) -> list[str]:
     """Block Kit 트리에서 사용자 노출 가능한 텍스트 필드를 수집한다.
 
     PR #43 reviewer P2-3 후속의 가드 보조 헬퍼. `text.text`, plain text value
     등을 모은다. `action_id` / `block_id` / `value` 는 내부 식별자라 제외.
+
+    PR #51 reviewer P2 #2 후속: `key == "text"` 분기에서 inner 텍스트를 직접
+    수집한 뒤 같은 노드를 다시 재귀로 들어가지 않는다 (중복 수집 제거 — 동작
+    변경 0, 발사 차단 판정에 영향 없음).
+
+    PR #51 reviewer P2 #3 후속: `image.alt_text`, `input.placeholder.text`,
+    `actions.elements[].placeholder.text`, `title`, `label`, `hint` 등 비-text
+    키도 누설 위험이 있어 수집 대상에 포함. 현재 호출 경로에는 해당 블록이
+    없으므로 회귀 0, 미래 블록 도입 시 안전망 역할.
     """
     collected: list[str] = []
 
     def _visit(node: object) -> None:
         if isinstance(node, dict):
             for key, value in node.items():
-                if key == "text" and isinstance(value, str):
-                    collected.append(value)
-                elif key == "text" and isinstance(value, dict):
-                    inner = value.get("text")
-                    if isinstance(inner, str):
-                        collected.append(inner)
+                if key == "text":
+                    # plain string text — 직접 수집 + 더 들어가지 않음 (중복 방지).
+                    if isinstance(value, str):
+                        collected.append(value)
+                        continue
+                    # text 객체 ({type, text} 형태) — inner 만 수집 + 재귀 생략.
+                    if isinstance(value, dict):
+                        inner = value.get("text")
+                        if isinstance(inner, str):
+                            collected.append(inner)
+                        # text 객체 내부에는 추가 노출 가치 키가 없으므로 재귀 생략.
+                        continue
+                if key in _BLOCK_USER_FACING_NON_TEXT_KEYS:
+                    # str 직접: image.alt_text 등.
+                    if isinstance(value, str):
+                        collected.append(value)
+                        continue
+                    # plain_text obj ({type, text}): title / label / hint /
+                    # placeholder 가 obj 형태일 때.
+                    if isinstance(value, dict):
+                        inner = value.get("text")
+                        if isinstance(inner, str):
+                            collected.append(inner)
+                        # 일반 재귀로 떨어져 추가 키도 훑되, text 가 이미
+                        # 수집됐으니 아래 _visit 호출은 일관성 차원에서 유지.
                 _visit(value)
         elif isinstance(node, list):
             for item in node:

--- a/ai/dev_relay/merger.py
+++ b/ai/dev_relay/merger.py
@@ -59,6 +59,53 @@ class MergeRejection(RuntimeError):
 REJECTION_REASON_RESTART_NO_EXPECTED: str = "expected approval missing (restart)"
 
 
+# audit `rejection_reason` 카테고리 (PR #51 reviewer P2 #1 후속).
+# `MergeRejection` 메시지를 분류해 audit.jsonl 에 정규화된 카테고리로 기록한다.
+# `UNKNOWN_ERROR` 단일 분류로 묶이던 케이스를 세분화 → 재시작 거절·멱등성 불일치·
+# 화이트리스트 위반·페이로드 형식 위반 빈도를 분리 분석 가능.
+REJECTION_CATEGORY_RESTART_NO_EXPECTED: str = "restart_no_expected"
+REJECTION_CATEGORY_IDEMPOTENCY_MISMATCH: str = "idempotency_mismatch"
+REJECTION_CATEGORY_JOB_ID_MISMATCH: str = "job_id_mismatch"
+REJECTION_CATEGORY_USER_NOT_ALLOWED: str = "user_not_allowed"
+REJECTION_CATEGORY_INVALID_PAYLOAD: str = "invalid_payload"
+REJECTION_CATEGORY_UNEXPECTED_ACTION: str = "unexpected_action"
+REJECTION_CATEGORY_OTHER: str = "other"
+
+
+def classify_merge_rejection(exc: MergeRejection | BaseException) -> str:
+    """`MergeRejection` 사유 문자열을 카테고리 1개로 분류.
+
+    audit.jsonl `rejection_reason` 필드 값으로 사용. 카테고리는 정규화 상수 —
+    분석 도구 회귀를 최소화하려 일관 라벨만 노출한다. 매칭 우선순위:
+
+    1. `restart_no_expected` (`expected_*` None — 데몬 재시작 후 이전 페이로드)
+    2. `idempotency_mismatch` (멱등성 키 불일치)
+    3. `job_id_mismatch` (job_id 불일치)
+    4. `user_not_allowed` (화이트리스트 미통과)
+    5. `invalid_payload` (pr_number / idempotency_key / job_id 누락·형식 위반)
+    6. `unexpected_action` (action_id 불일치)
+    7. `other` (위 어디에도 매칭되지 않음 — 신규 reason 도입 시 fallback)
+    """
+    msg = str(exc)
+    if msg == REJECTION_REASON_RESTART_NO_EXPECTED:
+        return REJECTION_CATEGORY_RESTART_NO_EXPECTED
+    if "idempotency_key mismatch" in msg:
+        return REJECTION_CATEGORY_IDEMPOTENCY_MISMATCH
+    if "job_id mismatch" in msg:
+        return REJECTION_CATEGORY_JOB_ID_MISMATCH
+    if "user_id not in allowed list" in msg:
+        return REJECTION_CATEGORY_USER_NOT_ALLOWED
+    if (
+        "invalid pr_number" in msg
+        or "missing idempotency_key" in msg
+        or "invalid job_id" in msg
+    ):
+        return REJECTION_CATEGORY_INVALID_PAYLOAD
+    if msg.startswith("unexpected action_id"):
+        return REJECTION_CATEGORY_UNEXPECTED_ACTION
+    return REJECTION_CATEGORY_OTHER
+
+
 def validate_approval(
     *,
     pr_number_in_payload: int | None,
@@ -184,7 +231,15 @@ __all__ = [
     "MergeOutcome",
     "MergeRejection",
     "MergeWorker",
+    "REJECTION_CATEGORY_IDEMPOTENCY_MISMATCH",
+    "REJECTION_CATEGORY_INVALID_PAYLOAD",
+    "REJECTION_CATEGORY_JOB_ID_MISMATCH",
+    "REJECTION_CATEGORY_OTHER",
+    "REJECTION_CATEGORY_RESTART_NO_EXPECTED",
+    "REJECTION_CATEGORY_UNEXPECTED_ACTION",
+    "REJECTION_CATEGORY_USER_NOT_ALLOWED",
     "REJECTION_REASON_RESTART_NO_EXPECTED",
+    "classify_merge_rejection",
     "classify_merge_stderr",
     "extract_sha",
     "perform_merge",

--- a/ai/dev_relay/nl_agent.py
+++ b/ai/dev_relay/nl_agent.py
@@ -230,6 +230,7 @@ def run_turn(
             "ts": now_iso(),
             "kind": "llm_invoked",
             "user": user_id_masked,
+            "user_id_masked": user_id_masked,
             "stage": ResponseStage.CLASSIFY.value,
             "model": "haiku-4-5",
             "prompt_tokens": classification.prompt_tokens,
@@ -241,6 +242,7 @@ def run_turn(
             "ts": now_iso(),
             "kind": "llm_classified",
             "user": user_id_masked,
+            "user_id_masked": user_id_masked,
             "label": classification.label.value,
             "input_chars": len(user_text or ""),
         }
@@ -256,6 +258,7 @@ def run_turn(
                 "ts": now_iso(),
                 "kind": "llm_invoked",
                 "user": user_id_masked,
+                "user_id_masked": user_id_masked,
                 "stage": ResponseStage.RESPOND.value,
                 "model": "haiku-4-5",
                 "prompt_tokens": haiku.prompt_tokens,
@@ -269,6 +272,7 @@ def run_turn(
                     "ts": now_iso(),
                     "kind": "llm_response_blocked",
                     "user": user_id_masked,
+                    "user_id_masked": user_id_masked,
                     "reason": blocked,
                 }
             )
@@ -290,6 +294,7 @@ def run_turn(
             "ts": now_iso(),
             "kind": "llm_invoked",
             "user": user_id_masked,
+            "user_id_masked": user_id_masked,
             "stage": ResponseStage.RESPOND.value,
             "model": "sonnet-4-6",
             "prompt_tokens": sonnet.prompt_tokens,
@@ -316,6 +321,7 @@ def run_turn(
                 "ts": now_iso(),
                 "kind": "llm_response_blocked",
                 "user": user_id_masked,
+                "user_id_masked": user_id_masked,
                 "reason": blocked,
             }
         )

--- a/ai/dev_relay/nl_sdk_runtime.py
+++ b/ai/dev_relay/nl_sdk_runtime.py
@@ -88,6 +88,7 @@ def _build_pre_tool_use_hook(
                 {
                     "ts": now_iso(),
                     "kind": "tool_call",
+                    "user_id_masked": user_id_masked,
                     "stage": "respond",
                     "tool": tool_name,
                     "brief": decision.brief,
@@ -99,6 +100,7 @@ def _build_pre_tool_use_hook(
             {
                 "ts": now_iso(),
                 "kind": "tool_denied",
+                "user_id_masked": user_id_masked,
                 "stage": "respond",
                 "tool": tool_name,
                 "reason": decision.reason or "not_whitelisted",

--- a/ai/tests/dev_relay/test_audit_user_id_masked.py
+++ b/ai/tests/dev_relay/test_audit_user_id_masked.py
@@ -239,7 +239,14 @@ class TestNLSessionAuditUserIdMasked:
 
 
 class TestAuditSchemaRegression:
-    """각 kind 가 `user_id_masked` 필드를 포함하는지 schema 회귀 방어."""
+    """각 kind 가 `user_id_masked` 필드를 포함하는지 schema 회귀 방어.
+
+    **셋 갱신 의무 (PR #50 후속)**: `ai/dev_relay/main.py` 에 신규 audit kind 가
+    추가되고 그 record 가 사용자 컨텍스트를 포함하면, 본 클래스의 `target_kinds`
+    셋도 함께 업데이트해야 한다. 정적 스캔이 신규 kind 의 누락을 자동으로 잡으려면
+    셋이 source-of-truth 와 동기화돼 있어야 한다. 시스템 audit (사용자 무관) 은
+    셋에 포함시키지 않는다 (Option A — 필드 자체 생략).
+    """
 
     def test_all_target_kinds_carry_user_id_masked_when_emitted_from_main(
         self, audit_path, monkeypatch
@@ -248,6 +255,9 @@ class TestAuditSchemaRegression:
 
         Source 를 직접 grep 해 `_append_audit({...})` 블록에 `user_id_masked` 키가
         존재함을 확인한다. 호출 흐름 재현 없이도 schema 누락 회귀를 잡는다.
+
+        신규 audit kind 추가 시 본 메서드의 `target_kinds` 셋도 함께 업데이트하라
+        (위 클래스 docstring 의 셋 갱신 의무 참조).
         """
         import re
 

--- a/ai/tests/dev_relay/test_merge_rejection_classify.py
+++ b/ai/tests/dev_relay/test_merge_rejection_classify.py
@@ -1,0 +1,131 @@
+"""`classify_merge_rejection` 단위 테스트.
+
+PR #51 reviewer P2 #1 후속. `merge_failed` audit 가 단일 `UNKNOWN_ERROR`
+분류로 묶이던 케이스를 세분화 — `MergeRejection` 메시지 → 정규화 카테고리.
+
+본 테스트는 audit.jsonl 분석 도구가 분리 카운트할 수 있도록 카테고리 라벨이
+안정적임을 회귀로 묶는다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ai.dev_relay.merger import (
+    REJECTION_CATEGORY_IDEMPOTENCY_MISMATCH,
+    REJECTION_CATEGORY_INVALID_PAYLOAD,
+    REJECTION_CATEGORY_JOB_ID_MISMATCH,
+    REJECTION_CATEGORY_OTHER,
+    REJECTION_CATEGORY_RESTART_NO_EXPECTED,
+    REJECTION_CATEGORY_UNEXPECTED_ACTION,
+    REJECTION_CATEGORY_USER_NOT_ALLOWED,
+    REJECTION_REASON_RESTART_NO_EXPECTED,
+    MergeRejection,
+    classify_merge_rejection,
+    validate_approval,
+)
+
+
+class TestClassifyByMessage:
+    """문자열 직접 매칭 — 분류 로직 단독 회귀."""
+
+    def test_restart_no_expected(self):
+        exc = MergeRejection(REJECTION_REASON_RESTART_NO_EXPECTED)
+        assert classify_merge_rejection(exc) == REJECTION_CATEGORY_RESTART_NO_EXPECTED
+
+    def test_idempotency_mismatch(self):
+        exc = MergeRejection("idempotency_key mismatch")
+        assert classify_merge_rejection(exc) == REJECTION_CATEGORY_IDEMPOTENCY_MISMATCH
+
+    def test_job_id_mismatch(self):
+        exc = MergeRejection("job_id mismatch")
+        assert classify_merge_rejection(exc) == REJECTION_CATEGORY_JOB_ID_MISMATCH
+
+    def test_user_not_allowed(self):
+        exc = MergeRejection("user_id not in allowed list")
+        assert classify_merge_rejection(exc) == REJECTION_CATEGORY_USER_NOT_ALLOWED
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "invalid pr_number in payload",
+            "missing idempotency_key in payload",
+            "invalid job_id in payload",
+        ],
+    )
+    def test_invalid_payload(self, msg):
+        exc = MergeRejection(msg)
+        assert classify_merge_rejection(exc) == REJECTION_CATEGORY_INVALID_PAYLOAD
+
+    def test_unexpected_action(self):
+        exc = MergeRejection("unexpected action_id=foo")
+        assert classify_merge_rejection(exc) == REJECTION_CATEGORY_UNEXPECTED_ACTION
+
+    def test_other_fallback(self):
+        # 미래의 신규 reason 이 카테고리 추가 없이 도입돼도 `other` 로 떨어진다.
+        exc = MergeRejection("some new failure mode")
+        assert classify_merge_rejection(exc) == REJECTION_CATEGORY_OTHER
+
+
+class TestClassifyFromValidateApproval:
+    """`validate_approval` 이 실제로 raise 한 `MergeRejection` 도 동일 분류."""
+
+    def _base_kwargs(self) -> dict:
+        return {
+            "pr_number_in_payload": 22,
+            "idempotency_key_in_payload": "abcd",
+            "job_id_in_payload": 7,
+            "user_id": "U0AE7A54NHL",
+            "allowed_user_ids": frozenset({"U0AE7A54NHL"}),
+            "action_id": "approve_merge",
+        }
+
+    def test_restart(self):
+        kwargs = self._base_kwargs() | {
+            "expected_idempotency_key": None,
+            "expected_job_id": None,
+        }
+        with pytest.raises(MergeRejection) as info:
+            validate_approval(**kwargs)
+        assert (
+            classify_merge_rejection(info.value)
+            == REJECTION_CATEGORY_RESTART_NO_EXPECTED
+        )
+
+    def test_idempotency(self):
+        kwargs = self._base_kwargs() | {
+            "expected_idempotency_key": "different",
+            "expected_job_id": 7,
+        }
+        with pytest.raises(MergeRejection) as info:
+            validate_approval(**kwargs)
+        assert (
+            classify_merge_rejection(info.value)
+            == REJECTION_CATEGORY_IDEMPOTENCY_MISMATCH
+        )
+
+    def test_user_not_allowed(self):
+        kwargs = self._base_kwargs() | {
+            "expected_idempotency_key": "abcd",
+            "expected_job_id": 7,
+            "user_id": "UNOT_IN_LIST",
+        }
+        with pytest.raises(MergeRejection) as info:
+            validate_approval(**kwargs)
+        assert (
+            classify_merge_rejection(info.value)
+            == REJECTION_CATEGORY_USER_NOT_ALLOWED
+        )
+
+    def test_invalid_payload_pr(self):
+        kwargs = self._base_kwargs() | {
+            "expected_idempotency_key": "abcd",
+            "expected_job_id": 7,
+            "pr_number_in_payload": 0,
+        }
+        with pytest.raises(MergeRejection) as info:
+            validate_approval(**kwargs)
+        assert (
+            classify_merge_rejection(info.value)
+            == REJECTION_CATEGORY_INVALID_PAYLOAD
+        )

--- a/ai/tests/dev_relay/test_nl_agent.py
+++ b/ai/tests/dev_relay/test_nl_agent.py
@@ -441,6 +441,66 @@ class TestRunTurnSonnetBranch:
         assert called[0]["tool"] == "Bash"
 
 
+class TestNLAgentCanonicalUserKey:
+    """PR #50 reviewer P2 #1 후속: `user_id_masked` canonical 키 병기.
+
+    기존 `"user"` 키는 back-compat 유지. 두 키 모두 같은 마스킹 값을 가진다.
+    """
+
+    def test_haiku_branch_canonical_key(self, audit_records, audit_sink, now_iso):
+        def classifier(_sys, _user):
+            return ClassificationResult(label=IntentLabel.STATUS_LIKE)
+
+        def haiku(_text):
+            return HaikuResponse(text="감사합니다.")
+
+        def sonnet(_text, _sid):
+            raise AssertionError
+
+        run_turn(
+            user_text="고마워",
+            user_id_masked="U0AE7A***",
+            classifier=classifier,
+            haiku_responder=haiku,
+            sonnet_responder=sonnet,
+            audit=audit_sink,
+            now_iso=now_iso,
+        )
+
+        # llm_invoked / llm_classified 모두 canonical + back-compat 키 병기.
+        for rec in audit_records:
+            if rec["kind"] in {"llm_invoked", "llm_classified"}:
+                assert rec.get("user_id_masked") == "U0AE7A***"
+                assert rec.get("user") == "U0AE7A***"
+
+    def test_sonnet_branch_canonical_key(self, audit_records, audit_sink, now_iso):
+        def classifier(_sys, _user):
+            return ClassificationResult(label=IntentLabel.SUMMARY_REQUEST)
+
+        def sonnet(_text, _sid):
+            return SonnetResponse(text="git push --force 위험 안내", tool_calls=[])
+
+        def haiku(_text):
+            raise AssertionError
+
+        run_turn(
+            user_text="요약해줘",
+            user_id_masked="U0AE7A***",
+            classifier=classifier,
+            haiku_responder=haiku,
+            sonnet_responder=sonnet,
+            audit=audit_sink,
+            now_iso=now_iso,
+        )
+
+        # llm_response_blocked 도 canonical 키 포함.
+        blocked = [r for r in audit_records if r["kind"] == "llm_response_blocked"]
+        assert blocked
+        for rec in blocked:
+            assert rec.get("user_id_masked") == "U0AE7A***"
+            assert rec.get("user") == "U0AE7A***"
+
+
 class TestPromptInjectionIsolation:
     """AC-18: prompt injection 합성 — 사용자 텍스트가 system role 을 덮어쓰지 않는다."""
 

--- a/ai/tests/dev_relay/test_post_blocks_guard.py
+++ b/ai/tests/dev_relay/test_post_blocks_guard.py
@@ -91,6 +91,109 @@ class TestCollectBlockUserFacingText:
         assert "pr=22;key=abcd;job=1" not in collected
         assert "승인" in collected
 
+    def test_text_object_not_double_collected(self):
+        """PR #51 reviewer P2 #2: `key == "text"` 분기에서 inner 만 한 번 수집.
+
+        text 객체 ({type, text}) 가 들어왔을 때 inner 텍스트는 한 번만 수집된다.
+        (중복 수집은 발사 차단 판정에 영향 0 이지만 walker 의도 명확화 차원.)
+        """
+        blocks = [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "한 번만 수집되어야 합니다"},
+            }
+        ]
+        collected = _collect_block_user_facing_text(blocks)
+        assert collected.count("한 번만 수집되어야 합니다") == 1
+
+
+class TestCollectBlockNonTextKeys:
+    """PR #51 reviewer P2 #3: 비-text 키 누락 위험 보강 회귀.
+
+    현재 호출 경로에는 image / input 블록이 없지만, 미래 도입 시 누설을 막기
+    위해 walker 가 다음 키도 수집해야 한다.
+    """
+
+    def test_image_alt_text_collected(self):
+        blocks = [
+            {
+                "type": "image",
+                "image_url": "https://example.com/x.png",
+                "alt_text": "차트 이미지 설명",
+            }
+        ]
+        collected = _collect_block_user_facing_text(blocks)
+        assert "차트 이미지 설명" in collected
+
+    def test_input_placeholder_collected(self):
+        blocks = [
+            {
+                "type": "input",
+                "label": {"type": "plain_text", "text": "라벨 텍스트"},
+                "element": {
+                    "type": "plain_text_input",
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": "여기에 입력하세요",
+                    },
+                },
+            }
+        ]
+        collected = _collect_block_user_facing_text(blocks)
+        assert "라벨 텍스트" in collected
+        assert "여기에 입력하세요" in collected
+
+    def test_actions_select_placeholder_collected(self):
+        blocks = [
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "static_select",
+                        "placeholder": {
+                            "type": "plain_text",
+                            "text": "옵션을 선택하세요",
+                        },
+                    }
+                ],
+            }
+        ]
+        assert "옵션을 선택하세요" in _collect_block_user_facing_text(blocks)
+
+    def test_image_title_collected(self):
+        blocks = [
+            {
+                "type": "image",
+                "image_url": "https://example.com/x.png",
+                "alt_text": "ok",
+                "title": {"type": "plain_text", "text": "이미지 캡션"},
+            }
+        ]
+        assert "이미지 캡션" in _collect_block_user_facing_text(blocks)
+
+    def test_dirty_alt_text_blocks_post(self):
+        """image.alt_text 에 도메인 키워드가 있으면 발사 차단된다 (회귀 안전망)."""
+        app = _FakeApp()
+        dirty_blocks = [
+            {
+                "type": "image",
+                "image_url": "https://example.com/x.png",
+                "alt_text": "leaked signal token",
+            }
+        ]
+        _post_blocks_to_thread(
+            app=app,
+            channel="C1",
+            thread_ts="123.456",
+            blocks=dirty_blocks,
+            text="알림",
+            logger=_logger(),
+        )
+        assert len(app.client.calls) == 1
+        # blocks 가 발사되지 않고 text-only fallback 으로 전환.
+        assert "blocks" not in app.client.calls[0]
+        assert app.client.calls[0]["text"] == FALLBACK_RESPONSE
+
 
 class TestPostBlocksGuardClean:
     """정상 케이스 회귀: 가드 통과 blocks 는 그대로 발사."""

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -655,3 +655,42 @@
   > 
   > ## 테스트 결과
 - **다음 작업 후보**: _PR 본문에 별도 섹션 없음. 본문 참고하여 판단._
+
+### 2026-05-14 — chore(dev-relay): PR #50/#51 reviewer P2 후속 묶음 — audit canonical + classify + walker (#52)
+
+- **slug**: `dev-relay-audit-followups` · **author**: @HY0118
+- **PR**: https://github.com/deeptrading-lab/trading-signal-engine/pull/52
+- **요약**: chore(dev-relay): PR #50/#51 reviewer P2 후속 묶음 — audit canonical + classify + walker
+- **현재 상태**: QA 통과 · 리뷰·머지 대기 (이 항목은 QA 통과 시점에 자동 기록됨)
+- **PR 본문 발췌**:
+  > ## 배경
+  > 
+  > PR #50 (audit `user_id_masked`) 와 PR #51 (validate_approval 재시작 거절 + blocks 가드) 의 reviewer P2 follow-up 7건을 묶어 처리.
+  > 
+  > **묶음 vs 분할 결정**: F-1 4건 + F-2 3건 모두 작은 변경 (대부분 docstring / 한 줄 추가 / 작은 함수 신설). reviewer 가 7건을 한 번에 봐도 부담이 분할 시 컨텍스트 전환 비용보다 낮다고 판단 → **1 PR 묶음 채택**.
+  > 
+  > ## 변경 사항
+  > 
+  > ### F-1 — PR #50 reviewer P2 4건 (audit user_id 후속)
+  > 
+  > 1. **SDK responder canonical 키 적용** (`ai/dev_relay/nl_agent.py` 6곳, `ai/dev_relay/nl_sdk_runtime.py` 2곳)
+  >    - `nl_agent.py`: `llm_invoked` x3, `llm_classified` x1, `llm_response_blocked` x2 에 `user_id_masked` 키 병기. 기존 `"user"` 키는 back-compat 유지.
+  >    - `nl_sdk_runtime.py`: PreToolUse hook 의 `tool_call` / `tool_denied` audit 에는 기존에 user 필드가 없었으므로 `user_id_masked` 만 신규 추가 (canonical 단일).
+  > 
+  > 2. **`target_kinds` 셋 갱신 의무 docstring 보강** (`test_audit_user_id_masked.py`)
+  >    - `TestAuditSchemaRegression` 클래스·메서드 docstring 에 "신규 audit kind 추가 시 본 셋도 함께 업데이트하라" 명시. 정적 스캔이 source-of-truth 와 동기화돼야 신규 kind 누락을 자동으로 잡는다.
+  > 
+  > 3. **`"user"` 키 deprecation 시점 명시** (`_append_audit` docstring)
+  >    - **2026-07-13 이후** (PR #50 머지 2026-05-13 기준 60일 window). 보수적으로 60일 채택. 실제 키 제거는 다운스트림 분석 도구 마이그레이션 확인 후 별도 PR (`D-1` 트랙).
+  > 
+  > 4. **`mask_user_id` 중복 호출 통일** (`main.py` `handle_cancel_merge` / `handle_approve_merge` / `handle_merge_review`)
+  >    - `masked = mask_user_id(user_id)` 변수 1회 계산 후 재사용. 총 9곳 중복 호출 제거. 동작 변경 0.
+  > 
+  > ### F-2 — PR #51 reviewer P2 3건 (approval guard 후속)
+  > 
+  > 1. **`merge_failed` audit classification 세분화** (`ai/dev_relay/merger.py`, `main.py`)
+  >    - 신규 상수 7개: `REJECTION_CATEGORY_RESTART_NO_EXPECTED` / `IDEMPOTENCY_MISMATCH` / `JOB_ID_MISMATCH` / `USER_NOT_ALLOWED` / `INVALID_PAYLOAD` / `UNEXPECTED_ACTION` / `OTHER`
+  >    - 신규 함수 `classify_merge_rejection(exc)` — `MergeRejection` 메시지를 카테고리 라벨로 정규화.
+  >    - `main.py` `handle_approve_merge` 의 `merge_failed` audit 에 `rejection_reason` 보조 키 추가. `classification: UNKNOWN_ERROR` 는 그대로 유지 — 두 차원을 분리해 분석 도구가 독립 카운트 가능 (enum 충돌 회피).
+  > 
+- **다음 작업 후보**: _PR 본문에 별도 섹션 없음. 본문 참고하여 판단._

--- a/docs/SESSION_NOTES.md
+++ b/docs/SESSION_NOTES.md
@@ -200,40 +200,102 @@
 
 ---
 
-## 2026-05-13 — NL 직렬화 impl 머지 + reviewer P2 후속 chore
+## 2026-05-13 — NL 직렬화 impl 머지 + A 트랙 전체 종결
 
-**요약**: 직전 세션 follow-up 표 1번(`dev-relay-nl-serialize` 구현) 종결 — PR #48 머지. PR #48 reviewer 가 남긴 P2-1·P2-2 후속 메모 2건을 본 세션에서 chore PR 로 처리. NL 분기는 이제 데몬 shutdown 시 새 진입 거절 + 진행 중 1건 graceful 종료가 wire 된 상태.
+**요약**: 직전 세션 follow-up 표 1번(`dev-relay-nl-serialize` 구현) 종결 — PR #48 머지. 이어서 A 그룹 (즉시 가능 chore 트랙) 5건 모두 종결 — PR #49 (NL shutdown wire), PR #50 (audit user_id_masked), PR #51 (validate_approval 재시작 거절 + blocks 가드), A-5 (PR #36/#37 로 이미 회귀 자동화 — 자연 종결). NL 분기는 데몬 shutdown 시 새 진입 거절 + 진행 중 1건 graceful 종료가 wire 됐고, audit 추적성·재시작 안전성·blocks 누설 방지까지 정합 완료.
 
 ### 처리한 일
 
-- **PR [#48](https://github.com/deeptrading-lab/trading-signal-engine/pull/48)** — `dev-relay-nl-serialize` 구현 (옵션 C: process-wide `threading.Lock` 단일 인스턴스). impl commit `40efb0c`. QA AC 9/9 PASS, reviewer P0=0 P1=0 P2=3 (P2-1 가드 위반 fallback 명문화 / P2-2 `_nl_shutdown_flag.set()` 호출 측 미통합 / P2-3 self-review 한계 — 비범위).
-- **본 PR (chore)** — `dev-relay-nl-shutdown-wire`. reviewer P2-1 + P2-2 후속.
-  - P2-1: `_emit_nl_busy_notice` 가드 위반 fallback 의도를 한 줄 코멘트로 명문화 (정책: 사용자 무발사 = 컴플라이언스 우선).
-  - P2-2: `shutdown_dev_relay(runner, *, timeout, logger)` 헬퍼 신설 → NL flag set + `AgentRunner.shutdown` 위임. `run()` finally 절에서 호출. 단위 테스트 5건 추가.
-- **SESSION_NOTES 동봉** — 본 항목 (정책 준수, 별도 PR 금지).
+- **PR [#48](https://github.com/deeptrading-lab/trading-signal-engine/pull/48)** — `dev-relay-nl-serialize` 구현 (옵션 C: process-wide `threading.Lock` 단일 인스턴스). impl commit `40efb0c`. QA AC 9/9 PASS, reviewer P0=0 P1=0 P2=3.
+- **PR [#49](https://github.com/deeptrading-lab/trading-signal-engine/pull/49)** — `dev-relay-nl-shutdown-wire` chore (PR #48 reviewer P2-1 + P2-2 후속). merged `ad770c6`. `shutdown_dev_relay(runner, *, timeout, logger)` 헬퍼 + `_emit_nl_busy_notice` fallback 코멘트 보강. 신규 테스트 5건.
+- **PR [#50](https://github.com/deeptrading-lab/trading-signal-engine/pull/50)** — `dev-relay-audit-user-id` chore (A-3, 직전 세션 P2 reviewer C-2 후속). merged `4fe3ed3`. `_append_audit` 17곳에 `user_id_masked` canonical 필드 추가 (기존 `"user"` 키 back-compat 유지). 신규 테스트 5건 (정적 스캔 1 + 흐름 4).
+- **PR [#51](https://github.com/deeptrading-lab/trading-signal-engine/pull/51)** — `dev-relay-approval-guard-blocks` chore (A-4, PR #43 reviewer P2-1·P2-3 후속). merged `97cad1c`. (a) `validate_approval(expected=None)` 즉시 거절 + `TEMPLATE_RESTART_APPROVAL_REJECTED` 안내, (b) `_post_blocks_to_thread` blocks walker 가드 + `FALLBACK_RESPONSE` text-only fallback. 신규 테스트 13건.
+- **A-5 자연 종결** — "사용자 검증 이슈 4건 회귀 테스트화" 의 정체 = PR #25 reviewer Concern 4건. 모두 이미 처리됨: audit.jsonl 0600 권한 (`queue.py:105-109` + `test_queue.py:199`), PR description `.env` 정정 (코드 무관), `_RateLimiter` 단위 테스트 (`test_handle_command_nl_serialize.py::TestNLSerializeRateLimitInterop`), `AgentRunner.shutdown` watchdog (`test_agent_runner_shutdown.py`). 추가 작업 없음.
+- **SESSION_NOTES 동봉** — 본 entry 는 PR #49 머지 시 동봉됐고, 본 update (PR #50/#51 + A-5 + 누적 follow-up) 는 working tree 에만 두어 **다음 세션 첫 PR 에 묻는다** (정책: 단독 PR 금지).
 
 ### 결정·합의 사항
 
-- **NL shutdown wire 설계 = 옵션 (b)**: `dev_relay/main.py` 에 통합 헬퍼 `shutdown_dev_relay(runner, *, timeout, logger)` 추가. 근거 — (1) `AgentRunner` 외부 시그니처 불변 (회귀 0), (2) NL flag 가 `main.py` 모듈 스코프라 같은 모듈 안에서 wire 가 가장 자연스러움, (3) 후속 정리 (예: handler.close / picker.stop) 와 묶을 위치가 분명. 옵션 (a) `AgentRunner.shutdown` 내부 호출은 모듈 전역 의존이 들어가 책임 분리 위반 — 거절. 옵션 (c) OS SIGTERM/SIGINT 핸들러 통합은 lifecycle 분기점이 늘어남 — 거절.
-- **PR #48 reviewer 가 `--approve` 대신 `--comment` 사용**: GitHub 가 동일 사용자 자가-승인 API 를 차단해 발생. AGENTS.md L235 정책 부연 허용 범위 내. 후속 트랙: 별도 운영자 / cmux 패널로 reviewer 분리 검토 (follow-up 표 B-2).
-- **단독 SESSION_NOTES PR 금지** 정책 준수: 본 entry 는 본 chore PR 브랜치에 동봉.
+- **NL shutdown wire 설계 = 옵션 (b)**: `dev_relay/main.py` 에 통합 헬퍼 `shutdown_dev_relay(runner, *, timeout, logger)` 추가. 근거 — (1) `AgentRunner` 외부 시그니처 불변 (회귀 0), (2) NL flag 가 `main.py` 모듈 스코프라 같은 모듈 안에서 wire 가 가장 자연스러움, (3) 후속 정리 (handler.close / picker.stop) 와 묶을 위치가 분명. 옵션 (a) `AgentRunner.shutdown` 내부 호출은 모듈 전역 의존 — 거절. 옵션 (c) OS SIGTERM/SIGINT 핸들러 통합은 lifecycle 분기점 증가 — 거절.
+- **audit `user_id_masked` 마이그레이션 = back-compat + canonical 병기**: 기존 `"user"` 키 유지 + `"user_id_masked"` canonical 신규 추가. 다운스트림 분석 회귀 0 보장. 시스템 audit (user 무관) 정책 = Option A (필드 생략) — 본 PR 범위에서 해당 케이스 0건이라 향후 신규 시스템 audit 도입 시 적용 정책.
+- **`validate_approval` 재시작 거절 = 옵션 (a)**: `expected_idempotency_key=None` 또는 `expected_job_id=None` 즉시 거절. 새 reason 상수 + 안내 메시지 `TEMPLATE_RESTART_APPROVAL_REJECTED` 도입. 호출 경로 단일 (`handle_approve_merge`) 이라 회귀 안전.
+- **`_post_blocks_to_thread` 정적 가드**: blocks walker (`_collect_block_user_facing_text`) 별도 헬퍼로 분리 + 단위 테스트 분리. 위반 시 `FALLBACK_RESPONSE` text-only fallback 발사. 호출 측 정상 경로 회귀 0.
+- **A-5 종결 = 후보 1**: "사용자 검증 이슈 4건" = PR #25 reviewer Concern 4건. PR #36/#37 머지 시점에 회귀 자동화 완료 확인 — 추가 작업 없음. 후보 2/3 (수동 검증 항목 자동화 / 사용자 informal 발견) 가능성은 사용자 결정으로 배제.
+- **PR #48/#49/#50/#51 reviewer 가 `--approve` 대신 `--comment` 사용 (4건 연속)**: GitHub 자가-승인 API 차단으로 발생. AGENTS.md L235 허용 범위 안이나 형식 한계는 B-2 트랙으로 일반화 (별도 운영자 / cmux 패널 분리 정책 결정 필요).
+- **단독 SESSION_NOTES PR 금지** 정책 준수: 본 entry update 는 working tree 에만 두어 다음 세션 첫 작업 PR 에 자연 동봉.
 
-### 다음 세션 시작 포인트 (follow-up 표 — 갱신)
+### 수동 검증 권장 (다음 세션 시작 전 선택)
 
-직전 표 1번(`dev-relay-nl-serialize` impl) 종결. 본 chore PR 머지 후 reviewer P2-1·P2-2 도 종결. P2-3 (self-review 한계) 는 B-2 트랙으로 일반화.
+자동 테스트가 못 잡는 실제 UX·timing 부분. 모바일 Slack 1 사이클 (5~10분):
+
+1. **PR #48 NL serialize**: 같은 스레드 NL 2개 빠르게 (1~2초 간격) → 첫 정상 / 둘째 "지금 다른 요청을 처리 중이에요…" 1줄
+2. **PR #48 회귀**: 첫 응답 완료 후 같은 스레드 새 NL → 정상 응답
+3. **PR #48 + #43 별도 락**: `review pr <N>` 실행 중 다른 스레드 NL 전송 → NL 즉시 정상 처리
+4. **PR #49 shutdown**: NL turn 도중 Ctrl+C → 진행 중 응답 완료 후 종료, 그 와중 새 NL → busy 안내
+5. **PR #50 audit**: `tail -20 ~/.local/state/dev_relay/audit.jsonl` → 모든 라인에 `user_id_masked` 필드 존재
+6. **PR #51 재시작 거절** (선택, 번거로움): 데몬 재시작 후 이전 reviewer 결과의 [승인] 클릭 → "이전 세션 페이로드는 거절됩니다…" 안내
+
+시간 없으면 **1·2·5** 만 — 핵심 회귀 보호.
+
+### 다음 세션 시작 포인트 (follow-up 표 — A 트랙 종결 반영)
+
+A-그룹 (즉시 가능 chore) 5건 모두 종결. 다음 세션은 B-그룹 (PRD / 정책) 또는 누적 P2 follow-up 묶음 chore 에서 시작.
 
 | 우선 | 항목 | 슬러그/이슈 | 비고 |
 |---|---|---|---|
-| A-3 | audit `user_id` 추적 누락 fix | 직전 세션 P2 (reviewer C-2 후속) | 즉시 가능. chore 또는 작은 PRD |
-| A-4 | PR #43 reviewer P2 코멘트 3건 | [#43 review comment](https://github.com/deeptrading-lab/trading-signal-engine/pull/43#issuecomment-4389053077) | 즉시 가능. (a) `validate_approval(expected=None)` fallback, (b) `_build_reviewer` NotImplementedError fallback, (c) `_post_blocks_to_thread` blocks 가드 미적용 |
-| A-5 | 사용자 검증 이슈 4건 회귀 테스트화 | 직전 세션 P3 (reviewer 권고) | 즉시 가능 |
+| ~~A-1·A-2·A-3·A-4·A-5~~ | ~~PR #49/#50/#51 + A-5 자연 종결~~ | — | **2026-05-13 종결** |
 | B-1 | Phase 2 PRD `dev-relay-write-tools` | 직전 세션 P2 | PRD 필요 — write 도구 + 머지 confirm |
-| B-2 | reviewer 운영자 분리 (정책 결정) | PR #48 reviewer P2-3 일반화 | GitHub 자가-승인 차단 회피 — 별도 cmux 패널/운영자 권장 정책화 |
+| B-2 | reviewer 운영자 분리 (정책 결정) | PR #48~#51 reviewer 4건 연속 self-review | GitHub 자가-승인 차단 회피 — 별도 cmux 패널/운영자 권장 정책 결정. AGENTS.md L235 정합 |
+| F-1 | PR #50 reviewer P2 4건 묶음 | QA + reviewer 메모 | (1) SDK responder canonical 키 (`nl_agent.py`, `nl_sdk_runtime.py`), (2) `target_kinds` 셋 갱신 의무 docstring, (3) `"user"` 키 deprecation 시점 명시 (30~60일), (4) `mask_user_id` 중복 호출 → `masked` 변수 통일 |
+| F-2 | PR #51 reviewer P2 3건 묶음 | reviewer 메모 | (1) `merge_failed` audit single `UNKNOWN_ERROR` classification 세분화, (2) walker `key=="text"` 중복 수집 (무해, refactor), (3) image/input 블록 도입 시 `alt_text`/`placeholder` 등 비-text 키 누락 위험 |
+| F-3 | PR #43 reviewer P2-2 | `_build_reviewer` NotImplementedError fallback | reviewer wire 자체가 B-1 (write-tools) 영역 — B-1 진행 시 동시 처리 권장 |
 | C-1 | shell metachar `;`/`>`/`<`/`&` 추가 허용 검토 | `dev-relay-shell-chain-allow` (가칭) | PR #45 머지(2026-05-07) 후 ~2026-05-21 데이터 prerequisite |
 | C-2 | NL 분기 옵션 A/B 재설계 검토 | `dev-relay-nl-serialize-v2` (가칭) | PR #48 머지(2026-05-13) 후 ~2026-05-27 `nl_busy_rejected` 빈도 데이터 prerequisite |
-| C-3 | Issue #28 §3 운영 모니터링 | quota / audit 로테이션 / launchd plist | 일상 운영 1~2주 데이터 prerequisite — 충족 시 항목별 분기 |
+| C-3 | Issue #28 §3 운영 모니터링 | quota / audit 로테이션 / launchd plist | 일상 운영 1~2주 데이터 prerequisite |
 
 ### 미결·블록
 
-- 본 chore PR 의 SESSION_NOTES append 는 정책 준수 (단독 PR 금지) — 본 브랜치에 동봉.
-- A-그룹 3건은 다음 세션 즉시 진입 가능. B-그룹 2건은 PRD 또는 정책 결정 필요. C-그룹 3건은 운영 데이터 수집 prerequisite.
+- **working tree 에 본 SESSION_NOTES update 가 미커밋 상태로 남아 있음** (PR #50/#51 + A-5 + 누적 follow-up 반영). 정책상 단독 PR 금지 — **다음 세션 첫 작업 PR 브랜치에 자연 동봉** 필수. 별도 SESSION_NOTES PR 만들면 정책 위반 (이전 세션 회귀 사례 있음).
+- B-그룹 2건 (B-1 PRD / B-2 정책 결정) 은 사용자 의사결정 또는 PM 진입 필요.
+- F-그룹 3건 (P2 follow-up 8건 누적) 은 묶음 chore PR 1~2건으로 처리 가능 — 즉시 가능.
+- C-그룹 3건은 운영 데이터 수집 prerequisite — C-1 (~2026-05-21), C-2 (~2026-05-27) 자연 진입 가능 시점.
+
+---
+
+## 2026-05-15 — F-1 + F-2 묶음 chore (PR #50/#51 reviewer P2 후속 7건)
+
+**요약**: 직전 세션 follow-up 표의 F-1 (PR #50 P2 4건) + F-2 (PR #51 P2 3건) 을 1건의 묶음 chore PR 로 처리. reviewer 부담 평가 결과 — 7건 모두 작은 변경 (대부분 docstring / 한 줄 추가 / 작은 함수 신설) 이라 묶음 단일 PR 이 분할보다 검토 효율적. 직전 세션 working tree 에 미커밋이던 SESSION_NOTES update (40 라인) 도 정책 준수 차원에서 동봉.
+
+### 처리한 일
+
+- **F-1 #1 — SDK responder canonical 키 적용**: `ai/dev_relay/nl_agent.py` 6곳 (`llm_invoked` x3, `llm_classified` x1, `llm_response_blocked` x2) 에 `user_id_masked` canonical 키 병기, `"user"` 키 back-compat 유지. `ai/dev_relay/nl_sdk_runtime.py` PreToolUse hook 의 `tool_call` / `tool_denied` audit 에는 기존에 user 필드가 없었으므로 `user_id_masked` 만 신규 추가 (canonical 단일).
+- **F-1 #2 — `target_kinds` 셋 갱신 의무 docstring 보강**: `ai/tests/dev_relay/test_audit_user_id_masked.py::TestAuditSchemaRegression` 의 클래스·메서드 docstring 에 "신규 audit kind 추가 시 본 셋도 함께 업데이트하라" 명시.
+- **F-1 #3 — `"user"` 키 deprecation 시점 명시**: `_append_audit` docstring 에 `"user"` 키 deprecation = **2026-07-13 이후** (PR #50 머지 2026-05-13 기준 60일 window) 명시. 다운스트림 분석 도구 마이그레이션 확인 후 별도 PR 로 키 제거.
+- **F-1 #4 — `mask_user_id` 중복 호출 통일**: `handle_cancel_merge` / `handle_approve_merge` / `handle_merge_review` 3개 핸들러에서 `masked = mask_user_id(user_id)` 변수 1회 계산 후 재사용 (총 9곳 중복 호출 제거). 동작 변경 0.
+- **F-2 #1 — `merge_failed` audit classification 세분화**: `ai/dev_relay/merger.py` 에 7개 `REJECTION_CATEGORY_*` 상수 + `classify_merge_rejection(exc)` 헬퍼 신설 — `MergeRejection` 메시지를 `restart_no_expected` / `idempotency_mismatch` / `job_id_mismatch` / `user_not_allowed` / `invalid_payload` / `unexpected_action` / `other` 7개 카테고리로 정규화. `main.py` `handle_approve_merge` 의 `merge_failed` audit 에 `rejection_reason` 보조 키 추가 (`classification: UNKNOWN_ERROR` 는 그대로 유지 — 분석 도구 회귀 0).
+- **F-2 #2 — walker `key=="text"` 중복 수집 refactor**: `_collect_block_user_facing_text` 의 `key == "text"` 분기에서 inner 텍스트를 한 번만 수집한 뒤 `continue` 로 재귀 생략. 발사 차단 판정에 영향 0.
+- **F-2 #3 — image/input 블록 방어적 보강**: `_BLOCK_USER_FACING_NON_TEXT_KEYS = {"alt_text", "placeholder", "title", "label", "hint"}` 정적 셋 + walker 가 `str` 직접·`{type, text}` obj 둘 다 수집. 현재 호출 경로엔 해당 블록 없어 회귀 0, 미래 블록 도입 시 회귀 안전망.
+- **SESSION_NOTES 동봉** — 직전 세션의 미커밋 update (40 라인) 와 본 entry 모두 본 chore PR 브랜치 첫 commit 에 포함 (정책 준수).
+
+### 결정·합의 사항
+
+- **묶음 vs 분할 = 묶음 1 PR**: F-1 4건 + F-2 3건 모두 작은 변경 (대부분 docstring / 한 줄 추가). reviewer 가 7건을 한 번에 봐도 부담 ≤ 분할 시 컨텍스트 전환 비용. 1 PR 채택.
+- **`"user"` 키 deprecation = 2026-07-13**: 30~60일 window 중 60일 (보수). 다운스트림 분석 도구 마이그레이션이 확실히 완료될 때까지 여유. 실제 키 제거는 별도 PR.
+- **`rejection_reason` 키 vs `classification` 세분화**: 후자는 `FailureClassification` enum (5종 + UNKNOWN) 의 의미적 자리 (HTTP / SDK / destructive / compliance) 라 `MergeRejection` 사유와 직교. 별도 `rejection_reason` 키 신설로 둘을 분리 — 분석 도구가 두 차원을 독립 카운트 가능. enum 자체에 reason 을 끼우면 의미적 충돌.
+- **`_BLOCK_USER_FACING_NON_TEXT_KEYS` 정적 셋 = 보수적 명시 5개**: image / input / select / 등 Slack Block Kit 의 모든 비-text 노출 키. 미래에 새 블록 도입 시 셋만 갱신하면 됨 — walker 로직은 불변.
+
+### 다음 세션 시작 포인트 (follow-up 표 — F-1·F-2 종결 반영)
+
+| 우선 | 항목 | 슬러그/이슈 | 비고 |
+|---|---|---|---|
+| ~~F-1·F-2~~ | ~~PR #50/#51 reviewer P2 7건 묶음 chore~~ | — | **2026-05-15 종결 (본 PR)** |
+| B-1 | Phase 2 PRD `dev-relay-write-tools` | 직전 세션 P2 | PRD 필요 — write 도구 + 머지 confirm |
+| B-2 | reviewer 운영자 분리 (정책 결정) | PR #48~#51 reviewer self-review | GitHub 자가-승인 차단 회피 — 별도 cmux 패널/운영자 정책 결정 |
+| F-3 | PR #43 reviewer P2-2 | `_build_reviewer` NotImplementedError fallback | B-1 (write-tools) 영역 — B-1 진행 시 동시 처리 권장 |
+| C-1 | shell metachar 추가 허용 검토 | `dev-relay-shell-chain-allow` (가칭) | PR #45 머지(2026-05-07) 후 ~2026-05-21 데이터 prerequisite |
+| C-2 | NL 분기 옵션 A/B 재설계 검토 | `dev-relay-nl-serialize-v2` (가칭) | PR #48 머지(2026-05-13) 후 ~2026-05-27 데이터 prerequisite |
+| C-3 | Issue #28 §3 운영 모니터링 | quota / audit 로테이션 / launchd plist | 일상 운영 1~2주 데이터 prerequisite |
+| D-1 | `"user"` 키 제거 PR | 본 PR docstring deprecation 시점 | 2026-07-13 이후 다운스트림 마이그레이션 확인 후 |
+
+### 미결·블록
+
+- 본 chore PR 후 즉시 가능 트랙 (A/F) 모두 정리됨. 다음 세션은 B-1 PRD (사용자 진입 필요) 또는 C-1 데이터 점검 (~2026-05-21) 자연 진입.

--- a/docs/qa/dev-relay-audit-followups.md
+++ b/docs/qa/dev-relay-audit-followups.md
@@ -1,0 +1,176 @@
+# QA — dev-relay-audit-followups (chore)
+
+- 입력 PR: **#52** (branch `feature/dev-relay-audit-followups`, head `36c4fa1`, label `impl-ready`)
+- PRD: 없음 (chore — PR #50 reviewer P2 4건 + PR #51 reviewer P2 3건 묶음 후속)
+- 변경 규모: 9 files, +527/-40
+- QA 일자: 2026-05-15
+- 판정: **qa-passed**
+
+---
+
+## 범위
+
+| 그룹 | 항목 | 출처 |
+|---|---|---|
+| F-1 #1 | `nl_agent.py` / `nl_sdk_runtime.py` audit canonical key `user_id_masked` 병기 | PR #50 reviewer P2 |
+| F-1 #2 | `test_audit_user_id_masked.py` 정적 스캔 `target_kinds` 셋 갱신 의무 docstring | PR #50 reviewer P2 |
+| F-1 #3 | `_append_audit` docstring 에 `"user"` 키 deprecation 시점 명시 (2026-07-13 이후) | PR #50 reviewer P2 |
+| F-1 #4 | `main.py` `mask_user_id(user_id)` 중복 호출 → `masked` 단일 변수 통일 (9곳) | PR #50 reviewer P2 |
+| F-2 #1 | `merger.py` `classify_merge_rejection` + 7개 `REJECTION_CATEGORY_*` 상수 | PR #51 reviewer P2 |
+| F-2 #2 | `_collect_block_user_facing_text` 의 `key=="text"` 중복 수집 단일화 | PR #51 reviewer P2 |
+| F-2 #3 | walker 비-text 키 (`alt_text`, `placeholder`, `title`, `label`, `hint`) 방어 | PR #51 reviewer P2 |
+
+---
+
+## 1. 수용 기준 검증
+
+### AC-1 — canonical user 키 적용 (F-1 #1)
+
+- **재현 절차**: `grep -n '"user_id_masked"' ai/dev_relay/nl_agent.py ai/dev_relay/nl_sdk_runtime.py`
+- **기대 결과**:
+  - `nl_agent.py` 6 hit (라인 233 / 245 / 261 / 275 / 297 / 324) — 6곳 모두 `"user": user_id_masked` 와 `"user_id_masked": user_id_masked` 병기
+  - `nl_sdk_runtime.py` 2 hit (라인 91 / 103) — PreToolUse `tool_call` / `tool_denied` audit 신규 `user_id_masked` 단일
+  - 신규 `TestNLAgentCanonicalUserKey::test_haiku_branch_canonical_key` PASS
+  - 신규 `TestNLAgentCanonicalUserKey::test_sonnet_branch_canonical_key` PASS
+- **실제 결과**: 일치, 8 hit + 2 tests PASS
+
+### AC-2 — target_kinds 갱신 의무 docstring (F-1 #2)
+
+- **재현 절차**: `grep -nE 'target_kinds|셋 갱신|set update|kinds set' ai/tests/dev_relay/test_audit_user_id_masked.py`
+- **기대 결과**: 클래스 docstring (라인 244-245) + 메서드 docstring (라인 251, 259-260) 에 "신규 audit kind 추가 시 본 셋도 함께 업데이트하라" 명시
+- **실제 결과**: 일치
+  ```
+  244:    **셋 갱신 의무 (PR #50 후속)**: `ai/dev_relay/main.py` 에 신규 audit kind 가
+  245:    추가되고 그 record 가 사용자 컨텍스트를 포함하면, 본 클래스의 `target_kinds`
+  259:        신규 audit kind 추가 시 본 메서드의 `target_kinds` 셋도 함께 업데이트하라
+  260:        (위 클래스 docstring 의 셋 갱신 의무 참조).
+  ```
+
+### AC-3 — deprecation 시점 명시 (F-1 #3)
+
+- **재현 절차**: `grep -nE 'deprecation|2026-07-13' ai/dev_relay/main.py`
+- **기대 결과**: `_append_audit` docstring 에 `"user"` 키 deprecation 시점 = **2026-07-13 이후** (PR #50 머지 2026-05-13 기준 60일 window) 명시
+- **실제 결과**: 일치 (라인 149: `- `"user"` 키 deprecation 시점: **2026-07-13 이후** (PR #50 머지 2026-05-13`)
+
+### AC-4 — mask_user_id 통일 (F-1 #4)
+
+- **재현 절차**: `grep -nE 'mask_user_id' ai/dev_relay/main.py`
+- **기대 결과**:
+  - `handle_cancel_merge` / `handle_approve_merge` / `handle_merge_review` 3개 핸들러에서 `masked = mask_user_id(user_id)` 1회 계산 후 재사용
+  - `mask_user_id(user_id)` 의 즉시 호출 흔적은 없고, audit record 내 `mask_user_id(job.user_id)` 만 잔존 (worker 측 — 별 컨텍스트라 영향 없음)
+- **실제 결과**:
+  - `masked = mask_user_id(user_id)` 5곳 (라인 299, 507, 728, 750, 921) + `mask_user_id(sender)` 1곳 (라인 654, 다른 변수)
+  - 한 핸들러 내 중복 호출 제거 — 확인됨 (handle_approve_merge: 728/750 두 분기에서 각 1회만 호출, 이후 `masked` 재사용)
+  - worker 측 `mask_user_id(job.user_id)` 6곳 (1152~1255) — 본 PR 의 변경 범위 외 (job context, user_id 변수 없음)
+
+### AC-5 — merge_failed classification 세분화 (F-2 #1)
+
+- **재현 절차**:
+  1. `grep -nE 'classify_merge_rejection|REJECTION_CATEGORY' ai/dev_relay/merger.py`
+  2. `cd ai && pytest tests/dev_relay/test_merge_rejection_classify.py -v`
+- **기대 결과**:
+  - 7개 `REJECTION_CATEGORY_*` 상수 (restart_no_expected / idempotency_mismatch / job_id_mismatch / user_not_allowed / invalid_payload / unexpected_action / other)
+  - `classify_merge_rejection(exc)` 헬퍼 정의 (라인 75-)
+  - `main.py` `handle_approve_merge` 의 `merge_failed` audit 에 `rejection_reason` 보조 키 추가 (라인 812-820)
+  - 신규 13건 (`TestClassifyByMessage` 9건 + `TestClassifyFromValidateApproval` 4건) PASS
+- **실제 결과**: 일치, 13/13 PASS, `__all__` exports 도 정상 노출
+
+### AC-6 — walker 중복 수집 refactor (F-2 #2)
+
+- **재현 절차**: `sed -n '1334,1410p' ai/dev_relay/main.py` + `pytest tests/dev_relay/test_post_blocks_guard.py::TestCollectBlockUserFacingText::test_text_object_not_double_collected -v`
+- **기대 결과**:
+  - `_visit` 내 `key == "text"` 분기: str 값은 즉시 수집 + `continue`, obj 값은 inner.text 수집 + `continue` (이후 `_visit(value)` 재진입 없음)
+  - `test_text_object_not_double_collected` PASS (`{type, text}` 객체에서 text 가 한 번만 수집됨)
+- **실제 결과**: 일치, PASS
+
+### AC-7 — image/input 블록 비-text 키 방어 (F-2 #3)
+
+- **재현 절차**:
+  1. `grep -nE '_BLOCK_USER_FACING_NON_TEXT_KEYS' ai/dev_relay/main.py`
+  2. `pytest tests/dev_relay/test_post_blocks_guard.py::TestCollectBlockNonTextKeys -v`
+- **기대 결과**:
+  - `_BLOCK_USER_FACING_NON_TEXT_KEYS = {"alt_text", "placeholder", "title", "label", "hint"}` 정적 셋 정의 (라인 1325-1331 영역)
+  - walker 가 비-text 키에서 `str` 직접·`{type, text}` obj 둘 다 수집
+  - 신규 5건 PASS: `test_image_alt_text_collected`, `test_input_placeholder_collected`, `test_actions_select_placeholder_collected`, `test_image_title_collected`, `test_dirty_alt_text_blocks_post`
+- **실제 결과**: 일치, 5/5 PASS. `test_dirty_alt_text_blocks_post` 가 `alt_text` 누설 시 `FALLBACK_RESPONSE` text-only fallback 발사 확인.
+
+### AC-8 — SESSION_NOTES 동봉 정합성
+
+- **재현 절차**: `grep -nE 'PR #50|PR #51|PR #52|F-1|F-2|A-5' docs/SESSION_NOTES.md | head -30`
+- **기대 결과**: 직전 미커밋 update (PR #50/#51 + A-5 + 누적 follow-up — 205/212/213/214/221/222 라인) + 본 세션 entry (264-290 라인, F-1/F-2 종결) 모두 포함
+- **실제 결과**: 일치. 264 라인에 "2026-05-15 — F-1 + F-2 묶음 chore" 헤더, 270-276 라인에 7건 개별 설명, 290 라인에 follow-up 표 종결 표기 (`~~F-1·F-2~~`).
+
+---
+
+## 2. 회귀 테스트
+
+| 스코프 | 커맨드 | 결과 |
+|---|---|---|
+| 신규 21건 | `pytest tests/dev_relay/test_nl_agent.py tests/dev_relay/test_post_blocks_guard.py tests/dev_relay/test_merge_rejection_classify.py -v` | **51/51 PASS** (기존 + 신규) |
+| 신규만 (F-1 canonical) | `pytest tests/dev_relay/test_nl_agent.py::TestNLAgentCanonicalUserKey -v` | **2/2 PASS** |
+| 신규만 (F-2 walker) | `pytest tests/dev_relay/test_post_blocks_guard.py -k 'NonText or not_double or ApprovalRestart' -v` | **8/8 PASS** (해당 신규 6건 포함) |
+| 신규만 (F-2 classify) | `pytest tests/dev_relay/test_merge_rejection_classify.py -v` | **13/13 PASS** |
+| 전체 dev_relay 회귀 | `cd ai && pytest tests/dev_relay/ -q` | **533/533 PASS** (2.48s) |
+| 컴플라이언스 | `cd ai && pytest tests/dev_relay/test_compliance.py -v` | **53/53 PASS** — 정적 템플릿 17건 + Block Kit builder 4건 + dev_relay 소스 21파일 (`nl_agent.py`, `nl_sdk_runtime.py`, `main.py`, `merger.py` 포함) 모두 0 hit |
+
+신규 테스트 합계: **21건 = 2 (nl_agent canonical) + 6 (post_blocks: 5 NonText + 1 not_double) + 13 (merge classify)**.
+
+---
+
+## 3. 컴플라이언스 정적 스캔
+
+본 PR 의 신규 식별자·문서 텍스트에 봇 표시명에 노출 금지 키워드 0 hit:
+
+| 식별자 / 토큰 | 결과 |
+|---|---|
+| `classify_merge_rejection` | 0 hit |
+| `REJECTION_CATEGORY_RESTART_NO_EXPECTED` | 0 hit |
+| `REJECTION_CATEGORY_IDEMPOTENCY_MISMATCH` | 0 hit |
+| `REJECTION_CATEGORY_JOB_ID_MISMATCH` | 0 hit |
+| `REJECTION_CATEGORY_USER_NOT_ALLOWED` | 0 hit |
+| `REJECTION_CATEGORY_INVALID_PAYLOAD` | 0 hit |
+| `REJECTION_CATEGORY_UNEXPECTED_ACTION` | 0 hit |
+| `REJECTION_CATEGORY_OTHER` | 0 hit |
+| `REJECTION_REASON_RESTART_NO_EXPECTED` | 0 hit |
+| `user_id_masked` | 0 hit |
+| `rejection_reason` | 0 hit |
+| `_collect_block_user_facing_text` | 0 hit |
+| `_BLOCK_USER_FACING_NON_TEXT_KEYS` | 0 hit |
+| 슬러그 `dev-relay-audit-followups` | 0 hit |
+
+`test_compliance.py::test_dev_relay_source_clean` 21파일도 100% PASS — 본 PR 의 4개 수정 소스 (`nl_agent.py`, `nl_sdk_runtime.py`, `main.py`, `merger.py`) 모두 위반 0.
+
+---
+
+## 4. 에지 케이스
+
+| 케이스 | 절차 | 기대 / 실제 |
+|---|---|---|
+| audit record 신규 kind 추가 시 셋 미갱신 | `test_audit_user_id_masked` 의 `target_kinds` 셋과 `main.py` 실제 `_append_audit` 호출의 kind 집합이 vary 하면 정적 스캔 테스트가 fail 해야 함 | 현 PR 의 `target_kinds` 갱신 의무 docstring 으로 휴먼 가드 마련. 자동 vary detection 은 별도 issue (스코프 외 — F-1 #2 는 docstring 만 요구) |
+| MergeRejection 의 message 가 예상 외 토큰 | `classify_merge_rejection` 의 fallback 카테고리 `other` 로 분류 | `test_other_fallback` PASS — `MergeRejection("totally unknown reason XYZ")` → `"other"` |
+| MergeRejection 이 아닌 일반 Exception | `classify_merge_rejection(ValueError("..."))` 도 `"other"` 로 fallback | `TestClassifyByMessage` 의 `test_other_fallback` 가 `MergeRejection` 만 검증하지만, `classify_merge_rejection` 의 signature `MergeRejection \| BaseException` 가 일반 Exception 도 허용. 정적 코드 리뷰로 fallback 안전 확인 |
+| Block Kit 트리에 중첩된 `text` 객체 | 한 번만 수집되어야 함 (이전엔 잠재 중복) | `test_text_object_not_double_collected` PASS — 정확히 1 회 수집 |
+| `alt_text` 에 forbidden keyword 누설 | `_post_blocks_to_thread` 가 발사 차단 + text-only fallback (`FALLBACK_RESPONSE`) | `test_dirty_alt_text_blocks_post` PASS — blocks 인자 없이 fallback 발사 |
+| `placeholder` 가 plain string 직접 | walker 가 str 직접 형태도 수집 | `test_input_placeholder_collected` 검증 — `placeholder: {type: plain_text, text: ...}` obj 형태도 OK |
+| F-1 deprecation 60-day window 후 (2026-07-13~) | `"user"` 키 제거 별도 PR 필수 — 본 PR 범위 외 | docstring 에 명시. 다운스트림 분석 도구 마이그레이션 확인 책임 명시됨 |
+| worker 측 `mask_user_id(job.user_id)` 중복 | 본 PR 의 F-1 #4 범위 외 (slack handler 만 통일) — worker 측은 `job.user_id` 변수가 함수 scope 외 lazy 로 변할 수 있어 보수적으로 호출 유지 | 정상. 분석상 worker `_append_audit` 호출 6곳 모두 inline 호출, 한 함수 내 중복 없음 |
+
+---
+
+## 5. 판정
+
+| 항목 | 결과 |
+|---|---|
+| 수용 기준 AC-1 ~ AC-8 | 8/8 PASS |
+| 신규 21건 | 21/21 PASS |
+| 전체 dev_relay 회귀 | 533/533 PASS |
+| 컴플라이언스 (53건 + 신규 식별자 14개 추가 정적 스캔) | 0 hit |
+| 실패 | **0건** |
+
+**최종 판정: qa-passed**.
+
+---
+
+## 6. 메모 (다음 세션 follow-up 없음)
+
+본 PR 은 직전 세션 follow-up 표의 F-1 + F-2 종결 PR. PR #50/#51 reviewer P2 7건 모두 docstring / 헬퍼 신설 / 작은 refactor 로 정리됨. 회귀 / 기능 영향 0. 본 QA 결과 기준으로 follow-up 신규 항목 없음.


### PR DESCRIPTION
## 배경

PR #50 (audit `user_id_masked`) 와 PR #51 (validate_approval 재시작 거절 + blocks 가드) 의 reviewer P2 follow-up 7건을 묶어 처리.

**묶음 vs 분할 결정**: F-1 4건 + F-2 3건 모두 작은 변경 (대부분 docstring / 한 줄 추가 / 작은 함수 신설). reviewer 가 7건을 한 번에 봐도 부담이 분할 시 컨텍스트 전환 비용보다 낮다고 판단 → **1 PR 묶음 채택**.

## 변경 사항

### F-1 — PR #50 reviewer P2 4건 (audit user_id 후속)

1. **SDK responder canonical 키 적용** (`ai/dev_relay/nl_agent.py` 6곳, `ai/dev_relay/nl_sdk_runtime.py` 2곳)
   - `nl_agent.py`: `llm_invoked` x3, `llm_classified` x1, `llm_response_blocked` x2 에 `user_id_masked` 키 병기. 기존 `"user"` 키는 back-compat 유지.
   - `nl_sdk_runtime.py`: PreToolUse hook 의 `tool_call` / `tool_denied` audit 에는 기존에 user 필드가 없었으므로 `user_id_masked` 만 신규 추가 (canonical 단일).

2. **`target_kinds` 셋 갱신 의무 docstring 보강** (`test_audit_user_id_masked.py`)
   - `TestAuditSchemaRegression` 클래스·메서드 docstring 에 "신규 audit kind 추가 시 본 셋도 함께 업데이트하라" 명시. 정적 스캔이 source-of-truth 와 동기화돼야 신규 kind 누락을 자동으로 잡는다.

3. **`"user"` 키 deprecation 시점 명시** (`_append_audit` docstring)
   - **2026-07-13 이후** (PR #50 머지 2026-05-13 기준 60일 window). 보수적으로 60일 채택. 실제 키 제거는 다운스트림 분석 도구 마이그레이션 확인 후 별도 PR (`D-1` 트랙).

4. **`mask_user_id` 중복 호출 통일** (`main.py` `handle_cancel_merge` / `handle_approve_merge` / `handle_merge_review`)
   - `masked = mask_user_id(user_id)` 변수 1회 계산 후 재사용. 총 9곳 중복 호출 제거. 동작 변경 0.

### F-2 — PR #51 reviewer P2 3건 (approval guard 후속)

1. **`merge_failed` audit classification 세분화** (`ai/dev_relay/merger.py`, `main.py`)
   - 신규 상수 7개: `REJECTION_CATEGORY_RESTART_NO_EXPECTED` / `IDEMPOTENCY_MISMATCH` / `JOB_ID_MISMATCH` / `USER_NOT_ALLOWED` / `INVALID_PAYLOAD` / `UNEXPECTED_ACTION` / `OTHER`
   - 신규 함수 `classify_merge_rejection(exc)` — `MergeRejection` 메시지를 카테고리 라벨로 정규화.
   - `main.py` `handle_approve_merge` 의 `merge_failed` audit 에 `rejection_reason` 보조 키 추가. `classification: UNKNOWN_ERROR` 는 그대로 유지 — 두 차원을 분리해 분석 도구가 독립 카운트 가능 (enum 충돌 회피).

2. **walker `key=="text"` 중복 수집 refactor** (`_collect_block_user_facing_text`)
   - `key == "text"` 분기에서 inner 텍스트를 한 번 수집한 뒤 `continue` 로 재귀 생략. 발사 차단 판정에 영향 0 — 정적 정확도 차원.

3. **image/input 블록 비-text 키 보강** (`_collect_block_user_facing_text`)
   - `_BLOCK_USER_FACING_NON_TEXT_KEYS = {"alt_text", "placeholder", "title", "label", "hint"}` 정적 셋 도입.
   - walker 가 `str` 직접 (예: `image.alt_text`) 과 `{type, text}` plain_text obj 둘 다 수집.
   - 현재 호출 경로엔 image/input 블록이 없어 회귀 0. 미래 블록 도입 시 회귀 안전망.

## 변경 파일

| 파일 | 변경 종류 |
|---|---|
| `ai/dev_relay/nl_agent.py` | audit canonical 키 6곳 추가 |
| `ai/dev_relay/nl_sdk_runtime.py` | tool_call/tool_denied audit 에 user_id_masked 추가 |
| `ai/dev_relay/merger.py` | REJECTION_CATEGORY_* 7개 + classify_merge_rejection 신설 |
| `ai/dev_relay/main.py` | mask_user_id 중복 통일 + rejection_reason 보조 키 + walker 보강 + _append_audit docstring |
| `ai/tests/dev_relay/test_audit_user_id_masked.py` | target_kinds 셋 갱신 의무 docstring |
| `ai/tests/dev_relay/test_nl_agent.py` | `TestNLAgentCanonicalUserKey` 2건 신규 |
| `ai/tests/dev_relay/test_post_blocks_guard.py` | walker 중복 1건 + 비-text 키 5건 신규 |
| `ai/tests/dev_relay/test_merge_rejection_classify.py` | 신규 — classify_merge_rejection 13건 |
| `docs/SESSION_NOTES.md` | 직전 세션 미커밋 update + 본 entry 동봉 (단독 PR 금지 정책 준수) |

## 테스트 결과

```
cd ai && python -m pytest tests/dev_relay/ -q
533 passed in 2.39s  (이전 512건 + 신규 21건)

cd ai && python -m pytest tests/dev_relay/test_compliance.py -v
53 passed in 0.03s   (도메인 키워드 0 hit)
```

## 수용 기준 체크리스트

- [x] F-1 #1 — SDK responder canonical 키 (nl_agent.py + nl_sdk_runtime.py)
- [x] F-1 #2 — target_kinds 셋 갱신 의무 docstring
- [x] F-1 #3 — "user" 키 deprecation 시점 명시 (2026-07-13)
- [x] F-1 #4 — mask_user_id 중복 호출 → masked 변수 통일
- [x] F-2 #1 — merge_failed audit classification 세분화 (7 카테고리)
- [x] F-2 #2 — walker key=="text" 중복 수집 refactor
- [x] F-2 #3 — image/input 블록 비-text 키 walker 보강
- [x] 회귀 0 (533/533 pass)
- [x] 컴플라이언스 0 hit (53/53 pass)
- [x] 외부 시그니처 변경 0
- [x] 신규 의존성 0
- [x] SESSION_NOTES 동봉 (단독 PR 금지 정책)

## PRD 경로

본 PR 은 chore — PRD 없음. PR #50 / PR #51 reviewer P2 후속 메모를 처리하는 follow-up 묶음.